### PR TITLE
Gracefully handle uninitialized objects and notify webhook does not work

### DIFF
--- a/pkg/controller/broadcastjob/broadcastjob_controller.go
+++ b/pkg/controller/broadcastjob/broadcastjob_controller.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	appsv1alpha1 "github.com/openkruise/kruise/pkg/apis/apps/v1alpha1"
+	"github.com/openkruise/kruise/pkg/webhook/default_server/broadcastjob/mutating"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -131,6 +132,7 @@ func (r *ReconcileBroadcastJob) Reconcile(request reconcile.Request) (reconcile.
 		klog.Errorf("failed to get job %s,", job.Name)
 		return reconcile.Result{}, err
 	}
+	mutating.SetDefaultBroadcastJob(job)
 	// Add pre-defined labels to pod template
 	addLabelToPodTemplate(job)
 

--- a/pkg/controller/sidecarset/sidecarset_controller.go
+++ b/pkg/controller/sidecarset/sidecarset_controller.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	appsv1alpha1 "github.com/openkruise/kruise/pkg/apis/apps/v1alpha1"
+	"github.com/openkruise/kruise/pkg/webhook/default_server/sidecarset/mutating"
 )
 
 /**
@@ -102,6 +103,7 @@ func (r *ReconcileSidecarSet) Reconcile(request reconcile.Request) (reconcile.Re
 		// Error reading the object - requeue the request.
 		return reconcile.Result{}, err
 	}
+	mutating.SetDefaultSidecarSet(sidecarSet)
 
 	klog.V(3).Infof("begin to process sidecarset %v", sidecarSet.Name)
 

--- a/pkg/controller/statefulset/statefulset_controller.go
+++ b/pkg/controller/statefulset/statefulset_controller.go
@@ -25,6 +25,7 @@ import (
 	"github.com/openkruise/kruise/pkg/client"
 	kruiseclientset "github.com/openkruise/kruise/pkg/client/clientset/versioned"
 	kruiseappslisters "github.com/openkruise/kruise/pkg/client/listers/apps/v1alpha1"
+	"github.com/openkruise/kruise/pkg/webhook/default_server/statefulset/mutating"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -193,6 +194,7 @@ func (ssc *ReconcileStatefulSet) Reconcile(request reconcile.Request) (reconcile
 		utilruntime.HandleError(fmt.Errorf("unable to retrieve StatefulSet %v from store: %v", key, err))
 		return reconcile.Result{}, err
 	}
+	mutating.SetObjectDefaults(set)
 
 	selector, err := metav1.LabelSelectorAsSelector(set.Spec.Selector)
 	if err != nil {

--- a/pkg/webhook/default_server/broadcastjob/mutating/broadcastjob_create_update_handler.go
+++ b/pkg/webhook/default_server/broadcastjob/mutating/broadcastjob_create_update_handler.go
@@ -51,12 +51,12 @@ type BroadcastJobCreateUpdateHandler struct {
 }
 
 func (h *BroadcastJobCreateUpdateHandler) mutatingBroadcastJobFn(ctx context.Context, obj *appsv1alpha1.BroadcastJob) error {
-	setDefaultBroadcastJob(obj)
+	SetDefaultBroadcastJob(obj)
 	return nil
 }
 
 // SetDefaults_BroadcastJob sets any unspecified values to defaults.
-func setDefaultBroadcastJob(job *appsv1alpha1.BroadcastJob) {
+func SetDefaultBroadcastJob(job *appsv1alpha1.BroadcastJob) {
 	utils.SetDefaultPodTemplate(&job.Spec.Template.Spec)
 	if job.Spec.CompletionPolicy.Type == "" {
 		job.Spec.CompletionPolicy.Type = appsv1alpha1.Always

--- a/pkg/webhook/default_server/broadcastjob/mutating/broadcastjob_create_update_handler_test.go
+++ b/pkg/webhook/default_server/broadcastjob/mutating/broadcastjob_create_update_handler_test.go
@@ -76,6 +76,10 @@ func TestHandle(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(expectedPatches, resp.Patches) {
-		t.Fatalf("expected patches %+v, got patches %+v", expectedPatches, resp.Patches)
+		// The response order is not deterministic
+		expectedPatches[0], expectedPatches[1] = expectedPatches[1], expectedPatches[0]
+		if !reflect.DeepEqual(expectedPatches, resp.Patches) {
+			t.Fatalf("expected patches %+v, got patches %+v", expectedPatches, resp.Patches)
+		}
 	}
 }

--- a/pkg/webhook/default_server/broadcastjob/mutating/broadcastjob_create_update_handler_test.go
+++ b/pkg/webhook/default_server/broadcastjob/mutating/broadcastjob_create_update_handler_test.go
@@ -3,6 +3,7 @@ package mutating
 import (
 	"context"
 	"reflect"
+	"sort"
 	"testing"
 
 	"github.com/appscode/jsonpatch"
@@ -74,12 +75,12 @@ func TestHandle(t *testing.T) {
 			Value:     map[string]interface{}{"RestartLimit": float64(0), "Type": string(appsv1alpha1.FailurePolicyTypeFailFast)},
 		},
 	}
+	// The response order is not deterministic
+	sort.SliceStable(resp.Patches, func(i, j int) bool {
+		return resp.Patches[i].Path < resp.Patches[j].Path
+	})
 
 	if !reflect.DeepEqual(expectedPatches, resp.Patches) {
-		// The response order is not deterministic
-		expectedPatches[0], expectedPatches[1] = expectedPatches[1], expectedPatches[0]
-		if !reflect.DeepEqual(expectedPatches, resp.Patches) {
-			t.Fatalf("expected patches %+v, got patches %+v", expectedPatches, resp.Patches)
-		}
+		t.Fatalf("expected patches %+v, got patches %+v", expectedPatches, resp.Patches)
 	}
 }

--- a/pkg/webhook/default_server/sidecarset/mutating/sidecarset_create_update_handler.go
+++ b/pkg/webhook/default_server/sidecarset/mutating/sidecarset_create_update_handler.go
@@ -62,7 +62,7 @@ type SidecarSetCreateHandler struct {
 	Decoder types.Decoder
 }
 
-func setDefaultSidecarSet(sidecarset *appsv1alpha1.SidecarSet) {
+func SetDefaultSidecarSet(sidecarset *appsv1alpha1.SidecarSet) {
 	setSidecarSetUpdateStratety(&sidecarset.Spec.Strategy)
 
 	for i := range sidecarset.Spec.Containers {
@@ -160,12 +160,12 @@ func (h *SidecarSetCreateHandler) Handle(ctx context.Context, req types.Request)
 
 	switch req.AdmissionRequest.Operation {
 	case v1beta1.Create, v1beta1.Update:
-		setDefaultSidecarSet(copy)
+		SetDefaultSidecarSet(copy)
 		if err := setHashSidecarSet(copy); err != nil {
 			return admission.ErrorResponse(http.StatusInternalServerError, err)
 		}
 	}
-
+	klog.V(3).Infof("sidecarset after mutating: %v", util.DumpJSON(copy))
 	// related issue: https://github.com/kubernetes-sigs/kubebuilder/issues/510
 	marshaledSidecarSet, err := json.Marshal(copy)
 	if err != nil {

--- a/pkg/webhook/default_server/sidecarset/mutating/sidecarset_mutating_test.go
+++ b/pkg/webhook/default_server/sidecarset/mutating/sidecarset_mutating_test.go
@@ -39,7 +39,7 @@ func TestSidecarSetDefault(t *testing.T) {
 		},
 	}
 
-	setDefaultSidecarSet(sidecarSet)
+	SetDefaultSidecarSet(sidecarSet)
 
 	if !reflect.DeepEqual(expectedOutputSidecarSet, sidecarSet) {
 		t.Errorf("\nexpect:\n%+v\nbut got:\n%+v", expectedOutputSidecarSet, sidecarSet)


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

Kruise relies on admission webhooks to set default fields for custom resources. If APIServer does not enable MutatingAdmissionWebhook,ValidatingAdmissionWebhook admission plugins, custom resources can be created without any desired initializations. This may lead controller manager to constantly crash in case a pointer is not initialized with a default object. See #134 for example.

Unfortunately, APIServer does not provide any API to query if certain admission plugin is enabled or not. In this change, we workaround this problem by doing the following:

1) Every time controller manager starts, it will do a self webhook enablement check by creating a test pod and checking if an expected signature annotation is added by pod mutant admission webhook. If this check fails, controller manager quits and suggests admin to check if APIServer has enabled required admission plugins.
2) It is still possible that people create kruise custom resources when controller is not working. To avoid controller crashing due to existing objects, controllers now mandatorily set defaults for reconciled objects read from APIServer. Unlike setting defaults in mutant admission webhook where defaults will be updates in APIServer, setting defaults in controller does not guarantee the defaults will be persisted in APIServer. 

We may need other uninitialized object identification mechanisms but i'd defer to do them unless they are necessary.


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
#134 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

Mostly manual tests and verify tutorial works.

### Ⅳ. Describe how to verify it

In case API Server enable admission plugin, controller log shows the following
I0926 22:15:21.735615       1 main.go:115] entrypoint "level"=0 "msg"="Start self webhook check"
I0926 22:15:21.745001       1 pod_create_handler.go:84] [WebhookTest] Inject annotation for webhook test pod default/webhook-tester-hje3h0rvreaj6w7z
I0926 22:15:22.832078       1 main.go:156] entrypoint "level"=0 "msg"="Webhook is working!"

In case API Server does not enable admission plugin, controller log shows the following

I0926 22:57:23.726331       1 main.go:115] entrypoint "level"=0 "msg"="Start self webhook check"
E0926 22:57:25.303721       1 main.go:150] entrypoint "msg"="fail to validate webhook test pod" "error"="Pod mutating webhook does not work. Please make sure APIServer enables MutatingAdmissionWebhook and ValidatingAdmissionWebhook admission plugins"
I0926 22:57:25.401487       1 main.go:158] entrypoint "level"=0 "msg"="Kruise controller relies on webhooks in order to work properly. Stop the controller since webhook test fails!"

### Ⅴ. Special notes for reviews

This change also fixes an unstable test.
