### PR TITLE
Revert "Update link to correct guestbook v2 yaml"

### DIFF
--- a/docs/tutorial/advanced-statefulset.md
+++ b/docs/tutorial/advanced-statefulset.md
@@ -85,7 +85,7 @@ You can now view the Guestbook on browser.
 kubectl get svc
 
 NAME                          TYPE           CLUSTER-IP     EXTERNAL-IP     PORT(S)                         AGE
-guestbook-v1      LoadBalancer   172.21.2.187   47.101.74.131   3000:31459/TCP,4000:32099/TCP   35m
+demo-v1-guestbook-kruise      LoadBalancer   172.21.2.187   47.101.74.131   3000:31459/TCP,4000:32099/TCP   35m
 ```
 
 `47.101.74.131` is the external IP. 
@@ -98,32 +98,32 @@ First, check the running pods.
 ```
 kubectl get pod -L controller-revision-hash -o wide | grep guestbook
 NAME                                        READY   STATUS    RESTARTS   AGE     IP             NODE            NOMINATED NODE   CONTROLLER-REVISION-HASH
-guestbook-v1-0                  1/1     Running   0          35s     172.29.1.21    192.168.1.113   <none>           guestbook-v1-7c947b5f94
-guestbook-v1-1                  1/1     Running   0          35s     172.29.0.148   192.168.1.112   <none>           guestbook-v1-7c947b5f94
-guestbook-v1-10                 1/1     Running   0          33s     172.29.1.23    192.168.1.113   <none>           guestbook-v1-7c947b5f94
-guestbook-v1-11                 1/1     Running   0          33s     172.29.0.151   192.168.1.112   <none>           guestbook-v1-7c947b5f94
-guestbook-v1-12                 1/1     Running   0          32s     172.29.0.152   192.168.1.112   <none>           guestbook-v1-7c947b5f94
-guestbook-v1-13                 1/1     Running   0          32s     172.29.0.153   192.168.1.112   <none>           guestbook-v1-7c947b5f94
-guestbook-v1-14                 1/1     Running   0          32s     172.29.0.27    192.168.1.114   <none>           guestbook-v1-7c947b5f94
-guestbook-v1-15                 1/1     Running   0          31s     172.29.0.28    192.168.1.114   <none>           guestbook-v1-7c947b5f94
-guestbook-v1-16                 1/1     Running   0          31s     172.29.1.24    192.168.1.113   <none>           guestbook-v1-7c947b5f94
-guestbook-v1-17                 1/1     Running   0          30s     172.29.0.29    192.168.1.114   <none>           guestbook-v1-7c947b5f94
-guestbook-v1-18                 1/1     Running   0          30s     172.29.0.154   192.168.1.112   <none>           guestbook-v1-7c947b5f94
-guestbook-v1-19                 1/1     Running   0          30s     172.29.1.25    192.168.1.113   <none>           guestbook-v1-7c947b5f94
-guestbook-v1-2                  1/1     Running   0          35s     172.29.0.22    192.168.1.114   <none>           guestbook-v1-7c947b5f94
-guestbook-v1-3                  1/1     Running   0          35s     172.29.0.149   192.168.1.112   <none>           guestbook-v1-7c947b5f94
-guestbook-v1-4                  1/1     Running   0          35s     172.29.0.23    192.168.1.114   <none>           guestbook-v1-7c947b5f94
-guestbook-v1-5                  1/1     Running   0          35s     172.29.1.22    192.168.1.113   <none>           guestbook-v1-7c947b5f94
-guestbook-v1-6                  1/1     Running   0          35s     172.29.0.24    192.168.1.114   <none>           guestbook-v1-7c947b5f94
-guestbook-v1-7                  1/1     Running   0          34s     172.29.0.150   192.168.1.112   <none>           guestbook-v1-7c947b5f94
-guestbook-v1-8                  1/1     Running   0          34s     172.29.0.25    192.168.1.114   <none>           guestbook-v1-7c947b5f94
-guestbook-v1-9                  1/1     Running   0          34s     172.29.0.26    192.168.1.114   <none>           guestbook-v1-7c947b5f94
+demo-v1-guestbook-kruise-0                  1/1     Running   0          35s     172.29.1.21    192.168.1.113   <none>           demo-v1-guestbook-kruise-7c947b5f94
+demo-v1-guestbook-kruise-1                  1/1     Running   0          35s     172.29.0.148   192.168.1.112   <none>           demo-v1-guestbook-kruise-7c947b5f94
+demo-v1-guestbook-kruise-10                 1/1     Running   0          33s     172.29.1.23    192.168.1.113   <none>           demo-v1-guestbook-kruise-7c947b5f94
+demo-v1-guestbook-kruise-11                 1/1     Running   0          33s     172.29.0.151   192.168.1.112   <none>           demo-v1-guestbook-kruise-7c947b5f94
+demo-v1-guestbook-kruise-12                 1/1     Running   0          32s     172.29.0.152   192.168.1.112   <none>           demo-v1-guestbook-kruise-7c947b5f94
+demo-v1-guestbook-kruise-13                 1/1     Running   0          32s     172.29.0.153   192.168.1.112   <none>           demo-v1-guestbook-kruise-7c947b5f94
+demo-v1-guestbook-kruise-14                 1/1     Running   0          32s     172.29.0.27    192.168.1.114   <none>           demo-v1-guestbook-kruise-7c947b5f94
+demo-v1-guestbook-kruise-15                 1/1     Running   0          31s     172.29.0.28    192.168.1.114   <none>           demo-v1-guestbook-kruise-7c947b5f94
+demo-v1-guestbook-kruise-16                 1/1     Running   0          31s     172.29.1.24    192.168.1.113   <none>           demo-v1-guestbook-kruise-7c947b5f94
+demo-v1-guestbook-kruise-17                 1/1     Running   0          30s     172.29.0.29    192.168.1.114   <none>           demo-v1-guestbook-kruise-7c947b5f94
+demo-v1-guestbook-kruise-18                 1/1     Running   0          30s     172.29.0.154   192.168.1.112   <none>           demo-v1-guestbook-kruise-7c947b5f94
+demo-v1-guestbook-kruise-19                 1/1     Running   0          30s     172.29.1.25    192.168.1.113   <none>           demo-v1-guestbook-kruise-7c947b5f94
+demo-v1-guestbook-kruise-2                  1/1     Running   0          35s     172.29.0.22    192.168.1.114   <none>           demo-v1-guestbook-kruise-7c947b5f94
+demo-v1-guestbook-kruise-3                  1/1     Running   0          35s     172.29.0.149   192.168.1.112   <none>           demo-v1-guestbook-kruise-7c947b5f94
+demo-v1-guestbook-kruise-4                  1/1     Running   0          35s     172.29.0.23    192.168.1.114   <none>           demo-v1-guestbook-kruise-7c947b5f94
+demo-v1-guestbook-kruise-5                  1/1     Running   0          35s     172.29.1.22    192.168.1.113   <none>           demo-v1-guestbook-kruise-7c947b5f94
+demo-v1-guestbook-kruise-6                  1/1     Running   0          35s     172.29.0.24    192.168.1.114   <none>           demo-v1-guestbook-kruise-7c947b5f94
+demo-v1-guestbook-kruise-7                  1/1     Running   0          34s     172.29.0.150   192.168.1.112   <none>           demo-v1-guestbook-kruise-7c947b5f94
+demo-v1-guestbook-kruise-8                  1/1     Running   0          34s     172.29.0.25    192.168.1.114   <none>           demo-v1-guestbook-kruise-7c947b5f94
+demo-v1-guestbook-kruise-9                  1/1     Running   0          34s     172.29.0.26    192.168.1.114   <none>           demo-v1-guestbook-kruise-7c947b5f94
 ```
 
 Run this command to update the statefulset to use the new image.
 
 ```
-kubectl apply -f https://raw.githubusercontent.com/kruiseio/kruise/master/docs/tutorial/v1/guestbook-statefulset-v2.yaml
+kubectl apply -f https://raw.githubusercontent.com/kruiseio/kruise/master/docs/tutorial/v1/guestbook-patch-to-v2.yaml
 ```
 
 What this command does is that it changes the image version to `v2` and changes `partition` to `15`.
@@ -152,41 +152,41 @@ Check the statefulset, find the statefulset has 5 pods updated
 kubectl get sts.apps.kruise.io
 
 NAME                       DESIRED   CURRENT   UPDATED   READY   AGE
-guestbook-v1   20        20        5         20      18h
+demo-v1-guestbook-kruise   20        20        5         20      18h
 ``` 
 
-Check the pods again. `guestbook-v1-15` to `guestbook-v1-19` are updated with `RESTARTS` showing `1`, 
-IPs remain the same, `CONTROLLER-REVISION-HASH` are updated from ` guestbook-v1-7c947b5f94` to `guestbook-v1-576bd76785`
+Check the pods again. `demo-v1-guestbook-kruise-15` to `demo-v1-guestbook-kruise-19` are updated with `RESTARTS` showing `1`, 
+IPs remain the same, `CONTROLLER-REVISION-HASH` are updated from ` demo-v1-guestbook-kruise-7c947b5f94` to `demo-v1-guestbook-kruise-576bd76785`
 
 ```
 kubectl get pod -L controller-revision-hash -o wide | grep guestbook
 
 NAME                                        READY   STATUS    RESTARTS   AGE     IP             NODE            NOMINATED NODE   CONTROLLER-REVISION-HASH
-guestbook-v1-0                  1/1     Running   0          3m22s   172.29.1.21    192.168.1.113   <none>           guestbook-v1-7c947b5f94
-guestbook-v1-1                  1/1     Running   0          3m22s   172.29.0.148   192.168.1.112   <none>           guestbook-v1-7c947b5f94
-guestbook-v1-10                 1/1     Running   0          3m20s   172.29.1.23    192.168.1.113   <none>           guestbook-v1-7c947b5f94
-guestbook-v1-11                 1/1     Running   0          3m20s   172.29.0.151   192.168.1.112   <none>           guestbook-v1-7c947b5f94
-guestbook-v1-12                 1/1     Running   0          3m19s   172.29.0.152   192.168.1.112   <none>           guestbook-v1-7c947b5f94
-guestbook-v1-13                 1/1     Running   0          3m19s   172.29.0.153   192.168.1.112   <none>           guestbook-v1-7c947b5f94
-guestbook-v1-14                 1/1     Running   0          3m19s   172.29.0.27    192.168.1.114   <none>           guestbook-v1-7c947b5f94
-guestbook-v1-15                 1/1     Running   1          3m18s   172.29.0.28    192.168.1.114   <none>           guestbook-v1-576bd76785
-guestbook-v1-16                 1/1     Running   1          3m18s   172.29.1.24    192.168.1.113   <none>           guestbook-v1-576bd76785
-guestbook-v1-17                 1/1     Running   1          3m17s   172.29.0.29    192.168.1.114   <none>           guestbook-v1-576bd76785
-guestbook-v1-18                 1/1     Running   1          3m17s   172.29.0.154   192.168.1.112   <none>           guestbook-v1-576bd76785
-guestbook-v1-19                 1/1     Running   1          3m17s   172.29.1.25    192.168.1.113   <none>           guestbook-v1-576bd76785
-guestbook-v1-2                  1/1     Running   0          3m22s   172.29.0.22    192.168.1.114   <none>           guestbook-v1-7c947b5f94
-guestbook-v1-3                  1/1     Running   0          3m22s   172.29.0.149   192.168.1.112   <none>           guestbook-v1-7c947b5f94
-guestbook-v1-4                  1/1     Running   0          3m22s   172.29.0.23    192.168.1.114   <none>           guestbook-v1-7c947b5f94
-guestbook-v1-5                  1/1     Running   0          3m22s   172.29.1.22    192.168.1.113   <none>           guestbook-v1-7c947b5f94
-guestbook-v1-6                  1/1     Running   0          3m22s   172.29.0.24    192.168.1.114   <none>           guestbook-v1-7c947b5f94
-guestbook-v1-7                  1/1     Running   0          3m21s   172.29.0.150   192.168.1.112   <none>           guestbook-v1-7c947b5f94
-guestbook-v1-8                  1/1     Running   0          3m21s   172.29.0.25    192.168.1.114   <none>           guestbook-v1-7c947b5f94
-guestbook-v1-9                  1/1     Running   0          3m21s   172.29.0.26    192.168.1.114   <none>           guestbook-v1-7c947b5f94
+demo-v1-guestbook-kruise-0                  1/1     Running   0          3m22s   172.29.1.21    192.168.1.113   <none>           demo-v1-guestbook-kruise-7c947b5f94
+demo-v1-guestbook-kruise-1                  1/1     Running   0          3m22s   172.29.0.148   192.168.1.112   <none>           demo-v1-guestbook-kruise-7c947b5f94
+demo-v1-guestbook-kruise-10                 1/1     Running   0          3m20s   172.29.1.23    192.168.1.113   <none>           demo-v1-guestbook-kruise-7c947b5f94
+demo-v1-guestbook-kruise-11                 1/1     Running   0          3m20s   172.29.0.151   192.168.1.112   <none>           demo-v1-guestbook-kruise-7c947b5f94
+demo-v1-guestbook-kruise-12                 1/1     Running   0          3m19s   172.29.0.152   192.168.1.112   <none>           demo-v1-guestbook-kruise-7c947b5f94
+demo-v1-guestbook-kruise-13                 1/1     Running   0          3m19s   172.29.0.153   192.168.1.112   <none>           demo-v1-guestbook-kruise-7c947b5f94
+demo-v1-guestbook-kruise-14                 1/1     Running   0          3m19s   172.29.0.27    192.168.1.114   <none>           demo-v1-guestbook-kruise-7c947b5f94
+demo-v1-guestbook-kruise-15                 1/1     Running   1          3m18s   172.29.0.28    192.168.1.114   <none>           demo-v1-guestbook-kruise-576bd76785
+demo-v1-guestbook-kruise-16                 1/1     Running   1          3m18s   172.29.1.24    192.168.1.113   <none>           demo-v1-guestbook-kruise-576bd76785
+demo-v1-guestbook-kruise-17                 1/1     Running   1          3m17s   172.29.0.29    192.168.1.114   <none>           demo-v1-guestbook-kruise-576bd76785
+demo-v1-guestbook-kruise-18                 1/1     Running   1          3m17s   172.29.0.154   192.168.1.112   <none>           demo-v1-guestbook-kruise-576bd76785
+demo-v1-guestbook-kruise-19                 1/1     Running   1          3m17s   172.29.1.25    192.168.1.113   <none>           demo-v1-guestbook-kruise-576bd76785
+demo-v1-guestbook-kruise-2                  1/1     Running   0          3m22s   172.29.0.22    192.168.1.114   <none>           demo-v1-guestbook-kruise-7c947b5f94
+demo-v1-guestbook-kruise-3                  1/1     Running   0          3m22s   172.29.0.149   192.168.1.112   <none>           demo-v1-guestbook-kruise-7c947b5f94
+demo-v1-guestbook-kruise-4                  1/1     Running   0          3m22s   172.29.0.23    192.168.1.114   <none>           demo-v1-guestbook-kruise-7c947b5f94
+demo-v1-guestbook-kruise-5                  1/1     Running   0          3m22s   172.29.1.22    192.168.1.113   <none>           demo-v1-guestbook-kruise-7c947b5f94
+demo-v1-guestbook-kruise-6                  1/1     Running   0          3m22s   172.29.0.24    192.168.1.114   <none>           demo-v1-guestbook-kruise-7c947b5f94
+demo-v1-guestbook-kruise-7                  1/1     Running   0          3m21s   172.29.0.150   192.168.1.112   <none>           demo-v1-guestbook-kruise-7c947b5f94
+demo-v1-guestbook-kruise-8                  1/1     Running   0          3m21s   172.29.0.25    192.168.1.114   <none>           demo-v1-guestbook-kruise-7c947b5f94
+demo-v1-guestbook-kruise-9                  1/1     Running   0          3m21s   172.29.0.26    192.168.1.114   <none>           demo-v1-guestbook-kruise-7c947b5f94
 ```
 
 Now upgrade all the pods, run
 ```
-kubectl edit sts.apps.kruise.io guestbook-v1
+kubectl edit sts.apps.kruise.io demo-v1-guestbook-kruise
 ``` 
 and update `partition` to `0`, all pods will be updated to v2 this time, and all pods' IP remain `unchanged`. You should also find 
 that all 20 pods are updated fairly fast because the `maxUnavailable` feature allows parallel updates instead of sequential update.
@@ -194,12 +194,12 @@ that all 20 pods are updated fairly fast because the `maxUnavailable` feature al
 ```
 kubectl get sts.apps.kruise.io
 NAME           DESIRED   CURRENT   UPDATED   READY   AGE
-guestbook-v1   20        20        20        20      18h
+demo-v1-guestbook-kruise   20        20        20        20      18h
 ```
 
 Describe a pod and find that the events show the original container is killed and new container is started. This verifies `in-place` update
 ```
-kubectl describe pod guestbook-v1-0
+kubectl describe pod demo-v1-guestbook-kruise-0
 
 ...
 Events:
@@ -245,7 +245,7 @@ helm uninstall demo-v1
 
 If you are not using helm, deleting the application using below commands:
 ```
-kubectl delete sts.apps.kruise.io guestbook-v1
-kubectl delete svc guestbook-v1 redis-master redis-slave
+kubectl delete sts.apps.kruise.io demo-v1-guestbook-kruise
+kubectl delete svc demo-v1-guestbook-kruise redis-master redis-slave
 kubectl delete deploy redis-master redis-slave
 ```


### PR DESCRIPTION
Reverts openkruise/kruise#64

And I will send out a follow up PR to fix the inconsistency naming in tutorials.

Thanks @jian-he 