### PR TITLE
Gracefully handle uninitialized objects

### DIFF
--- a/pkg/apis/apps/v1alpha1/defaults.go
+++ b/pkg/apis/apps/v1alpha1/defaults.go
@@ -17,9 +17,140 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"github.com/openkruise/kruise/pkg/webhook/default_server/utils"
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/kubernetes/pkg/apis/core/v1"
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
 	return RegisterDefaults(scheme)
+}
+
+func SetDefaults_SidecarSet(obj *SidecarSet) {
+	setSidecarSetUpdateStratety(&obj.Spec.Strategy)
+
+	for i := range obj.Spec.Containers {
+		setSidecarDefaultContainer(&obj.Spec.Containers[i])
+	}
+}
+
+func setSidecarSetUpdateStratety(strategy *SidecarSetUpdateStrategy) {
+	if strategy.RollingUpdate == nil {
+		rollingUpdate := RollingUpdateSidecarSet{}
+		strategy.RollingUpdate = &rollingUpdate
+	}
+	if strategy.RollingUpdate.MaxUnavailable == nil {
+		maxUnavailable := intstr.FromInt(1)
+		strategy.RollingUpdate.MaxUnavailable = &maxUnavailable
+	}
+}
+
+func setSidecarDefaultContainer(sidecarContainer *SidecarContainer) {
+	container := &sidecarContainer.Container
+	v1.SetDefaults_Container(container)
+	for i := range container.Ports {
+		p := &container.Ports[i]
+		v1.SetDefaults_ContainerPort(p)
+	}
+	for i := range container.Env {
+		e := &container.Env[i]
+		if e.ValueFrom != nil {
+			if e.ValueFrom.FieldRef != nil {
+				v1.SetDefaults_ObjectFieldSelector(e.ValueFrom.FieldRef)
+			}
+		}
+	}
+	v1.SetDefaults_ResourceList(&container.Resources.Limits)
+	v1.SetDefaults_ResourceList(&container.Resources.Requests)
+	if container.LivenessProbe != nil {
+		v1.SetDefaults_Probe(container.LivenessProbe)
+		if container.LivenessProbe.Handler.HTTPGet != nil {
+			v1.SetDefaults_HTTPGetAction(container.LivenessProbe.Handler.HTTPGet)
+		}
+	}
+	if container.ReadinessProbe != nil {
+		v1.SetDefaults_Probe(container.ReadinessProbe)
+		if container.ReadinessProbe.Handler.HTTPGet != nil {
+			v1.SetDefaults_HTTPGetAction(container.ReadinessProbe.Handler.HTTPGet)
+		}
+	}
+	if container.Lifecycle != nil {
+		if container.Lifecycle.PostStart != nil {
+			if container.Lifecycle.PostStart.HTTPGet != nil {
+				v1.SetDefaults_HTTPGetAction(container.Lifecycle.PostStart.HTTPGet)
+			}
+		}
+		if container.Lifecycle.PreStop != nil {
+			if container.Lifecycle.PreStop.HTTPGet != nil {
+				v1.SetDefaults_HTTPGetAction(container.Lifecycle.PreStop.HTTPGet)
+			}
+		}
+	}
+}
+
+func SetDefaults_BroadcastJob(obj *BroadcastJob) {
+	utils.SetDefaultPodTemplate(&obj.Spec.Template.Spec)
+	if obj.Spec.CompletionPolicy.Type == "" {
+		obj.Spec.CompletionPolicy.Type = Always
+	}
+
+	if obj.Spec.Parallelism == nil {
+		parallelism := int32(1<<31 - 1)
+		parallelismIntStr := intstr.FromInt(int(parallelism))
+		obj.Spec.Parallelism = &parallelismIntStr
+	}
+
+	if obj.Spec.FailurePolicy.Type == "" {
+		obj.Spec.FailurePolicy.Type = FailurePolicyTypeFailFast
+	}
+}
+
+func SetDefaults_StatefulSet(obj *StatefulSet) {
+	if len(obj.Spec.PodManagementPolicy) == 0 {
+		obj.Spec.PodManagementPolicy = appsv1.OrderedReadyPodManagement
+	}
+
+	if obj.Spec.UpdateStrategy.Type == "" {
+		obj.Spec.UpdateStrategy.Type = appsv1.RollingUpdateStatefulSetStrategyType
+
+		// UpdateStrategy.RollingUpdate will take default values below.
+		obj.Spec.UpdateStrategy.RollingUpdate = &RollingUpdateStatefulSetStrategy{}
+	}
+
+	if obj.Spec.UpdateStrategy.Type == appsv1.RollingUpdateStatefulSetStrategyType {
+		if obj.Spec.UpdateStrategy.RollingUpdate == nil {
+			obj.Spec.UpdateStrategy.RollingUpdate = &RollingUpdateStatefulSetStrategy{}
+		}
+		if obj.Spec.UpdateStrategy.RollingUpdate.Partition == nil {
+			obj.Spec.UpdateStrategy.RollingUpdate.Partition = new(int32)
+			*obj.Spec.UpdateStrategy.RollingUpdate.Partition = 0
+		}
+		if obj.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable == nil {
+			maxUnavailable := intstr.FromInt(1)
+			obj.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable = &maxUnavailable
+		}
+		if obj.Spec.UpdateStrategy.RollingUpdate.PodUpdatePolicy == "" {
+			obj.Spec.UpdateStrategy.RollingUpdate.PodUpdatePolicy = RecreatePodUpdateStrategyType
+		}
+	}
+
+	if obj.Spec.Replicas == nil {
+		obj.Spec.Replicas = new(int32)
+		*obj.Spec.Replicas = 1
+	}
+	if obj.Spec.RevisionHistoryLimit == nil {
+		obj.Spec.RevisionHistoryLimit = new(int32)
+		*obj.Spec.RevisionHistoryLimit = 10
+	}
+
+	utils.SetDefaultPodTemplate(&obj.Spec.Template.Spec)
+	for i := range obj.Spec.VolumeClaimTemplates {
+		a := &obj.Spec.VolumeClaimTemplates[i]
+		v1.SetDefaults_PersistentVolumeClaim(a)
+		v1.SetDefaults_ResourceList(&a.Spec.Resources.Limits)
+		v1.SetDefaults_ResourceList(&a.Spec.Resources.Requests)
+		v1.SetDefaults_ResourceList(&a.Status.Capacity)
+	}
 }

--- a/pkg/apis/apps/v1alpha1/zz_generated.defaults.go
+++ b/pkg/apis/apps/v1alpha1/zz_generated.defaults.go
@@ -27,5 +27,44 @@ import (
 // Public to allow building arbitrary schemes.
 // All generated defaulters are covering - they call all nested defaulters.
 func RegisterDefaults(scheme *runtime.Scheme) error {
+	scheme.AddTypeDefaultingFunc(&BroadcastJob{}, func(obj interface{}) { SetObjectDefaults_BroadcastJob(obj.(*BroadcastJob)) })
+	scheme.AddTypeDefaultingFunc(&BroadcastJobList{}, func(obj interface{}) { SetObjectDefaults_BroadcastJobList(obj.(*BroadcastJobList)) })
+	scheme.AddTypeDefaultingFunc(&SidecarSet{}, func(obj interface{}) { SetObjectDefaults_SidecarSet(obj.(*SidecarSet)) })
+	scheme.AddTypeDefaultingFunc(&SidecarSetList{}, func(obj interface{}) { SetObjectDefaults_SidecarSetList(obj.(*SidecarSetList)) })
+	scheme.AddTypeDefaultingFunc(&StatefulSet{}, func(obj interface{}) { SetObjectDefaults_StatefulSet(obj.(*StatefulSet)) })
+	scheme.AddTypeDefaultingFunc(&StatefulSetList{}, func(obj interface{}) { SetObjectDefaults_StatefulSetList(obj.(*StatefulSetList)) })
 	return nil
+}
+
+func SetObjectDefaults_BroadcastJob(in *BroadcastJob) {
+	SetDefaults_BroadcastJob(in)
+}
+
+func SetObjectDefaults_BroadcastJobList(in *BroadcastJobList) {
+	for i := range in.Items {
+		a := &in.Items[i]
+		SetObjectDefaults_BroadcastJob(a)
+	}
+}
+
+func SetObjectDefaults_SidecarSet(in *SidecarSet) {
+	SetDefaults_SidecarSet(in)
+}
+
+func SetObjectDefaults_SidecarSetList(in *SidecarSetList) {
+	for i := range in.Items {
+		a := &in.Items[i]
+		SetObjectDefaults_SidecarSet(a)
+	}
+}
+
+func SetObjectDefaults_StatefulSet(in *StatefulSet) {
+	SetDefaults_StatefulSet(in)
+}
+
+func SetObjectDefaults_StatefulSetList(in *StatefulSetList) {
+	for i := range in.Items {
+		a := &in.Items[i]
+		SetObjectDefaults_StatefulSet(a)
+	}
 }

--- a/pkg/webhook/default_server/broadcastjob/mutating/broadcastjob_create_update_handler.go
+++ b/pkg/webhook/default_server/broadcastjob/mutating/broadcastjob_create_update_handler.go
@@ -23,8 +23,6 @@ import (
 
 	appsv1alpha1 "github.com/openkruise/kruise/pkg/apis/apps/v1alpha1"
 	patchutil "github.com/openkruise/kruise/pkg/util/patch"
-	"github.com/openkruise/kruise/pkg/webhook/default_server/utils"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/types"
@@ -51,26 +49,8 @@ type BroadcastJobCreateUpdateHandler struct {
 }
 
 func (h *BroadcastJobCreateUpdateHandler) mutatingBroadcastJobFn(ctx context.Context, obj *appsv1alpha1.BroadcastJob) error {
-	setDefaultBroadcastJob(obj)
+	appsv1alpha1.SetDefaults_BroadcastJob(obj)
 	return nil
-}
-
-// SetDefaults_BroadcastJob sets any unspecified values to defaults.
-func setDefaultBroadcastJob(job *appsv1alpha1.BroadcastJob) {
-	utils.SetDefaultPodTemplate(&job.Spec.Template.Spec)
-	if job.Spec.CompletionPolicy.Type == "" {
-		job.Spec.CompletionPolicy.Type = appsv1alpha1.Always
-	}
-
-	if job.Spec.Parallelism == nil {
-		parallelism := int32(1<<31 - 1)
-		parallelismIntStr := intstr.FromInt(int(parallelism))
-		job.Spec.Parallelism = &parallelismIntStr
-	}
-
-	if job.Spec.FailurePolicy.Type == "" {
-		job.Spec.FailurePolicy.Type = appsv1alpha1.FailurePolicyTypeFailFast
-	}
 }
 
 var _ admission.Handler = &BroadcastJobCreateUpdateHandler{}

--- a/pkg/webhook/default_server/broadcastjob/mutating/broadcastjob_create_update_handler_test.go
+++ b/pkg/webhook/default_server/broadcastjob/mutating/broadcastjob_create_update_handler_test.go
@@ -3,6 +3,7 @@ package mutating
 import (
 	"context"
 	"reflect"
+	"sort"
 	"testing"
 
 	"github.com/appscode/jsonpatch"
@@ -74,6 +75,10 @@ func TestHandle(t *testing.T) {
 			Value:     map[string]interface{}{"RestartLimit": float64(0), "Type": string(appsv1alpha1.FailurePolicyTypeFailFast)},
 		},
 	}
+	// The response order is not deterministic
+	sort.SliceStable(resp.Patches, func(i, j int) bool {
+		return resp.Patches[i].Path < resp.Patches[j].Path
+	})
 
 	if !reflect.DeepEqual(expectedPatches, resp.Patches) {
 		t.Fatalf("expected patches %+v, got patches %+v", expectedPatches, resp.Patches)

--- a/pkg/webhook/default_server/sidecarset/mutating/sidecarset_mutating_test.go
+++ b/pkg/webhook/default_server/sidecarset/mutating/sidecarset_mutating_test.go
@@ -39,7 +39,7 @@ func TestSidecarSetDefault(t *testing.T) {
 		},
 	}
 
-	setDefaultSidecarSet(sidecarSet)
+	appsv1alpha1.SetDefaults_SidecarSet(sidecarSet)
 
 	if !reflect.DeepEqual(expectedOutputSidecarSet, sidecarSet) {
 		t.Errorf("\nexpect:\n%+v\nbut got:\n%+v", expectedOutputSidecarSet, sidecarSet)


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

Kruise relies on admission webhooks to set default fields for custom resources. If APIServer does not enable MutatingAdmissionWebhook,ValidatingAdmissionWebhook admission plugins, custom resources can be created without any desired initializations. This may lead controller manager to constantly crash in case a pointer is not initialized with a default object. See #134 for example.

Unfortunately, APIServer does not provide any API to query if certain admission plugin is enabled or not. To avoid controller crashing due to existing uninitialized objects, now we add type defaulting Funcs in API schema for all Kruise CRDs. 

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
#134 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
This change also fixes an unstable test.

