### PR TITLE
Fix a bug that StatefulSet applies the revision incorrectly

### DIFF
--- a/pkg/controller/statefulset/stateful_set_utils.go
+++ b/pkg/controller/statefulset/stateful_set_utils.go
@@ -340,11 +340,12 @@ func ApplyRevision(set *appsv1alpha1.StatefulSet, revision *apps.ControllerRevis
 	if err != nil {
 		return nil, err
 	}
-	err = json.Unmarshal(patched, clone)
+	restoredSet := &appsv1alpha1.StatefulSet{}
+	err = json.Unmarshal(patched, restoredSet)
 	if err != nil {
 		return nil, err
 	}
-	return clone, nil
+	return restoredSet, nil
 }
 
 // nextRevision finds the next valid revision number based on revisions. If the length of revisions

--- a/pkg/controller/statefulset/stateful_set_utils_test.go
+++ b/pkg/controller/statefulset/stateful_set_utils_test.go
@@ -20,6 +20,7 @@ package statefulset
 import (
 	"fmt"
 	"math/rand"
+	"reflect"
 	"sort"
 	"strconv"
 	"testing"
@@ -287,6 +288,39 @@ func TestCreateApplyRevision(t *testing.T) {
 	}
 	if value != expectedValue {
 		t.Errorf("for annotation %s wanted %s got %s", key, expectedValue, value)
+	}
+}
+
+func TestRollingUpdateApplyRevision(t *testing.T) {
+	set := newStatefulSet(1)
+	set.Status.CollisionCount = new(int32)
+	currentSet := set.DeepCopy()
+	currentRevision, err := newRevision(set, 1, set.Status.CollisionCount)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	set.Spec.Template.Spec.Containers[0].Env = []v1.EnvVar{{Name: "foo", Value: "bar"}}
+	updateSet := set.DeepCopy()
+	updateRevision, err := newRevision(set, 2, set.Status.CollisionCount)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	restoredCurrentSet, err := ApplyRevision(set, currentRevision)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(currentSet.Spec.Template, restoredCurrentSet.Spec.Template) {
+		t.Errorf("want %v got %v", currentSet.Spec.Template, restoredCurrentSet.Spec.Template)
+	}
+
+	restoredUpdateSet, err := ApplyRevision(set, updateRevision)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(updateSet.Spec.Template, restoredUpdateSet.Spec.Template) {
+		t.Errorf("want %v got %v", updateSet.Spec.Template, restoredUpdateSet.Spec.Template)
 	}
 }
 


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
I think the root cause of https://github.com/kubernetes/kubernetes/issues/78420 is that StatefulSet, which will be json.Unmarshal to, is not reset.
so that ApplyRevision makes the subfield env of StatefulSet has both field valueFrom and value that is invalid.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes https://github.com/kubernetes/kubernetes/issues/78420

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.
unit test

### Ⅳ. Describe how to verify it
in https://github.com/kubernetes/kubernetes/issues/78420

### Ⅴ. Special notes for reviews


