### PR TITLE
support sidecar update

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -305,6 +305,10 @@
             "$ref": "#/definitions/kruise.apps.v1alpha1.SidecarContainer"
           }
         },
+        "paused": {
+          "description": "indicates that the sidecarset is paused and will not be processed by the sidecarset controller.",
+          "type": "boolean"
+        },
         "selector": {
           "description": "selector is a label query over pods that should be injected",
           "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"

--- a/config/crds/apps_v1alpha1_sidecarset.yaml
+++ b/config/crds/apps_v1alpha1_sidecarset.yaml
@@ -57,6 +57,10 @@ spec:
               items:
                 type: object
               type: array
+            paused:
+              description: indicates that the sidecarset is paused and will not be
+                processed by the sidecarset controller.
+              type: boolean
             selector:
               description: selector is a label query over pods that should be injected
               type: object
@@ -65,7 +69,7 @@ spec:
           properties:
             matchedPods:
               description: matchedPods is the number of Pods whose labels are matched
-                with this SidecarSet's selector
+                with this SidecarSet's selector and are created after sidecarset creates
               format: int32
               type: integer
             observedGeneration:

--- a/docs/concepts/sidecarSet/README.md
+++ b/docs/concepts/sidecarSet/README.md
@@ -53,7 +53,7 @@ spec:
       app: nginx
   containers:
   - name: sidecar1
-    image: centos:7
+    image: centos:6.7
     command: ["sleep", "999d"] # do nothing at all
 ```
 
@@ -100,6 +100,14 @@ status:
   readyPods: 1
   updatedPods: 1
 ```
+
+### Update a SidecarSet
+
+Use ```kubectl edit sidecarset test-sidecarset``` to modify sidecarSet image from "centos:6.7" to "centos:6.8", then you will see matched pods will be updated in place one by one(we only support maxUnavailable=1 for now).
+
+You could use ```kubectl patch sidecarset test-sidecarset --type merge -p '{"spec":{"paused":true}}'``` to pause the update procedure.
+
+If user modifies fields other than image in sidecarSet, pod won't get updated until pod is recreated by workload(e.g. deployment), which we called "lazy update".
 
 ## Tutorial
 

--- a/pkg/apis/apps/v1alpha1/openapi_generated.go
+++ b/pkg/apis/apps/v1alpha1/openapi_generated.go
@@ -585,6 +585,13 @@ func schema_pkg_apis_apps_v1alpha1_SidecarSetSpec(ref common.ReferenceCallback) 
 							},
 						},
 					},
+					"paused": {
+						SchemaProps: spec.SchemaProps{
+							Description: "indicates that the sidecarset is paused and will not be processed by the sidecarset controller.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/apis/apps/v1alpha1/sidecarset_types.go
+++ b/pkg/apis/apps/v1alpha1/sidecarset_types.go
@@ -30,6 +30,9 @@ type SidecarSetSpec struct {
 	// 1. normal container info that should be injected into pod
 	// 2. custom fields to control insert behavior(currently empty)
 	Containers []SidecarContainer `json:"containers,omitempty"`
+
+	// indicates that the sidecarset is paused and will not be processed by the sidecarset controller.
+	Paused bool `json:"paused,omitempty"`
 }
 
 // SidecarContainer defines the container of Sidecar
@@ -43,7 +46,7 @@ type SidecarSetStatus struct {
 	// SidecarSet's generation, which is updated on mutation by the API Server.
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 
-	// matchedPods is the number of Pods whose labels are matched with this SidecarSet's selector
+	// matchedPods is the number of Pods whose labels are matched with this SidecarSet's selector and are created after sidecarset creates
 	MatchedPods int32 `json:"matchedPods"`
 
 	// updatedPods is the number of matched Pods that are injected with the latest SidecarSet's containers

--- a/pkg/controller/sidecarset/sidecarset_controller_test.go
+++ b/pkg/controller/sidecarset/sidecarset_controller_test.go
@@ -1,0 +1,209 @@
+package sidecarset
+
+import (
+	"context"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"testing"
+
+	"github.com/openkruise/kruise/pkg/webhook/default_server/sidecarset/mutating"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	appsv1alpha1 "github.com/openkruise/kruise/pkg/apis/apps/v1alpha1"
+)
+
+var (
+	scheme *runtime.Scheme
+
+	sidecarSetDemo = &appsv1alpha1.SidecarSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				mutating.SidecarSetHashAnnotation:             "ccc",
+				mutating.SidecarSetHashWithoutImageAnnotation: "bbb",
+			},
+			Name: "test-sidecarset",
+		},
+		Spec: appsv1alpha1.SidecarSetSpec{
+			Containers: []appsv1alpha1.SidecarContainer{
+				{
+					Container: corev1.Container{
+						Name:  "test-sidecar",
+						Image: "test-image:v2",
+					},
+				},
+			},
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "nginx"},
+			},
+		},
+	}
+
+	podDemo = &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				mutating.SidecarSetHashAnnotation:             `{"test-sidecarset":"aaa"}`,
+				mutating.SidecarSetHashWithoutImageAnnotation: `{"test-sidecarset":"bbb"}`,
+			},
+			Name:      "test-pod",
+			Namespace: "default",
+			Labels:    map[string]string{"app": "nginx"},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "nginx",
+					Image: "nginx:1.15.1",
+				},
+				{
+					Name:  "test-sidecar",
+					Image: "test-image:v1",
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{
+				{
+					Type:   corev1.PodReady,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		},
+	}
+)
+
+func init() {
+	scheme = runtime.NewScheme()
+	_ = appsv1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+}
+
+func getLatestPod(client client.Client, pod *corev1.Pod) (*corev1.Pod, error) {
+	newPod := &corev1.Pod{}
+	podKey := types.NamespacedName{
+		Namespace: pod.Namespace,
+		Name: pod.Name,
+	}
+	err := client.Get(context.TODO(), podKey, newPod)
+	return newPod, err
+}
+
+func isSidecarImageUpdated(pod *corev1.Pod, containerName, containerImage string) bool {
+	for _, container := range pod.Spec.Containers {
+		if container.Name == containerName {
+			return container.Image == containerImage
+		}
+	}
+	return false
+}
+
+func TestUpdateWhenEverythingIsFine(t *testing.T) {
+	sidecarSetInput := sidecarSetDemo.DeepCopy()
+	podInput := podDemo.DeepCopy()
+	request := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: sidecarSetInput.Namespace,
+			Name:      sidecarSetInput.Name,
+		},
+	}
+
+	fakeClient := fake.NewFakeClientWithScheme(scheme, sidecarSetInput, podInput)
+	reconciler := ReconcileSidecarSet{Client: fakeClient}
+	if _, err := reconciler.Reconcile(request); err != nil {
+		t.Errorf("reconcile failed, err: %v", err)
+	}
+
+	podOutput, err := getLatestPod(fakeClient, podInput)
+	if err != nil {
+		t.Errorf("get latest pod failed, err: %v", err)
+	}
+	if !isSidecarImageUpdated(podOutput, "test-sidecar", "test-image:v2") {
+		t.Errorf("should update sidecar")
+	}
+}
+
+func TestUpdateWhenSidecarSetPaused(t *testing.T) {
+	sidecarSetInput := sidecarSetDemo.DeepCopy()
+	sidecarSetInput.Spec.Paused = true
+	podInput := podDemo.DeepCopy()
+	request := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: sidecarSetInput.Namespace,
+			Name:      sidecarSetInput.Name,
+		},
+	}
+
+	fakeClient := fake.NewFakeClientWithScheme(scheme, sidecarSetInput, podInput)
+	reconciler := ReconcileSidecarSet{Client: fakeClient}
+	if _, err := reconciler.Reconcile(request); err != nil {
+		t.Errorf("reconcile failed, err: %v", err)
+	}
+
+	podOutput, err := getLatestPod(fakeClient, podInput)
+	if err != nil {
+		t.Errorf("get latest pod failed, err: %v", err)
+	}
+	if isSidecarImageUpdated(podOutput, "test-sidecar", "test-image:v2") {
+		t.Errorf("shouldn't update sidecar because sidecarset is paused")
+	}
+}
+
+func TestUpdateWhenOtherFieldsChanged(t *testing.T) {
+	sidecarSetInput := sidecarSetDemo.DeepCopy()
+	sidecarSetInput.Annotations[mutating.SidecarSetHashAnnotation] = "ccc"
+	sidecarSetInput.Annotations[mutating.SidecarSetHashWithoutImageAnnotation] = "ddd"
+	podInput := podDemo.DeepCopy()
+	request := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: sidecarSetInput.Namespace,
+			Name:      sidecarSetInput.Name,
+		},
+	}
+
+	fakeClient := fake.NewFakeClientWithScheme(scheme, sidecarSetInput, podInput)
+	reconciler := ReconcileSidecarSet{Client: fakeClient}
+	if _, err := reconciler.Reconcile(request); err != nil {
+		t.Errorf("reconcile failed, err: %v", err)
+	}
+
+	podOutput, err := getLatestPod(fakeClient, podInput)
+	if err != nil {
+		t.Errorf("get latest pod failed, err: %v", err)
+	}
+	if isSidecarImageUpdated(podOutput, "test-sidecar", "test-image:v2") {
+		t.Errorf("shouldn't update sidecar because other fields in sidecarset had changed")
+	}
+}
+
+func TestUpdateWhenMaxUnavailableNotZero(t *testing.T) {
+	sidecarSetInput := sidecarSetDemo.DeepCopy()
+	updateCache.reset(sidecarSetInput)
+	podInput := podDemo.DeepCopy()
+	podInput.Status.Phase = corev1.PodPending
+	request := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: sidecarSetInput.Namespace,
+			Name:      sidecarSetInput.Name,
+		},
+	}
+
+	fakeClient := fake.NewFakeClientWithScheme(scheme, sidecarSetInput, podInput)
+	reconciler := ReconcileSidecarSet{Client: fakeClient}
+	if _, err := reconciler.Reconcile(request); err != nil {
+		t.Errorf("reconcile failed, err: %v", err)
+	}
+
+	podOutput, err := getLatestPod(fakeClient, podInput)
+	if err != nil {
+		t.Errorf("get latest pod failed, err: %v", err)
+	}
+	if isSidecarImageUpdated(podOutput, "test-sidecar", "test-image:v2") {
+		t.Errorf("shouldn't update sidecar because unavailable number is not zero")
+	}
+}

--- a/pkg/controller/sidecarset/sidecarset_pod_event_handler.go
+++ b/pkg/controller/sidecarset/sidecarset_pod_event_handler.go
@@ -151,11 +151,16 @@ func isPodChanged(oldPod, newPod *corev1.Pod) bool {
 	if newPod.DeletionTimestamp != oldPod.DeletionTimestamp {
 		return true
 	}
+
 	// If the pod's readiness has changed, the associated endpoint address
 	// will move from the unready endpoints set to the ready endpoints.
 	// So for the purposes of an endpoint, a readiness change on a pod
 	// means we have a changed pod.
 	if podutil.IsPodReady(oldPod) != podutil.IsPodReady(newPod) {
+		return true
+	}
+
+	if !isPodImageConsistent(oldPod) && isPodImageConsistent(newPod) {
 		return true
 	}
 

--- a/pkg/controller/sidecarset/sidecarset_utils.go
+++ b/pkg/controller/sidecarset/sidecarset_utils.go
@@ -3,6 +3,9 @@ package sidecarset
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -11,11 +14,18 @@ import (
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 
 	appsv1alpha1 "github.com/openkruise/kruise/pkg/apis/apps/v1alpha1"
-	"github.com/openkruise/kruise/pkg/webhook/default_server/pod/mutating"
+	podmutating "github.com/openkruise/kruise/pkg/webhook/default_server/pod/mutating"
+	sidecarsetmutating "github.com/openkruise/kruise/pkg/webhook/default_server/sidecarset/mutating"
+)
+
+var (
+	updateCache = &updatedPodCache{
+		podSidecarUpdated: make(map[string]string),
+	}
 )
 
 func isIgnoredPod(pod *corev1.Pod) bool {
-	for _, namespace := range mutating.SidecarIgnoredNamespaces {
+	for _, namespace := range podmutating.SidecarIgnoredNamespaces {
 		if pod.Namespace == namespace {
 			return true
 		}
@@ -27,7 +37,7 @@ func calculateStatus(sidecarSet *appsv1alpha1.SidecarSet, pods []*corev1.Pod) (*
 	var matchedPods, updatedPods, readyPods int32
 	matchedPods = int32(len(pods))
 	for _, pod := range pods {
-		updated, err := isPodUpdated(sidecarSet, pod)
+		updated, err := isPodSidecarUpdated(sidecarSet, pod)
 		if err != nil {
 			return nil, err
 		}
@@ -48,20 +58,18 @@ func calculateStatus(sidecarSet *appsv1alpha1.SidecarSet, pods []*corev1.Pod) (*
 	}, nil
 }
 
-func isPodUpdated(sidecarSet *appsv1alpha1.SidecarSet, pod *corev1.Pod) (bool, error) {
-	if pod.Annotations[mutating.SidecarSetGenerationAnnotation] == "" {
+func isPodSidecarUpdated(sidecarSet *appsv1alpha1.SidecarSet, pod *corev1.Pod) (bool, error) {
+	hashKey := sidecarsetmutating.SidecarSetHashAnnotation
+	if pod.Annotations[hashKey] == "" {
 		return false, nil
 	}
 
-	sidecarSetGeneration := make(map[string]int64)
-	if err := json.Unmarshal([]byte(pod.Annotations[mutating.SidecarSetGenerationAnnotation]), &sidecarSetGeneration); err != nil {
+	sidecarSetHash := make(map[string]string)
+	if err := json.Unmarshal([]byte(pod.Annotations[hashKey]), &sidecarSetHash); err != nil {
 		return false, err
 	}
 
-	if sidecarSetGeneration[sidecarSet.Name] == sidecarSet.Status.ObservedGeneration {
-		return true, nil
-	}
-	return false, nil
+	return sidecarSetHash[sidecarSet.Name] == sidecarSet.Annotations[hashKey], nil
 }
 
 func isRunningAndReady(pod *corev1.Pod) bool {
@@ -73,20 +81,21 @@ func (r *ReconcileSidecarSet) updateSidecarSetStatus(sidecarSet *appsv1alpha1.Si
 		return nil
 	}
 
+	sidecarSetClone := sidecarSet.DeepCopy()
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		sidecarSet.Status = *status
+		sidecarSetClone.Status = *status
 
-		updateErr := r.Status().Update(context.TODO(), sidecarSet)
+		updateErr := r.Status().Update(context.TODO(), sidecarSetClone)
 		if updateErr == nil {
 			return nil
 		}
 
 		key := types.NamespacedName{
-			Name: sidecarSet.Name,
+			Name: sidecarSetClone.Name,
 		}
 
-		if err := r.Get(context.TODO(), key, sidecarSet); err != nil {
-			klog.Errorf("error getting updated service %s from client", sidecarSet.Name)
+		if err := r.Get(context.TODO(), key, sidecarSetClone); err != nil {
+			klog.Errorf("error getting updated sidecarset %s from client", sidecarSetClone.Name)
 		}
 
 		return updateErr
@@ -100,4 +109,199 @@ func inconsistentStatus(sidecarSet *appsv1alpha1.SidecarSet, status *appsv1alpha
 		status.MatchedPods != sidecarSet.Status.MatchedPods ||
 		status.UpdatedPods != sidecarSet.Status.UpdatedPods ||
 		status.ReadyPods != sidecarSet.Status.ReadyPods
+}
+
+// add this cache to avoid be influenced by informer cache latency when controller try to count maxUnavailable
+type updatedPodCache struct {
+	lock sync.RWMutex
+	// key is in the format: sidecarset name/pod namespace/pod name
+	// value is sidecarset hash
+	podSidecarUpdated map[string]string
+}
+
+func (u *updatedPodCache) set(key, hash string) {
+	u.lock.Lock()
+	u.podSidecarUpdated[key] = hash
+	u.lock.Unlock()
+}
+
+func (u *updatedPodCache) delete(key string) {
+	u.lock.Lock()
+	delete(u.podSidecarUpdated, key)
+	u.lock.Unlock()
+}
+
+// return true means: sidecar of pod is updated
+func (u *updatedPodCache) isSidecarUpdated(sidecarSet *appsv1alpha1.SidecarSet, pod *corev1.Pod) bool {
+	key := fmt.Sprintf("%v/%v/%v", sidecarSet.Name, pod.Namespace, pod.Name)
+	u.lock.RLock()
+	hash := u.podSidecarUpdated[key]
+	u.lock.RUnlock()
+
+	if hash == sidecarSet.Annotations[sidecarsetmutating.SidecarSetHashAnnotation] {
+		return true
+	}
+	// if sidecarset changed, clean all stale cache related with this sidecarset
+	if hash != "" {
+		u.reset(sidecarSet)
+	}
+	return false
+}
+
+func (u *updatedPodCache) reset(sidecarSet *appsv1alpha1.SidecarSet) {
+	prefix := fmt.Sprintf("%v/", sidecarSet.Name)
+	u.lock.Lock()
+	for key := range u.podSidecarUpdated {
+		if strings.HasPrefix(key, prefix) {
+			delete(u.podSidecarUpdated, key)
+		}
+	}
+	u.lock.Unlock()
+}
+
+// available definition:
+// 1. image in pod.spec and pod.status is exactly the same
+// 2. pod is ready
+func getUnavailableNumber(sidecarSet *appsv1alpha1.SidecarSet, pods []*corev1.Pod) (int, error) {
+	var unavailableNum int
+	for _, pod := range pods {
+		// in case of informer cache latency
+		key := fmt.Sprintf("%v/%v/%v", sidecarSet.Name, pod.Namespace, pod.Name)
+		podInCacheUpdated := updateCache.isSidecarUpdated(sidecarSet, pod)
+		podInInformerUpdated, err := isPodSidecarUpdated(sidecarSet, pod)
+		if err != nil {
+			return 0, err
+		}
+		if podInCacheUpdated && !podInInformerUpdated {
+			unavailableNum++
+			continue
+		}
+		if podInCacheUpdated && podInInformerUpdated {
+			updateCache.delete(key)
+		}
+
+		if !isPodImageConsistent(pod) {
+			unavailableNum++
+			continue
+		}
+
+		if !isRunningAndReady(pod) {
+			unavailableNum++
+		}
+	}
+	return unavailableNum, nil
+}
+
+func isPodCreatedBeforeSidecarSet(sidecarSet *appsv1alpha1.SidecarSet, pod *corev1.Pod) (bool, error) {
+	hashKey := sidecarsetmutating.SidecarSetHashAnnotation
+	if pod.Annotations[hashKey] == "" {
+		return true, nil
+	}
+
+	sidecarSetHash := make(map[string]string)
+	if err := json.Unmarshal([]byte(pod.Annotations[hashKey]), &sidecarSetHash); err != nil {
+		return false, err
+	}
+	if _, ok := sidecarSetHash[sidecarSet.Name]; !ok {
+		return true, nil
+	}
+	return false, nil
+}
+
+// check if fields other than sidecar image had changed
+func otherFieldsInSidecarChanged(sidecarSet *appsv1alpha1.SidecarSet, pod *corev1.Pod) (bool, error) {
+	hashKey := sidecarsetmutating.SidecarSetHashWithoutImageAnnotation
+	if pod.Annotations[hashKey] == "" {
+		return false, nil
+	}
+
+	sidecarSetHash := make(map[string]string)
+	if err := json.Unmarshal([]byte(pod.Annotations[hashKey]), &sidecarSetHash); err != nil {
+		return false, err
+	}
+
+	return sidecarSetHash[sidecarSet.Name] != sidecarSet.Annotations[hashKey], nil
+}
+
+func isPodImageConsistent(pod *corev1.Pod) bool {
+	containerSpecImage := make(map[string]string, len(pod.Spec.Containers))
+	for _, container := range pod.Spec.Containers {
+		containerSpecImage[container.Name] = container.Image
+	}
+
+	for _, containerStatus := range pod.Status.ContainerStatuses {
+		if containerSpecImage[containerStatus.Name] != containerStatus.Image {
+			return false
+		}
+	}
+	return true
+}
+
+func (r *ReconcileSidecarSet) updateSidecarImageAndHash(sidecarSet *appsv1alpha1.SidecarSet, pods []*corev1.Pod) error {
+	if len(pods) == 0 {
+		return nil
+	}
+
+	// only support maxUnavailable=1 currently
+	klog.V(3).Infof("try to update sidecar of %v/%v", pods[0].Namespace, pods[0].Name)
+	if err := r.updatePodSidecarAndHash(sidecarSet, pods[0]); err != nil {
+		return err
+	}
+	updateCache.set(
+		fmt.Sprintf("%v/%v/%v", sidecarSet.Name, pods[0].Namespace, pods[0].Name),
+		sidecarSet.Annotations[sidecarsetmutating.SidecarSetHashAnnotation])
+	return nil
+}
+
+func (r *ReconcileSidecarSet) updatePodSidecarAndHash(sidecarSet *appsv1alpha1.SidecarSet, pod *corev1.Pod) error {
+	podClone := pod.DeepCopy()
+	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		// update sidecar image
+		updatePodSidecar(sidecarSet, podClone)
+
+		// update hash
+		hashKey := sidecarsetmutating.SidecarSetHashAnnotation
+		sidecarSetHash := make(map[string]string)
+		if err := json.Unmarshal([]byte(podClone.Annotations[hashKey]), &sidecarSetHash); err != nil {
+			return err
+		}
+		sidecarSetHash[sidecarSet.Name] = sidecarSet.Annotations[hashKey]
+		newHash, err := json.Marshal(sidecarSetHash)
+		if err != nil {
+			return err
+		}
+		podClone.Annotations[hashKey] = string(newHash)
+
+		updateErr := r.Update(context.TODO(), podClone)
+		if updateErr == nil {
+			return nil
+		}
+
+		key := types.NamespacedName{
+			Namespace: podClone.Namespace,
+			Name:      podClone.Name,
+		}
+
+		if err := r.Get(context.TODO(), key, podClone); err != nil {
+			klog.Errorf("error getting updated pod %s from client", sidecarSet.Name)
+		}
+
+		return updateErr
+	})
+
+	return err
+}
+
+func updatePodSidecar(sidecarSet *appsv1alpha1.SidecarSet, pod *corev1.Pod) {
+	sidecarImage := make(map[string]string, len(sidecarSet.Spec.Containers))
+	for _, container := range sidecarSet.Spec.Containers {
+		sidecarImage[container.Name] = container.Image
+	}
+
+	for i := range pod.Spec.Containers {
+		container := &pod.Spec.Containers[i]
+		if image, ok := sidecarImage[container.Name]; ok {
+			container.Image = image
+		}
+	}
 }

--- a/pkg/webhook/default_server/sidecarset/mutating/create_update_webhook.go
+++ b/pkg/webhook/default_server/sidecarset/mutating/create_update_webhook.go
@@ -23,13 +23,13 @@ import (
 )
 
 func init() {
-	builderName := "mutating-create-sidecarset"
+	builderName := "mutating-create-update-sidecarset"
 	Builders[builderName] = builder.
 		NewWebhookBuilder().
-		Name(builderName + ".kruise.io").
-		Path("/" + builderName).
+		Name(builderName+".kruise.io").
+		Path("/"+builderName).
 		Mutating().
-		Operations(admissionregistrationv1beta1.Create).
+		Operations(admissionregistrationv1beta1.Create, admissionregistrationv1beta1.Update).
 		FailurePolicy(admissionregistrationv1beta1.Fail).
 		ForType(&appsv1alpha1.SidecarSet{})
 }

--- a/pkg/webhook/default_server/sidecarset/mutating/hash.go
+++ b/pkg/webhook/default_server/sidecarset/mutating/hash.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2019 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutating
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/util/rand"
+
+	appsv1alpha1 "github.com/openkruise/kruise/pkg/apis/apps/v1alpha1"
+)
+
+// SidecarSetHash returns a hash of the SidecarSet.
+// The Containers are taken into account.
+func SidecarSetHash(sidecarSet *appsv1alpha1.SidecarSet) (string, error) {
+	encoded, err := encodeSidecarSet(sidecarSet)
+	if err != nil {
+		return "", err
+	}
+	h := rand.SafeEncodeString(hash(encoded))
+	return h, nil
+}
+
+// SidecarSetHashWithoutImage calculates hash without sidecars's image
+func SidecarSetHashWithoutImage(sidecarSet *appsv1alpha1.SidecarSet) (string, error) {
+	ss := sidecarSet.DeepCopy()
+	for i := range ss.Spec.Containers {
+		ss.Spec.Containers[i].Image = ""
+	}
+	return SidecarSetHash(ss)
+}
+
+func encodeSidecarSet(sidecarSet *appsv1alpha1.SidecarSet) (string, error) {
+	// json.Marshal sorts the keys in a stable order in the encoding
+	m := map[string]interface{}{"containers": sidecarSet.Spec.Containers}
+	data, err := json.Marshal(m)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+// hash hashes `data` with sha256 and returns the hex string
+func hash(data string) string {
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(data)))
+}

--- a/pkg/webhook/default_server/sidecarset/mutating/sidecarset_mutating_test.go
+++ b/pkg/webhook/default_server/sidecarset/mutating/sidecarset_mutating_test.go
@@ -9,18 +9,23 @@ import (
 	appsv1alpha1 "github.com/openkruise/kruise/pkg/apis/apps/v1alpha1"
 )
 
-func TestMutateSidecarSet(t *testing.T) {
-	sidecarSet := &appsv1alpha1.SidecarSet{
+var (
+	sidecarSetDemo = &appsv1alpha1.SidecarSet{
 		Spec: appsv1alpha1.SidecarSetSpec{
 			Containers: []appsv1alpha1.SidecarContainer{
 				{
 					Container: corev1.Container{
-						Name: "test-sidecar",
+						Name:  "test-sidecar",
+						Image: "test-image:v1",
 					},
 				},
 			},
 		},
 	}
+)
+
+func TestSidecarSetDefault(t *testing.T) {
+	sidecarSet := sidecarSetDemo.DeepCopy()
 
 	expectedOutputSidecarSet := sidecarSet.DeepCopy()
 	expectedOutputSidecarSet.Spec.Containers[0].TerminationMessagePath = corev1.TerminationMessagePathDefault
@@ -28,6 +33,25 @@ func TestMutateSidecarSet(t *testing.T) {
 	expectedOutputSidecarSet.Spec.Containers[0].ImagePullPolicy = corev1.PullIfNotPresent
 
 	setDefaultSidecarSet(sidecarSet)
+
+	if !reflect.DeepEqual(expectedOutputSidecarSet, sidecarSet) {
+		t.Errorf("\nexpect:\n%+v\nbut got:\n%+v", expectedOutputSidecarSet, sidecarSet)
+	}
+}
+
+func TestSidecarSetHash(t *testing.T) {
+	sidecarSet := sidecarSetDemo.DeepCopy()
+
+	expectedOutputSidecarSet := sidecarSet.DeepCopy()
+	if expectedOutputSidecarSet.Annotations == nil {
+		expectedOutputSidecarSet.Annotations = make(map[string]string)
+	}
+	expectedOutputSidecarSet.Annotations[SidecarSetHashAnnotation] = "vd6xbxv9w5f8794x5v852cf9288x4v8d926zw2bbcc8545847xw4w7f4xdbx5z6b"
+	expectedOutputSidecarSet.Annotations[SidecarSetHashWithoutImageAnnotation] = "cfd67dc8z844x4f7cd9f7b624x5ddxxd97wdwv45x48z49cx4942w5c8z84v2dzx"
+
+	if err := setHashSidecarSet(sidecarSet); err != nil {
+		t.Errorf("got error %v", err)
+	}
 
 	if !reflect.DeepEqual(expectedOutputSidecarSet, sidecarSet) {
 		t.Errorf("\nexpect:\n%+v\nbut got:\n%+v", expectedOutputSidecarSet, sidecarSet)


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

support sidecar update. feature list:

* support maxUnavailable=1 update strategy
* only support image update currently
* support pause, unpause

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

pkg/webhook/default_server/pod/mutating/pod_mutating_test.go
pkg/webhook/default_server/sidecarset/mutating/sidecarset_mutating_test.go
pkg/controller/sidecarset/sidecarset_controller_test.go

### Ⅳ. Describe how to verify it

create a sidecarset and some matched pods or high level workloads, then update image in sidecarset. 

* check whether sidecars in pods are updated
* during the update process, check whether sidecars are updated one by one(maxUnavailable=1)
* during the update process, use kubectl to update pause field, check whether update process is paused/unpaused 

### Ⅴ. Special notes for reviews

add paused field, which is similar to paused in deployment semantically
