### PR TITLE
feature: statefulset supports pause

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -227,6 +227,10 @@
         "podUpdatePolicy": {
           "description": "PodUpdatePolicy indicates how pods should be updated Default value is \"ReCreate\"",
           "type": "string"
+        },
+        "paused": {
+          "description": "Paused indicates that the StatefulSet is paused and will not be processed by the StatefulSet controller.",
+          "type": "boolean"
         }
       }
     },

--- a/config/crds/apps_v1alpha1_statefulset.yaml
+++ b/config/crds/apps_v1alpha1_statefulset.yaml
@@ -131,6 +131,10 @@ spec:
                       description: PodUpdatePolicy indicates how pods should be updated
                         Default value is "ReCreate"
                       type: string
+                    paused:
+                      description: Paused indicates that the StatefulSet is paused and will not be
+                        processed by the StatefulSet controller.Default value is false.
+                      type: boolean
                   type: object
                 type:
                   description: Type indicates the type of the StatefulSetUpdateStrategy.

--- a/pkg/apis/apps/v1alpha1/openapi_generated.go
+++ b/pkg/apis/apps/v1alpha1/openapi_generated.go
@@ -433,6 +433,13 @@ func schema_pkg_apis_apps_v1alpha1_RollingUpdateStatefulSetStrategy(ref common.R
 							Format:      "",
 						},
 					},
+					"paused": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Paused indicates that the StatefulSet is paused and will not be processed by the StatefulSet controller.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/apis/apps/v1alpha1/statefulset_types.go
+++ b/pkg/apis/apps/v1alpha1/statefulset_types.go
@@ -79,6 +79,10 @@ type RollingUpdateStatefulSetStrategy struct {
 	// Default value is "ReCreate"
 	// +optional
 	PodUpdatePolicy PodUpdateStrategyType `json:"podUpdatePolicy,omitempty"`
+	// Paused indicates that the StatefulSet is paused.
+	// Default value is false
+	// +optional
+	Paused bool `json:"paused,omitempty"`
 }
 
 // PodUpdateStrategyType is a string enumeration type that enumerates

--- a/pkg/controller/statefulset/stateful_set_control.go
+++ b/pkg/controller/statefulset/stateful_set_control.go
@@ -522,7 +522,11 @@ func (ssc *defaultStatefulSetControl) updateStatefulSet(
 		if err != nil {
 			return &status, err
 		}
+		if set.Spec.UpdateStrategy.RollingUpdate.Paused {
+			return &status, nil
+		}
 	}
+
 	var unavailablePods []string
 	// we terminate the Pod with the largest ordinal that does not match the update revision.
 	for target := len(replicas) - 1; target >= updateMin; target-- {


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
add paused field in StatefulSetSpec to supports pause feature. 

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.
added  TestStatefulSetControlRollingUpdateWithPaused in stateful_set_control_test.go

### Ⅳ. Describe how to verify it
Create a StatefulSet , then update image in StatefulSet.  During the update process, use kubectl to update pause field, check whether update process is paused/unpaused

### Ⅴ. Special notes for reviews


