### PR TITLE
Add permission for getting nodes

### DIFF
--- a/config/crds/apps_v1alpha1_statefulset.yaml
+++ b/config/crds/apps_v1alpha1_statefulset.yaml
@@ -127,14 +127,14 @@ spec:
                         should be partitioned. Default value is 0.
                       format: int32
                       type: integer
+                    paused:
+                      description: Paused indicates that the StatefulSet is paused.
+                        Default value is false
+                      type: boolean
                     podUpdatePolicy:
                       description: PodUpdatePolicy indicates how pods should be updated
                         Default value is "ReCreate"
                       type: string
-                    paused:
-                      description: Paused indicates that the StatefulSet is paused and will not be
-                        processed by the StatefulSet controller.Default value is false.
-                      type: boolean
                   type: object
                 type:
                   description: Type indicates the type of the StatefulSetUpdateStrategy.

--- a/config/rbac/rbac_role.yaml
+++ b/config/rbac/rbac_role.yaml
@@ -19,6 +19,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - pods/status
   verbs:
   - get

--- a/pkg/controller/broadcastjob/broadcastjob_controller.go
+++ b/pkg/controller/broadcastjob/broadcastjob_controller.go
@@ -106,6 +106,7 @@ type ReconcileBroadcastJob struct {
 // and what is in the BroadcastJob.Spec
 // Automatically generate RBAC rules to allow the Controller to read and write Deployments
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=pods/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=apps.kruise.io,resources=broadcastjobs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps.kruise.io,resources=broadcastjobs/status,verbs=get;update;patch


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Currently, kruise-controller does not have permissions for get/list nodes. 
This is required by BroadcastJob. The patch adds the permission for get/list nodes

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
a sidefix for the auto generated yaml 

