### PR TITLE
Fix chart yaml

### DIFF
--- a/charts/kruise/v0.1.0/templates/manager.yaml
+++ b/charts/kruise/v0.1.0/templates/manager.yaml
@@ -31,6 +31,7 @@ metadata:
   namespace: kruise-system
 spec:
   replicas: 1
+  serviceName: kruise-controller-manager-service
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:

--- a/charts/kruise/v0.2.0/templates/manager.yaml
+++ b/charts/kruise/v0.2.0/templates/manager.yaml
@@ -31,6 +31,7 @@ metadata:
   namespace: kruise-system
 spec:
   replicas: 1
+  serviceName: kruise-controller-manager-service
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Fix chart installation failure:
```bash
$ helm install kruise charts/
Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(StatefulSet.spec): missing required field "serviceName" in io.k8s.api.apps.v1.StatefulSetSpec
```
`serviceName` in StatefulSet spec is required.



