### PR TITLE
fix jsonpatch bug.

### DIFF
--- a/vendor/github.com/appscode/jsonpatch/jsonpatch.go
+++ b/vendor/github.com/appscode/jsonpatch/jsonpatch.go
@@ -326,7 +326,7 @@ func backtrace(s, t []interface{}, p string, i int, j int, matrix [][]int) []Ope
 			return append([]Operation{op}, backtrace(s, t, p, i-1, j-1, matrix)...)
 		}
 
-		p2, _ := handleValues(s[j-1], t[j-1], makePath(p, i-1), []Operation{})
+		p2, _ := handleValues(s[i-1], t[j-1], makePath(p, i-1), []Operation{})
 		return append(p2, backtrace(s, t, p, i-1, j-1, matrix)...)
 	}
 	if i > 0 && j > 0 && matrix[i-1][j-1] == matrix[i][j] {


### PR DESCRIPTION
jsonpatch will trigger ` runtime error: index out of range` in some cases.
See https://github.com/gomodules/jsonpatch/blob/master/v2/jsonpatch.go . v2 fix this bug. 