### PR TITLE
Fix Kustomize template

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Generate manifests e.g. CRD, RBAC YAML files etc.
 `make manifests`
 
 Run `kruise-controller-manager` locally for testing, this will run against kubernetes cluster defined in  `~/.kube/config`.
-Run below command from root folder.
+Run below command from Kruise folder. Note: if Kruise CRDs have not been installed, [install all CRDs](#install-crds) first!  
 
 `make run` or `go run ./cmd/manager/main.go`
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Generate manifests e.g. CRD, RBAC YAML files etc.
 `make manifests`
 
 Run `kruise-controller-manager` locally for testing, this will run against kubernetes cluster defined in  `~/.kube/config`.
-Run below command from Kruise folder. Note: if Kruise CRDs have not been installed, [install all CRDs](#install-crds) first!  
+Run below command from Kruise folder. Note: if Kruise CRDs have not been installed, [install all CRDs](#install-crds) first!
 
 `make run` or `go run ./cmd/manager/main.go`
 

--- a/config/manager/webhookconfiguration.yaml
+++ b/config/manager/webhookconfiguration.yaml
@@ -1,17 +1,17 @@
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: kruise-mutating-webhook-configuration
+  name: mutating-webhook-configuration
 ---
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: kruise-validating-webhook-configuration
+  name: validating-webhook-configuration
 webhooks:
   - clientConfig:
       caBundle: fake
       service:
-        name: kruise-webhook-server-service
+        name: webhook-server-service
         namespace: kruise-system
         path: /validating-create-update-broadcastjob
     failurePolicy: Fail
@@ -33,7 +33,7 @@ webhooks:
   - clientConfig:
       caBundle: fake
       service:
-        name: kruise-webhook-server-service
+        name: webhook-server-service
         namespace: kruise-system
         path: /validating-create-update-sidecarset
     failurePolicy: Fail
@@ -55,7 +55,7 @@ webhooks:
   - clientConfig:
       caBundle: fake
       service:
-        name: kruise-webhook-server-service
+        name: webhook-server-service
         namespace: kruise-system
         path: /validating-create-update-statefulset
     failurePolicy: Fail


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Kustomize will add a Kruise- prefix for all the object names in the
template. config/manager/webhookconfiguration.yaml needs to be fixed
to avoid generating objects with wrong names.

Bonus fix: add a prerequsite for `make run` command in README.md.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE.

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.
NA

### Ⅳ. Describe how to verify it
Manually verify that a broadcast job can be created after running `make deploy`. Without this fix,
the job creation will fail with certification error.

### Ⅴ. Special notes for reviews


