### PR TITLE
Install kubebuilder if not available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ go_check:
 	@scripts/check_go_version "1.11.1"
 
 # Run tests
-test: generate fmt vet manifests
+test: generate fmt vet manifests kubebuilder
 	go test ./pkg/... ./cmd/... -coverprofile cover.out
 
 # Build manager binary
@@ -49,6 +49,17 @@ ifndef GOPATH
 endif
 	go generate ./pkg/... ./cmd/...
 	go run ./hack/gen-openapi-spec/main.go > ${CURRENT_DIR}/api/openapi-spec/swagger.json
+
+# kubebuilder binary
+kubebuilder:
+ifeq (, $(shell which kubebuilder))
+	# Download kubebuilder and extract it to tmp
+	curl -sL https://go.kubebuilder.io/dl/2.0.0/$(shell go env GOOS)/$(shell go env GOARCH) | tar -xz -C /tmp/
+	# You'll need to set the KUBEBUILDER_ASSETS env var if you put it somewhere else
+	sudo mv /tmp/kubebuilder_2.0.0_$(shell go env GOOS)_$(shell go env GOARCH) /usr/local/kubebuilder
+newPATH:=$(PATH):/usr/local/kubebuilder/bin
+export PATH=$(newPATH)
+endif
 
 # Build the docker image
 docker-build: #test

--- a/Makefile
+++ b/Makefile
@@ -54,9 +54,9 @@ endif
 kubebuilder:
 ifeq (, $(shell which kubebuilder))
 	# Download kubebuilder and extract it to tmp
-	curl -sL https://go.kubebuilder.io/dl/2.0.0/$(shell go env GOOS)/$(shell go env GOARCH) | tar -xz -C /tmp/
+	curl -sL https://go.kubebuilder.io/dl/1.0.8/$(shell go env GOOS)/$(shell go env GOARCH) | tar -xz -C /tmp/
 	# You'll need to set the KUBEBUILDER_ASSETS env var if you put it somewhere else
-	sudo mv /tmp/kubebuilder_2.0.0_$(shell go env GOOS)_$(shell go env GOARCH) /usr/local/kubebuilder
+	sudo mv /tmp/kubebuilder_1.0.8_$(shell go env GOOS)_$(shell go env GOARCH) /usr/local/kubebuilder
 newPATH:=$(PATH):/usr/local/kubebuilder/bin
 export PATH=$(newPATH)
 endif

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ export KUBECONFIG=PATH_TO_CONFIG
 sh -c "$(curl -fsSL https://raw.githubusercontent.com/kruiseio/kruise/master/scripts/uninstall.sh)"
 ```
 
-Note that this will lead to all resources created by Kruise, including webhook configurations, services, namespace, CRDs, CR instances and Pods managed by Kruise controller, to be deleted! 
+Note that this will lead to all resources created by Kruise, including webhook configurations, services, namespace, CRDs, CR instances and Pods managed by Kruise controller, to be deleted!
 Please do this **ONLY** when you fully understand the consequence.
 
 ## Community


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
kubebuilder binary is needed to run default test framework. Change the makefile to automatically install kubebuilder binary if it is not available in the machine

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
#124 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.
N/A

### Ⅳ. Describe how to verify it
This is part of the output of `make` cmd if kubebuilder binary does not exists

```
...
# Download kubebuilder and extract it to tmp
curl -sL https://go.kubebuilder.io/dl/1.0.8/darwin/amd64 | tar -xz -C /tmp/
# You'll need to set the KUBEBUILDER_ASSETS env var if you put it somewhere else
sudo mv /tmp/kubebuilder_1.0.8_darwin_amd64 /usr/local/kubebuilder
Password:
...
```

### Ⅴ. Special notes for reviews
This change fixes the kubebuilder binary version to 1.0.8 which is the one Kruise used to create controller scaffolding code.

