### PR TITLE
report statefulSet condition error

### DIFF
--- a/pkg/apis/apps/v1alpha1/statefulset_types.go
+++ b/pkg/apis/apps/v1alpha1/statefulset_types.go
@@ -213,6 +213,12 @@ type StatefulSetStatus struct {
 	Conditions []apps.StatefulSetCondition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 }
 
+// These are valid conditions of a statefulset.
+const (
+	FailedCreatePod apps.StatefulSetConditionType = "FailedCreatePod"
+	FailedUpdatePod apps.StatefulSetConditionType = "FailedUpdatePod"
+)
+
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 

--- a/pkg/controller/statefulset/stateful_set_utils.go
+++ b/pkg/controller/statefulset/stateful_set_utils.go
@@ -379,3 +379,50 @@ func (ao ascendingOrdinal) Swap(i, j int) {
 func (ao ascendingOrdinal) Less(i, j int) bool {
 	return getOrdinal(ao[i]) < getOrdinal(ao[j])
 }
+
+// NewStatefulsetCondition creates a new statefulset condition.
+func NewStatefulsetCondition(conditionType apps.StatefulSetConditionType, conditionStatus v1.ConditionStatus, reason, message string) apps.StatefulSetCondition {
+	return apps.StatefulSetCondition{
+		Type:               conditionType,
+		Status:             conditionStatus,
+		LastTransitionTime: metav1.Now(),
+		Reason:             reason,
+		Message:            message,
+	}
+}
+
+// GetStatefulsetConditition returns the condition with the provided type.
+func GetStatefulsetConditition(status appsv1alpha1.StatefulSetStatus, condType apps.StatefulSetConditionType) *apps.StatefulSetCondition {
+	for i := range status.Conditions {
+		c := status.Conditions[i]
+		if c.Type == condType {
+			return &c
+		}
+	}
+	return nil
+}
+
+// SetStatefulsetCondition updates the statefulset to include the provided condition. If the condition that
+func SetStatefulsetCondition(status *appsv1alpha1.StatefulSetStatus, condition apps.StatefulSetCondition) {
+	currentCond := GetStatefulsetConditition(*status, condition.Type)
+	if currentCond != nil && currentCond.Status == condition.Status && currentCond.Reason == condition.Reason {
+		return
+	}
+	if currentCond != nil && currentCond.Status == condition.Status {
+		condition.LastTransitionTime = currentCond.LastTransitionTime
+	}
+
+	newConditions := filterOutCondition(status.Conditions, condition.Type)
+	status.Conditions = append(newConditions, condition)
+}
+
+func filterOutCondition(conditions []apps.StatefulSetCondition, condType apps.StatefulSetConditionType) []apps.StatefulSetCondition {
+	var newCondtitions []apps.StatefulSetCondition
+	for _, c := range conditions {
+		if c.Type == condType {
+			continue
+		}
+		newCondtitions = append(newCondtitions, c)
+	}
+	return newCondtitions
+}


### PR DESCRIPTION
Signed-off-by: Junjun Li <junjunli666@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

1. fix bug: `no statefulset status after creating sts` 
2. add conditition in sts status when create/update pod error


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

https://github.com/openkruise/kruise/projects/1

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it

```
➜  ~ kubectl get sts.apps.kruise.io myapp -o yaml

apiVersion: apps.kruise.io/v1alpha1
kind: StatefulSet
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"apps.kruise.io/v1alpha1","kind":"StatefulSet","metadata":{"annotations":{},"labels":{"app":"myapp"},"name":"myapp","namespace":"default"},"spec":{"podManagementPolicy":"Parallel","replicas":5,"selector":{"matchLabels":{"app":"myapp"}},"serviceName":"myapp-svc","template":{"metadata":{"labels":{"app":"myapp"}},"spec":{"containers":[{"image":"junjunli/simple-server:v1","imagePullPolicy":"IfNotPresent","name":"myapp","ports":[{"containerPort":8080}],"volumeMounts":[{"mountPath":"/usr/share/nginx/html","name":"myappdatai"}]}],"readinessGates":[{"conditionType":"InPlaceUpdateReady"}]}},"updateStrategy":{"rollingUpdate":{"maxUnavailable":3,"podUpdatePolicy":"InPlaceIfPossible"},"type":"RollingUpdate"},"volumeClaimTemplates":[{"metadata":{"name":"myappdata"},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"5Gi"}},"storageClassName":"rook-ceph-block"}}]}}
  creationTimestamp: "2019-11-13T06:12:22Z"
  generation: 1
  labels:
    app: myapp
  name: myapp
  namespace: default
  resourceVersion: "878104"
  selfLink: /apis/apps.kruise.io/v1alpha1/namespaces/default/statefulsets/myapp
  uid: 124ede90-4657-4e3b-a2c2-64d0624d97d3
spec:
  podManagementPolicy: Parallel
  replicas: 5
  revisionHistoryLimit: 10
  selector:
    matchLabels:
      app: myapp
  serviceName: myapp-svc
  template:
    metadata:
      creationTimestamp: null
      labels:
        app: myapp
    spec:
      containers:
      - image: junjunli/simple-server:v1
        imagePullPolicy: IfNotPresent
        name: myapp
        ports:
        - containerPort: 8080
          protocol: TCP
        resources: {}
        terminationMessagePath: /dev/termination-log
        terminationMessagePolicy: File
        volumeMounts:
        - mountPath: /usr/share/nginx/html
          name: myappdatai
      dnsPolicy: ClusterFirst
      readinessGates:
      - conditionType: InPlaceUpdateReady
      restartPolicy: Always
      schedulerName: default-scheduler
      securityContext: {}
      terminationGracePeriodSeconds: 30
  updateStrategy:
    rollingUpdate:
      maxUnavailable: 3
      partition: 0
      podUpdatePolicy: InPlaceIfPossible
    type: RollingUpdate
  volumeClaimTemplates:
  - metadata:
      creationTimestamp: null
      name: myappdata
    spec:
      accessModes:
      - ReadWriteOnce
      dataSource: null
      resources:
        requests:
          storage: 5Gi
      storageClassName: rook-ceph-block
      volumeMode: Filesystem
    status:
      phase: Pending
status:
  collisionCount: 0
  conditions:
  - lastTransitionTime: "2019-11-13T06:12:23Z"
    message: 'StatefulPodControl failed to create Pod error: Pod "myapp-0" is invalid:
      spec.containers[0].volumeMounts[0].name: Not found: "myappdatai"'
    status: "True"
    type: FailedCreatePod
  currentReplicas: 0
  currentRevision: myapp-6cbf474bcc
  observedGeneration: 1
  readyReplicas: 0
  replicas: 0
  updateRevision: myapp-6cbf474bcc
  updatedReplicas: 0
```

### Ⅴ. Special notes for reviews


