### PR TITLE
update yamls and add helm chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,9 @@ deploy: manifests
 # Generate manifests e.g. CRD, RBAC etc.
 manifests:
 	go run vendor/sigs.k8s.io/controller-tools/cmd/controller-gen/main.go all
+	cp config/crds/*.yaml ./install/kruise/templates/
+	cp rbac/rbac_role.yaml ./install/kruise/templates/
+	helm template ./install/kruise > install/yaml/kruise_all_in_one.yaml
 
 # Run go fmt against code
 fmt:

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ deploy: manifests
 manifests:
 	go run vendor/sigs.k8s.io/controller-tools/cmd/controller-gen/main.go all
 	cp config/crds/*.yaml ./install/kruise/templates/
-	cp rbac/rbac_role.yaml ./install/kruise/templates/
+	cp config/rbac/rbac_role.yaml ./install/kruise/templates/
 	helm template ./install/kruise > install/yaml/kruise_all_in_one.yaml
 
 # Run go fmt against code

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,6 @@ manifests:
 	go run vendor/sigs.k8s.io/controller-tools/cmd/controller-gen/main.go all
 	cp config/crds/*.yaml ./install/kruise/templates/
 	cp config/rbac/rbac_role.yaml ./install/kruise/templates/
-	helm template ./install/kruise > install/yaml/kruise_all_in_one.yaml
 
 # Run go fmt against code
 fmt:

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -1,7 +1,7 @@
 # This patch inject a sidecar container which is a HTTP proxy for the controller manager,
 # it performs RBAC authorization against the Kubernetes API using SubjectAccessReviews.
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: controller-manager
   namespace: system

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: controller-manager
   namespace: system
@@ -10,3 +10,7 @@ spec:
       # Change the value of image field below to your controller image URL
       - image: openkruise/kruise-manager:v0.1.0
         name: manager
+        args:
+        - "--metrics-addr=127.0.0.1:8080"
+        - "--logtostderr=true"
+        - "--v=4"

--- a/config/default/manager_image_patch.yaml-e
+++ b/config/default/manager_image_patch.yaml-e
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: controller-manager
   namespace: system

--- a/config/default/manager_prometheus_metrics_patch.yaml
+++ b/config/default/manager_prometheus_metrics_patch.yaml
@@ -1,6 +1,6 @@
 # This patch enables Prometheus scraping for the manager pod.
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: controller-manager
   namespace: system

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -22,7 +22,7 @@ spec:
   - port: 443
 ---
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: controller-manager
   namespace: system
@@ -30,11 +30,16 @@ metadata:
     control-plane: controller-manager
     controller-tools.k8s.io: "1.0"
 spec:
+  replicas: 3
   selector:
     matchLabels:
       control-plane: controller-manager
       controller-tools.k8s.io: "1.0"
-  serviceName: controller-manager-service
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 3
+    type: RollingUpdate
   template:
     metadata:
       labels:
@@ -61,6 +66,9 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        readinessProbe:
+          tcpSocket:
+            port: 9876
         ports:
         - containerPort: 9876
           name: webhook-server

--- a/install/kruise/Chart.yaml
+++ b/install/kruise/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+name: kruise
+description: Helm chart for all kruise components
+version: 0.1.0
+#kubeVersion: ">=1.10.0"
+keywords:
+  - kruise
+  - workload
+  - statefulset
+  - sidecar
+home: https://openkruise.io
+sources:
+  - https://github.com/openkruise/kruise

--- a/install/kruise/README.md
+++ b/install/kruise/README.md
@@ -1,0 +1,14 @@
+# Kruise
+[Kruise](https://openkruise.io) is a set of controllers which extends and complements 
+[Kubernetes core controllers](https://kubernetes.io/docs/concepts/overview/what-is-kubernetes/)
+on application workload management.
+
+## Introduction
+This chart bootstraps kruise-manager and its CRDs into your cluster.
+
+## Official Documentation
+Official project documentation found [here](https://github.com/openkruise/kruise).
+
+## Prerequisites
+- With Kubernetes 1.10+ you can install Kruise and enjoy it.
+- What's more, some features like **StatefulSet in-place update** require 1.12+.

--- a/install/kruise/templates/apps_v1alpha1_broadcastjob.yaml
+++ b/install/kruise/templates/apps_v1alpha1_broadcastjob.yaml
@@ -1,0 +1,172 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: broadcastjobs.apps.kruise.io
+spec:
+  group: apps.kruise.io
+  names:
+    kind: BroadcastJob
+    plural: broadcastjobs
+    shortNames:
+      - bj
+  scope: Namespaced
+  additionalPrinterColumns:
+    - name: Desired
+      type: integer
+      description: The desired number of pods, this is typically equal to the number of nodes satisfied to run pods.
+      JSONPath: .status.desired
+    - name: Active
+      type: integer
+      description: The number of actively running pods.
+      JSONPath: .status.active
+    - name: Succeeded
+      type: integer
+      description: The number of pods which reached phase Succeeded.
+      JSONPath: .status.succeeded
+    - name: Failed
+      type: integer
+      description: The number of pods which reached phase Failed.
+      JSONPath: .status.failed
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            completionPolicy:
+              description: CompletionPolicy indicates the completion policy of the
+                job. Default is Always CompletionPolicyType
+              properties:
+                activeDeadlineSeconds:
+                  description: Specifies the duration in seconds relative to the startTime
+                    that the job may be active before the system tries to terminate
+                    it; value must be positive integer. Only works for Always type
+                  format: int64
+                  type: integer
+                backoffLimit:
+                  description: Specifies the number of retries before marking this
+                    job failed. Not setting value means no limit. Only works for Always
+                    type
+                  format: int32
+                  type: integer
+                ttlSecondsAfterFinished:
+                  description: ttlSecondsAfterFinished limits the lifetime of a Job
+                    that has finished execution (either Complete or Failed). If this
+                    field is set, ttlSecondsAfterFinished after the Job finishes,
+                    it is eligible to be automatically deleted. When the Job is being
+                    deleted, its lifecycle guarantees (e.g. finalizers) will be honored.
+                    If this field is unset, the Job won't be automatically deleted.
+                    If this field is set to zero, the Job becomes eligible to be deleted
+                    immediately after it finishes. This field is alpha-level and is
+                    only honored by servers that enable the TTLAfterFinished feature.
+                    Only works for Always type
+                  format: int32
+                  type: integer
+                type:
+                  description: Type indicates the type of the CompletionPolicy Default
+                    is Always
+                  type: string
+              type: object
+            parallelism:
+              description: Specifies the maximum desired number of pods the job should
+                run at any given time. The actual number of pods running in steady
+                state will be less than this number when the work left to do is less
+                than max parallelism. Not setting this value means no limit.
+              format: int32
+              type: integer
+            template:
+              description: Describes the pod that will be created when executing a
+                job.
+              type: object
+          required:
+          - template
+          - completionPolicy
+          type: object
+        status:
+          properties:
+            active:
+              description: The number of actively running pods.
+              format: int32
+              type: integer
+            completionTime:
+              description: Represents time when the job was completed. It is not guaranteed
+                to be set in happens-before order across separate operations. It is
+                represented in RFC3339 form and is in UTC.
+              format: date-time
+              type: string
+            conditions:
+              description: The latest available observations of an object's current
+                state. +patchMergeKey=type +patchStrategy=merge
+              items:
+                properties:
+                  lastProbeTime:
+                    description: Last time the condition was checked.
+                    format: date-time
+                    type: string
+                  lastTransitionTime:
+                    description: Last time the condition transit from one status to
+                      another.
+                    format: date-time
+                    type: string
+                  message:
+                    description: Human readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: (brief) reason for the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of True, False, Unknown.
+                    type: string
+                  type:
+                    description: Type of job condition, Complete or Failed.
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+            desired:
+              description: The desired number of pods, this is typically equal to
+                the number of nodes satisfied to run pods.
+              format: int32
+              type: integer
+            failed:
+              description: The number of pods which reached phase Failed.
+              format: int32
+              type: integer
+            startTime:
+              description: Represents time when the job was acknowledged by the job
+                controller. It is not guaranteed to be set in happens-before order
+                across separate operations. It is represented in RFC3339 form and
+                is in UTC.
+              format: date-time
+              type: string
+            succeeded:
+              description: The number of pods which reached phase Succeeded.
+              format: int32
+              type: integer
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/install/kruise/templates/apps_v1alpha1_sidecarset.yaml
+++ b/install/kruise/templates/apps_v1alpha1_sidecarset.yaml
@@ -1,0 +1,74 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: sidecarsets.apps.kruise.io
+spec:
+  group: apps.kruise.io
+  names:
+    kind: SidecarSet
+    plural: sidecarsets
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            containers:
+              description: 'containers contains two pieces of information: 1. normal
+                container info that should be injected into pod 2. custom fields to
+                control insert behavior(currently empty)'
+              items:
+                type: object
+              type: array
+            selector:
+              description: selector is a label query over pods that should be injected
+              type: object
+          type: object
+        status:
+          properties:
+            matchedPods:
+              description: matchedPods is the number of Pods whose labels are matched
+                with this SidecarSet's selector
+              format: int32
+              type: integer
+            observedGeneration:
+              description: observedGeneration is the most recent generation observed
+                for this SidecarSet. It corresponds to the SidecarSet's generation,
+                which is updated on mutation by the API Server.
+              format: int64
+              type: integer
+            readyPods:
+              description: readyPods is the number of matched Pods that have a ready
+                condition
+              format: int32
+              type: integer
+            updatedPods:
+              description: updatedPods is the number of matched Pods that are injected
+                with the latest SidecarSet's containers
+              format: int32
+              type: integer
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/install/kruise/templates/apps_v1alpha1_statefulset.yaml
+++ b/install/kruise/templates/apps_v1alpha1_statefulset.yaml
@@ -1,0 +1,189 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: statefulsets.apps.kruise.io
+spec:
+  group: apps.kruise.io
+  names:
+    kind: StatefulSet
+    plural: statefulsets
+  scope: Namespaced
+  subresources:
+    scale:
+      labelSelectorPath: .status.labelSelector
+      specReplicasPath: .spec.replicas
+      statusReplicasPath: .status.replicas
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            podManagementPolicy:
+              description: podManagementPolicy controls how pods are created during
+                initial scale up, when replacing pods on nodes, or when scaling down.
+                The default policy is `OrderedReady`, where pods are created in increasing
+                order (pod-0, then pod-1, etc) and the controller will wait until
+                each pod is ready before continuing. When scaling down, the pods are
+                removed in the opposite order. The alternative policy is `Parallel`
+                which will create pods in parallel to match the desired scale without
+                waiting, and on scale down will delete all pods at once.
+              type: string
+            replicas:
+              description: 'replicas is the desired number of replicas of the given
+                Template. These are replicas in the sense that they are instantiations
+                of the same Template, but individual replicas also have a consistent
+                identity. If unspecified, defaults to 1. TODO: Consider a rename of
+                this field.'
+              format: int32
+              type: integer
+            revisionHistoryLimit:
+              description: revisionHistoryLimit is the maximum number of revisions
+                that will be maintained in the StatefulSet's revision history. The
+                revision history consists of all revisions not represented by a currently
+                applied StatefulSetSpec version. The default value is 10.
+              format: int32
+              type: integer
+            selector:
+              description: 'selector is a label query over pods that should match
+                the replica count. It must match the pod template''s labels. More
+                info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
+              type: object
+            serviceName:
+              description: 'serviceName is the name of the service that governs this
+                StatefulSet. This service must exist before the StatefulSet, and is
+                responsible for the network identity of the set. Pods get DNS/hostnames
+                that follow the pattern: pod-specific-string.serviceName.default.svc.cluster.local
+                where "pod-specific-string" is managed by the StatefulSet controller.'
+              type: string
+            template:
+              description: template is the object that describes the pod that will
+                be created if insufficient replicas are detected. Each pod stamped
+                out by the StatefulSet will fulfill this Template, but have a unique
+                identity from the rest of the StatefulSet.
+              type: object
+            updateStrategy:
+              description: updateStrategy indicates the StatefulSetUpdateStrategy
+                that will be employed to update Pods in the StatefulSet when a revision
+                is made to Template.
+              properties:
+                rollingUpdate:
+                  description: RollingUpdate is used to communicate parameters when
+                    Type is RollingUpdateStatefulSetStrategyType.
+                  properties:
+                    maxUnavailable:
+                      description: 'The maximum number of pods that can be unavailable
+                        during the update. Value can be an absolute number (ex: 5)
+                        or a percentage of desired pods (ex: 10%). Absolute number
+                        is calculated from percentage by rounding down. Also, maxUnavailable
+                        can just be allowed to work with Parallel podManagementPolicy.
+                        Defaults to 1.'
+                      oneOf:
+                      - type: string
+                      - type: integer
+                    partition:
+                      description: Partition indicates the ordinal at which the StatefulSet
+                        should be partitioned. Default value is 0.
+                      format: int32
+                      type: integer
+                    podUpdatePolicy:
+                      description: PodUpdatePolicy indicates how pods should be updated
+                        Default value is "ReCreate"
+                      type: string
+                  type: object
+                type:
+                  description: Type indicates the type of the StatefulSetUpdateStrategy.
+                    Default is RollingUpdate.
+                  type: string
+              type: object
+            volumeClaimTemplates:
+              description: 'volumeClaimTemplates is a list of claims that pods are
+                allowed to reference. The StatefulSet controller is responsible for
+                mapping network identities to claims in a way that maintains the identity
+                of a pod. Every claim in this list must have at least one matching
+                (by name) volumeMount in one container in the template. A claim in
+                this list takes precedence over any volumes in the template, with
+                the same name. TODO: Define the behavior if a claim already exists
+                with the same name.'
+              items:
+                type: object
+              type: array
+          required:
+          - selector
+          - template
+          - serviceName
+          type: object
+        status:
+          properties:
+            collisionCount:
+              description: collisionCount is the count of hash collisions for the
+                StatefulSet. The StatefulSet controller uses this field as a collision
+                avoidance mechanism when it needs to create the name for the newest
+                ControllerRevision.
+              format: int32
+              type: integer
+            conditions:
+              description: Represents the latest available observations of a statefulset's
+                current state. +patchMergeKey=type +patchStrategy=merge
+              items:
+                type: object
+              type: array
+            currentReplicas:
+              description: currentReplicas is the number of Pods created by the StatefulSet
+                controller from the StatefulSet version indicated by currentRevision.
+              format: int32
+              type: integer
+            currentRevision:
+              description: currentRevision, if not empty, indicates the version of
+                the StatefulSet used to generate Pods in the sequence [0,currentReplicas).
+              type: string
+            observedGeneration:
+              description: observedGeneration is the most recent generation observed
+                for this StatefulSet. It corresponds to the StatefulSet's generation,
+                which is updated on mutation by the API Server.
+              format: int64
+              type: integer
+            readyReplicas:
+              description: readyReplicas is the number of Pods created by the StatefulSet
+                controller that have a Ready Condition.
+              format: int32
+              type: integer
+            replicas:
+              description: replicas is the number of Pods created by the StatefulSet
+                controller.
+              format: int32
+              type: integer
+            updateRevision:
+              description: updateRevision, if not empty, indicates the version of
+                the StatefulSet used to generate Pods in the sequence [replicas-updatedReplicas,replicas)
+              type: string
+            updatedReplicas:
+              description: updatedReplicas is the number of Pods created by the StatefulSet
+                controller from the StatefulSet version indicated by updateRevision.
+              format: int32
+              type: integer
+          required:
+          - replicas
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/install/kruise/templates/manager.yaml
+++ b/install/kruise/templates/manager.yaml
@@ -1,0 +1,95 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: controller-manager
+    controller-tools.k8s.io: "1.0"
+  name: kruise-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    control-plane: controller-manager
+    controller-tools.k8s.io: "1.0"
+  name: kruise-controller-manager-service
+  namespace: kruise-system
+spec:
+  ports:
+    - port: 443
+  selector:
+    control-plane: controller-manager
+    controller-tools.k8s.io: "1.0"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    control-plane: controller-manager
+    controller-tools.k8s.io: "1.0"
+  name: kruise-controller-manager
+  namespace: kruise-system
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+      controller-tools.k8s.io: "1.0"
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 3
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+      labels:
+        control-plane: controller-manager
+        controller-tools.k8s.io: "1.0"
+    spec:
+      containers:
+        - command:
+            - /manager
+          args:
+            - "--metrics-addr=127.0.0.1:8080"
+            - "--logtostderr=true"
+            - "--v={{ .Values.log.level }}"
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: SECRET_NAME
+              value: kruise-webhook-server-secret
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: Always
+          name: manager
+          ports:
+            - containerPort: 8080
+              name: metrics
+              protocol: TCP
+            - containerPort: 9876
+              name: webhook-server
+              protocol: TCP
+          readinessProbe:
+            tcpSocket:
+              port: 9876
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - mountPath: /tmp/cert
+              name: cert
+              readOnly: true
+      terminationGracePeriodSeconds: 10
+      volumes:
+        - name: cert
+          secret:
+            defaultMode: 420
+            secretName: kruise-webhook-server-secret
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kruise-webhook-server-secret
+  namespace: kruise-system

--- a/install/kruise/templates/rbac_role.yaml
+++ b/install/kruise/templates/rbac_role.yaml
@@ -1,0 +1,179 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: kruise-manager-role
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - pods/status
+    verbs:
+      - get
+      - update
+      - patch
+  - apiGroups:
+      - apps.kruise.io
+    resources:
+      - broadcastjobs
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - apps.kruise.io
+    resources:
+      - broadcastjobs/status
+    verbs:
+      - get
+      - update
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - apps.kruise.io
+    resources:
+      - sidecarsets
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - apps.kruise.io
+    resources:
+      - sidecarsets/status
+    verbs:
+      - get
+      - update
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - pods/status
+    verbs:
+      - get
+      - update
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumeclaims
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - apps
+    resources:
+      - controllerrevisions
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - apps.kruise.io
+    resources:
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - apps.kruise.io
+    resources:
+      - statefulsets/status
+    verbs:
+      - get
+      - update
+      - patch
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - mutatingwebhookconfigurations
+      - validatingwebhookconfigurations
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete

--- a/install/kruise/templates/rbac_role_binding.yaml
+++ b/install/kruise/templates/rbac_role_binding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: kruise-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kruise-manager-role
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: kruise-system

--- a/install/kruise/values.yaml
+++ b/install/kruise/values.yaml
@@ -1,0 +1,22 @@
+# Default values for kruise.
+
+# settings for log print
+log:
+  # log level for kruise-manager
+  level: "4"
+
+# image settings
+image:
+  # repository for kruise-manager image
+  repository: openkruise/kruise-manager
+  # tag for kruise-manager image
+  tag: v0.1.0
+
+# resources of kruise-manager container
+resources:
+  limits:
+    cpu: 100m
+    memory: 100Mi
+  requests:
+    cpu: 100m
+    memory: 60Mi

--- a/install/yaml/kruise_all_in_one.yaml
+++ b/install/yaml/kruise_all_in_one.yaml
@@ -1,0 +1,743 @@
+---
+# Source: kruise/templates/manager.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: controller-manager
+    controller-tools.k8s.io: "1.0"
+  name: kruise-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    control-plane: controller-manager
+    controller-tools.k8s.io: "1.0"
+  name: kruise-controller-manager-service
+  namespace: kruise-system
+spec:
+  ports:
+    - port: 443
+  selector:
+    control-plane: controller-manager
+    controller-tools.k8s.io: "1.0"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    control-plane: controller-manager
+    controller-tools.k8s.io: "1.0"
+  name: kruise-controller-manager
+  namespace: kruise-system
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+      controller-tools.k8s.io: "1.0"
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 3
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+      labels:
+        control-plane: controller-manager
+        controller-tools.k8s.io: "1.0"
+    spec:
+      containers:
+        - command:
+            - /manager
+          args:
+            - "--metrics-addr=127.0.0.1:8080"
+            - "--logtostderr=true"
+            - "--v=4"
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: SECRET_NAME
+              value: kruise-webhook-server-secret
+          image: "openkruise/kruise-manager:v0.1.0"
+          imagePullPolicy: Always
+          name: manager
+          ports:
+            - containerPort: 8080
+              name: metrics
+              protocol: TCP
+            - containerPort: 9876
+              name: webhook-server
+              protocol: TCP
+          readinessProbe:
+            tcpSocket:
+              port: 9876
+          resources:
+            limits:
+              cpu: 100m
+              memory: 100Mi
+            requests:
+              cpu: 100m
+              memory: 60Mi
+            
+          volumeMounts:
+            - mountPath: /tmp/cert
+              name: cert
+              readOnly: true
+      terminationGracePeriodSeconds: 10
+      volumes:
+        - name: cert
+          secret:
+            defaultMode: 420
+            secretName: kruise-webhook-server-secret
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kruise-webhook-server-secret
+  namespace: kruise-system
+---
+# Source: kruise/templates/apps_v1alpha1_broadcastjob.yaml
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: broadcastjobs.apps.kruise.io
+spec:
+  group: apps.kruise.io
+  names:
+    kind: BroadcastJob
+    plural: broadcastjobs
+    shortNames:
+      - bj
+  scope: Namespaced
+  additionalPrinterColumns:
+    - name: Desired
+      type: integer
+      description: The desired number of pods, this is typically equal to the number of nodes satisfied to run pods.
+      JSONPath: .status.desired
+    - name: Active
+      type: integer
+      description: The number of actively running pods.
+      JSONPath: .status.active
+    - name: Succeeded
+      type: integer
+      description: The number of pods which reached phase Succeeded.
+      JSONPath: .status.succeeded
+    - name: Failed
+      type: integer
+      description: The number of pods which reached phase Failed.
+      JSONPath: .status.failed
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            completionPolicy:
+              description: CompletionPolicy indicates the completion policy of the
+                job. Default is Always CompletionPolicyType
+              properties:
+                activeDeadlineSeconds:
+                  description: Specifies the duration in seconds relative to the startTime
+                    that the job may be active before the system tries to terminate
+                    it; value must be positive integer. Only works for Always type
+                  format: int64
+                  type: integer
+                backoffLimit:
+                  description: Specifies the number of retries before marking this
+                    job failed. Not setting value means no limit. Only works for Always
+                    type
+                  format: int32
+                  type: integer
+                ttlSecondsAfterFinished:
+                  description: ttlSecondsAfterFinished limits the lifetime of a Job
+                    that has finished execution (either Complete or Failed). If this
+                    field is set, ttlSecondsAfterFinished after the Job finishes,
+                    it is eligible to be automatically deleted. When the Job is being
+                    deleted, its lifecycle guarantees (e.g. finalizers) will be honored.
+                    If this field is unset, the Job won't be automatically deleted.
+                    If this field is set to zero, the Job becomes eligible to be deleted
+                    immediately after it finishes. This field is alpha-level and is
+                    only honored by servers that enable the TTLAfterFinished feature.
+                    Only works for Always type
+                  format: int32
+                  type: integer
+                type:
+                  description: Type indicates the type of the CompletionPolicy Default
+                    is Always
+                  type: string
+              type: object
+            parallelism:
+              description: Specifies the maximum desired number of pods the job should
+                run at any given time. The actual number of pods running in steady
+                state will be less than this number when the work left to do is less
+                than max parallelism. Not setting this value means no limit.
+              format: int32
+              type: integer
+            template:
+              description: Describes the pod that will be created when executing a
+                job.
+              type: object
+          required:
+          - template
+          - completionPolicy
+          type: object
+        status:
+          properties:
+            active:
+              description: The number of actively running pods.
+              format: int32
+              type: integer
+            completionTime:
+              description: Represents time when the job was completed. It is not guaranteed
+                to be set in happens-before order across separate operations. It is
+                represented in RFC3339 form and is in UTC.
+              format: date-time
+              type: string
+            conditions:
+              description: The latest available observations of an object's current
+                state. +patchMergeKey=type +patchStrategy=merge
+              items:
+                properties:
+                  lastProbeTime:
+                    description: Last time the condition was checked.
+                    format: date-time
+                    type: string
+                  lastTransitionTime:
+                    description: Last time the condition transit from one status to
+                      another.
+                    format: date-time
+                    type: string
+                  message:
+                    description: Human readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: (brief) reason for the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of True, False, Unknown.
+                    type: string
+                  type:
+                    description: Type of job condition, Complete or Failed.
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+            desired:
+              description: The desired number of pods, this is typically equal to
+                the number of nodes satisfied to run pods.
+              format: int32
+              type: integer
+            failed:
+              description: The number of pods which reached phase Failed.
+              format: int32
+              type: integer
+            startTime:
+              description: Represents time when the job was acknowledged by the job
+                controller. It is not guaranteed to be set in happens-before order
+                across separate operations. It is represented in RFC3339 form and
+                is in UTC.
+              format: date-time
+              type: string
+            succeeded:
+              description: The number of pods which reached phase Succeeded.
+              format: int32
+              type: integer
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+# Source: kruise/templates/apps_v1alpha1_sidecarset.yaml
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: sidecarsets.apps.kruise.io
+spec:
+  group: apps.kruise.io
+  names:
+    kind: SidecarSet
+    plural: sidecarsets
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            containers:
+              description: 'containers contains two pieces of information: 1. normal
+                container info that should be injected into pod 2. custom fields to
+                control insert behavior(currently empty)'
+              items:
+                type: object
+              type: array
+            selector:
+              description: selector is a label query over pods that should be injected
+              type: object
+          type: object
+        status:
+          properties:
+            matchedPods:
+              description: matchedPods is the number of Pods whose labels are matched
+                with this SidecarSet's selector
+              format: int32
+              type: integer
+            observedGeneration:
+              description: observedGeneration is the most recent generation observed
+                for this SidecarSet. It corresponds to the SidecarSet's generation,
+                which is updated on mutation by the API Server.
+              format: int64
+              type: integer
+            readyPods:
+              description: readyPods is the number of matched Pods that have a ready
+                condition
+              format: int32
+              type: integer
+            updatedPods:
+              description: updatedPods is the number of matched Pods that are injected
+                with the latest SidecarSet's containers
+              format: int32
+              type: integer
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+# Source: kruise/templates/apps_v1alpha1_statefulset.yaml
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: statefulsets.apps.kruise.io
+spec:
+  group: apps.kruise.io
+  names:
+    kind: StatefulSet
+    plural: statefulsets
+  scope: Namespaced
+  subresources:
+    scale:
+      labelSelectorPath: .status.labelSelector
+      specReplicasPath: .spec.replicas
+      statusReplicasPath: .status.replicas
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            podManagementPolicy:
+              description: podManagementPolicy controls how pods are created during
+                initial scale up, when replacing pods on nodes, or when scaling down.
+                The default policy is `OrderedReady`, where pods are created in increasing
+                order (pod-0, then pod-1, etc) and the controller will wait until
+                each pod is ready before continuing. When scaling down, the pods are
+                removed in the opposite order. The alternative policy is `Parallel`
+                which will create pods in parallel to match the desired scale without
+                waiting, and on scale down will delete all pods at once.
+              type: string
+            replicas:
+              description: 'replicas is the desired number of replicas of the given
+                Template. These are replicas in the sense that they are instantiations
+                of the same Template, but individual replicas also have a consistent
+                identity. If unspecified, defaults to 1. TODO: Consider a rename of
+                this field.'
+              format: int32
+              type: integer
+            revisionHistoryLimit:
+              description: revisionHistoryLimit is the maximum number of revisions
+                that will be maintained in the StatefulSet's revision history. The
+                revision history consists of all revisions not represented by a currently
+                applied StatefulSetSpec version. The default value is 10.
+              format: int32
+              type: integer
+            selector:
+              description: 'selector is a label query over pods that should match
+                the replica count. It must match the pod template''s labels. More
+                info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
+              type: object
+            serviceName:
+              description: 'serviceName is the name of the service that governs this
+                StatefulSet. This service must exist before the StatefulSet, and is
+                responsible for the network identity of the set. Pods get DNS/hostnames
+                that follow the pattern: pod-specific-string.serviceName.default.svc.cluster.local
+                where "pod-specific-string" is managed by the StatefulSet controller.'
+              type: string
+            template:
+              description: template is the object that describes the pod that will
+                be created if insufficient replicas are detected. Each pod stamped
+                out by the StatefulSet will fulfill this Template, but have a unique
+                identity from the rest of the StatefulSet.
+              type: object
+            updateStrategy:
+              description: updateStrategy indicates the StatefulSetUpdateStrategy
+                that will be employed to update Pods in the StatefulSet when a revision
+                is made to Template.
+              properties:
+                rollingUpdate:
+                  description: RollingUpdate is used to communicate parameters when
+                    Type is RollingUpdateStatefulSetStrategyType.
+                  properties:
+                    maxUnavailable:
+                      description: 'The maximum number of pods that can be unavailable
+                        during the update. Value can be an absolute number (ex: 5)
+                        or a percentage of desired pods (ex: 10%). Absolute number
+                        is calculated from percentage by rounding down. Also, maxUnavailable
+                        can just be allowed to work with Parallel podManagementPolicy.
+                        Defaults to 1.'
+                      oneOf:
+                      - type: string
+                      - type: integer
+                    partition:
+                      description: Partition indicates the ordinal at which the StatefulSet
+                        should be partitioned. Default value is 0.
+                      format: int32
+                      type: integer
+                    podUpdatePolicy:
+                      description: PodUpdatePolicy indicates how pods should be updated
+                        Default value is "ReCreate"
+                      type: string
+                  type: object
+                type:
+                  description: Type indicates the type of the StatefulSetUpdateStrategy.
+                    Default is RollingUpdate.
+                  type: string
+              type: object
+            volumeClaimTemplates:
+              description: 'volumeClaimTemplates is a list of claims that pods are
+                allowed to reference. The StatefulSet controller is responsible for
+                mapping network identities to claims in a way that maintains the identity
+                of a pod. Every claim in this list must have at least one matching
+                (by name) volumeMount in one container in the template. A claim in
+                this list takes precedence over any volumes in the template, with
+                the same name. TODO: Define the behavior if a claim already exists
+                with the same name.'
+              items:
+                type: object
+              type: array
+          required:
+          - selector
+          - template
+          - serviceName
+          type: object
+        status:
+          properties:
+            collisionCount:
+              description: collisionCount is the count of hash collisions for the
+                StatefulSet. The StatefulSet controller uses this field as a collision
+                avoidance mechanism when it needs to create the name for the newest
+                ControllerRevision.
+              format: int32
+              type: integer
+            conditions:
+              description: Represents the latest available observations of a statefulset's
+                current state. +patchMergeKey=type +patchStrategy=merge
+              items:
+                type: object
+              type: array
+            currentReplicas:
+              description: currentReplicas is the number of Pods created by the StatefulSet
+                controller from the StatefulSet version indicated by currentRevision.
+              format: int32
+              type: integer
+            currentRevision:
+              description: currentRevision, if not empty, indicates the version of
+                the StatefulSet used to generate Pods in the sequence [0,currentReplicas).
+              type: string
+            observedGeneration:
+              description: observedGeneration is the most recent generation observed
+                for this StatefulSet. It corresponds to the StatefulSet's generation,
+                which is updated on mutation by the API Server.
+              format: int64
+              type: integer
+            readyReplicas:
+              description: readyReplicas is the number of Pods created by the StatefulSet
+                controller that have a Ready Condition.
+              format: int32
+              type: integer
+            replicas:
+              description: replicas is the number of Pods created by the StatefulSet
+                controller.
+              format: int32
+              type: integer
+            updateRevision:
+              description: updateRevision, if not empty, indicates the version of
+                the StatefulSet used to generate Pods in the sequence [replicas-updatedReplicas,replicas)
+              type: string
+            updatedReplicas:
+              description: updatedReplicas is the number of Pods created by the StatefulSet
+                controller from the StatefulSet version indicated by updateRevision.
+              format: int32
+              type: integer
+          required:
+          - replicas
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+# Source: kruise/templates/rbac_role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: kruise-manager-role
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - pods/status
+    verbs:
+      - get
+      - update
+      - patch
+  - apiGroups:
+      - apps.kruise.io
+    resources:
+      - broadcastjobs
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - apps.kruise.io
+    resources:
+      - broadcastjobs/status
+    verbs:
+      - get
+      - update
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - apps.kruise.io
+    resources:
+      - sidecarsets
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - apps.kruise.io
+    resources:
+      - sidecarsets/status
+    verbs:
+      - get
+      - update
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - pods/status
+    verbs:
+      - get
+      - update
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumeclaims
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - apps
+    resources:
+      - controllerrevisions
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - apps.kruise.io
+    resources:
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - apps.kruise.io
+    resources:
+      - statefulsets/status
+    verbs:
+      - get
+      - update
+      - patch
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - mutatingwebhookconfigurations
+      - validatingwebhookconfigurations
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+---
+# Source: kruise/templates/rbac_role_binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: kruise-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kruise-manager-role
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: kruise-system


### PR DESCRIPTION
Update yamls:
- use Deployment to deploy kruise-manager instead of StatefulSet
- the default Deployment will create 3 Pods, but only one of them can be Ready through leaderelection, other of them will keep acquiring lease
- once the leader Pod going down, another Pod will get the lease and turn to leader in a short time

Helm chart:
build a helm chart for Kruise, then we need to package and upload it so that users outside can install the chart in their clusters.