### PR TITLE
Add check_for_installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,22 @@ A [video](https://www.youtube.com/watch?v=elB7reZ6eAQ) by [Lachlan Evenson](http
 
 ## Getting started
 
+### Check before installation
+
+You should check the cluster before installation via the command-line with either `curl` or `wget`.
+
+#### via curl
+
+```bash
+sh -c "$(curl -fsSL https://raw.githubusercontent.com/openkruise/kruise/master/scripts/check_for_installation.sh)"
+```
+
+#### via wget
+
+```bash
+sh -c "$(wget -O- https://raw.githubusercontent.com/openkruise/kruise/master/scripts/check_for_installation.sh)"
+```
+
 ### Install with helm charts
 
 ```

--- a/scripts/check_for_installation.sh
+++ b/scripts/check_for_installation.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+
+set -e
+
+mkdir -p /tmp/kruise
+TIMESTAMP=$(date +%s)
+CONF_FILE=/tmp/kruise/install-check-config-${TIMESTAMP}.yaml
+CR_FILE=/tmp/kruise/install-check-cr-${TIMESTAMP}.yaml
+LOG_FILE=/tmp/kruise/install-check-${TIMESTAMP}.log
+
+cat > "${CONF_FILE}" <<- EOM
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: enablewebhooks.check.kruise.io
+spec:
+  group: check.kruise.io
+  version: v1alpha1
+  scope: Cluster
+  names:
+    plural: enablewebhooks
+    singular: enablewebhook
+    kind: EnableWebhook
+
+---
+
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: kruise-check-install-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    caBundle: Cg==
+    url: https://127.0.0.1:9876/validating-kruise-check-install
+  failurePolicy: Fail
+  name: validating-kruise-check-install.kruise.io
+  rules:
+  - apiGroups:
+    - check.kruise.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    resources:
+    - enablewebhooks
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 1
+EOM
+
+cat > "${CR_FILE}" <<- EOM
+apiVersion: check.kruise.io/v1alpha1
+kind: EnableWebhook
+metadata:
+  name: enablewebhook-test
+spec:
+  foo: bar
+EOM
+
+kubectl apply -f "${CONF_FILE}" >> "${LOG_FILE}" 2>&1
+
+set +e
+
+kubectl apply -f "${CR_FILE}" >> "${LOG_FILE}" 2>&1
+RETURN_CODE=$?
+
+if [[ ${RETURN_CODE} -eq 0 ]]; then
+    kubectl delete -f "${CR_FILE}" >> "${LOG_FILE}" 2>&1
+fi
+kubectl delete -f "${CONF_FILE}" >> "${LOG_FILE}" 2>&1
+rm -f "${CR_FILE}" "${CONF_FILE}"
+
+if [[ ${RETURN_CODE} -eq 0 ]]; then
+    echo "Failed to check for installation because of webhook not working."
+    echo "Please check the arguments of your kube-apiserver, make sure that MutatingAdmissionWebhook and ValidatingAdmissionWebhook have been open."
+    exit 1
+fi
+
+echo "Successfully check for installation, you can install kruise now."


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Add check_for_installation script.
The script can help users check if the k8s cluster is ready to install and run kruise-manager.

### ⅠI. Testing result
The expected result of this script is: 
```
Successfully check for installation, you can install kruise now.
```
It means webhook configuration in your cluster has been open, it is ready to install and use Kruise.

If the `ValidatingAdmissionWebhook` and `MutatingAdmissionWebhook` plugins of kube-apiserver are closed, the result of this script like this:
```
Failed to check for installation because of webhook not working.
Please check the arguments of your kube-apiserver, make sure that MutatingAdmissionWebhook and ValidatingAdmissionWebhook have been open.
```
You should add these plugins into kube-apiserver argument:
```
--enable-admission-plugins=ValidatingAdmissionWebhook,MutatingAdmissionWebhook
```
