### PR TITLE
Remove the use of "slave"

### DIFF
--- a/docs/tutorial/advanced-statefulset.md
+++ b/docs/tutorial/advanced-statefulset.md
@@ -19,7 +19,7 @@ If you don't use helm, you need to install with YAML files as below.
 
 ## Install the Guestbook application with YAML files
 
-Below installs a redis cluster with 1 master 2 slaves
+Below installs a redis cluster with 1 master 2 replicas
 ```
 kubectl apply -f https://raw.githubusercontent.com/kruiseio/kruise/master/docs/tutorial/v1/redis-master-deployment.yaml
 kubectl apply -f https://raw.githubusercontent.com/kruiseio/kruise/master/docs/tutorial/v1/redis-master-service.yaml


### PR DESCRIPTION
Redis has begun renaming "slave" to "replica" which is both a more accurate term to describe what it does and doesn't use the language of oppressors.

There are more instances of the word "slave" used in this repo, if this PR is welcomed I can go through the rest