### PR TITLE
Support gate for custom resource

### DIFF
--- a/pkg/controller/broadcastjob/broadcastjob_controller.go
+++ b/pkg/controller/broadcastjob/broadcastjob_controller.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	appsv1alpha1 "github.com/openkruise/kruise/pkg/apis/apps/v1alpha1"
+	"github.com/openkruise/kruise/pkg/util/gate"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -54,6 +55,9 @@ var controllerKind = appsv1alpha1.SchemeGroupVersion.WithKind("BroadcastJob")
 // Add creates a new BroadcastJob Controller and adds it to the Manager with default RBAC. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager) error {
+	if !gate.ResourceEnabled(&appsv1alpha1.BroadcastJob{}) {
+		return nil
+	}
 	return add(mgr, newReconciler(mgr))
 }
 

--- a/pkg/controller/cloneset/cloneset_controller.go
+++ b/pkg/controller/cloneset/cloneset_controller.go
@@ -28,6 +28,7 @@ import (
 	updatecontrol "github.com/openkruise/kruise/pkg/controller/cloneset/update"
 	clonesetutils "github.com/openkruise/kruise/pkg/controller/cloneset/utils"
 	"github.com/openkruise/kruise/pkg/util/expectations"
+	"github.com/openkruise/kruise/pkg/util/gate"
 	historyutil "github.com/openkruise/kruise/pkg/util/history"
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -62,6 +63,9 @@ var (
 // Add creates a new CloneSet Controller and adds it to the Manager with default RBAC. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager) error {
+	if !gate.ResourceEnabled(&appsv1alpha1.CloneSet{}) {
+		return nil
+	}
 	return add(mgr, newReconciler(mgr))
 }
 

--- a/pkg/controller/sidecarset/sidecarset_controller.go
+++ b/pkg/controller/sidecarset/sidecarset_controller.go
@@ -19,6 +19,7 @@ package sidecarset
 import (
 	"context"
 
+	"github.com/openkruise/kruise/pkg/util/gate"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -44,6 +45,9 @@ import (
 // Add creates a new SidecarSet Controller and adds it to the Manager with default RBAC. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager) error {
+	if !gate.ResourceEnabled(&appsv1alpha1.SidecarSet{}) {
+		return nil
+	}
 	return add(mgr, newReconciler(mgr))
 }
 

--- a/pkg/controller/statefulset/statefulset_controller.go
+++ b/pkg/controller/statefulset/statefulset_controller.go
@@ -25,6 +25,7 @@ import (
 	"github.com/openkruise/kruise/pkg/client"
 	kruiseclientset "github.com/openkruise/kruise/pkg/client/clientset/versioned"
 	kruiseappslisters "github.com/openkruise/kruise/pkg/client/listers/apps/v1alpha1"
+	"github.com/openkruise/kruise/pkg/util/gate"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -54,6 +55,9 @@ var controllerKind = appsv1alpha1.SchemeGroupVersion.WithKind("StatefulSet")
 // Add creates a new StatefulSet Controller and adds it to the Manager with default RBAC. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager) error {
+	if !gate.ResourceEnabled(&appsv1alpha1.StatefulSet{}) {
+		return nil
+	}
 	r, err := newReconciler(mgr)
 	if err != nil {
 		return err

--- a/pkg/controller/uniteddeployment/uniteddeployment_controller.go
+++ b/pkg/controller/uniteddeployment/uniteddeployment_controller.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/openkruise/kruise/pkg/util/gate"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -58,6 +59,9 @@ const (
 // Add creates a new UnitedDeployment Controller and adds it to the Manager with default RBAC. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager) error {
+	if !gate.ResourceEnabled(&appsv1alpha1.UnitedDeployment{}) {
+		return nil
+	}
 	return add(mgr, newReconciler(mgr))
 }
 

--- a/pkg/util/gate/custom_resource_gate.go
+++ b/pkg/util/gate/custom_resource_gate.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2019 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gate
+
+import (
+	"os"
+	"strings"
+
+	"github.com/openkruise/kruise/pkg/apis"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/discovery"
+	"k8s.io/klog"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+)
+
+const (
+	envCustomResourceEnable = "CUSTOM_RESOURCE_ENABLE"
+)
+
+var (
+	internalScheme  = runtime.NewScheme()
+	discoveryClient discovery.DiscoveryInterface
+)
+
+func init() {
+	_ = apis.AddToScheme(internalScheme)
+	cfg, err := config.GetConfig()
+	if err == nil {
+		discoveryClient = discovery.NewDiscoveryClientForConfigOrDie(cfg)
+	}
+}
+
+// ResourceEnabled help runnable check if the custom resource is valid and enabled
+// 1. If this CRD is not found from kueb-apiserver, it is invalid.
+// 2. If 'CUSTOM_RESOURCE_ENABLE' env is not empty and this CRD kind is not in ${CUSTOM_RESOURCE_ENABLE}.
+func ResourceEnabled(obj runtime.Object) bool {
+	gvk, err := apiutil.GVKForObject(obj, internalScheme)
+	if err != nil {
+		klog.Warningf("custom resource gate not recognized object %T in scheme: %v", obj, err)
+		return false
+	}
+
+	return discoveryEnabled(gvk) && envEnabled(gvk)
+}
+
+func discoveryEnabled(gvk schema.GroupVersionKind) bool {
+	if discoveryClient == nil {
+		return true
+	}
+	resourceList, err := discoveryClient.ServerResourcesForGroupVersion(gvk.GroupVersion().String())
+	if err != nil {
+		klog.Warningf("custom resource gate not found groupVersionKind %v in discovery: %v", gvk, err)
+		return false
+	}
+
+	for _, r := range resourceList.APIResources {
+		if r.Kind == gvk.Kind {
+			return true
+		}
+	}
+
+	return false
+}
+
+func envEnabled(gvk schema.GroupVersionKind) bool {
+	limits := strings.TrimSpace(os.Getenv(envCustomResourceEnable))
+	if len(limits) == 0 {
+		// all enabled by default
+		return true
+	}
+
+	if !sets.NewString(strings.Split(limits, ",")...).Has(gvk.Kind) {
+		klog.Warningf("custom resource gate not found groupVersionKind %v in CUSTOM_RESOURCE_ENABLE: %v", gvk, limits)
+		return false
+	}
+
+	return true
+}

--- a/pkg/webhook/default_server/add_mutating_broadcastjob.go
+++ b/pkg/webhook/default_server/add_mutating_broadcastjob.go
@@ -19,10 +19,15 @@ package defaultserver
 import (
 	"fmt"
 
+	appsv1alpha1 "github.com/openkruise/kruise/pkg/apis/apps/v1alpha1"
+	"github.com/openkruise/kruise/pkg/util/gate"
 	"github.com/openkruise/kruise/pkg/webhook/default_server/broadcastjob/mutating"
 )
 
 func init() {
+	if !gate.ResourceEnabled(&appsv1alpha1.BroadcastJob{}) {
+		return
+	}
 	for k, v := range mutating.Builders {
 		_, found := builderMap[k]
 		if found {

--- a/pkg/webhook/default_server/add_mutating_pod.go
+++ b/pkg/webhook/default_server/add_mutating_pod.go
@@ -19,10 +19,15 @@ package defaultserver
 import (
 	"fmt"
 
+	appsv1alpha1 "github.com/openkruise/kruise/pkg/apis/apps/v1alpha1"
+	"github.com/openkruise/kruise/pkg/util/gate"
 	"github.com/openkruise/kruise/pkg/webhook/default_server/pod/mutating"
 )
 
 func init() {
+	if !gate.ResourceEnabled(&appsv1alpha1.SidecarSet{}) {
+		return
+	}
 	for k, v := range mutating.Builders {
 		_, found := builderMap[k]
 		if found {

--- a/pkg/webhook/default_server/add_mutating_sidecarset.go
+++ b/pkg/webhook/default_server/add_mutating_sidecarset.go
@@ -19,10 +19,15 @@ package defaultserver
 import (
 	"fmt"
 
+	appsv1alpha1 "github.com/openkruise/kruise/pkg/apis/apps/v1alpha1"
+	"github.com/openkruise/kruise/pkg/util/gate"
 	"github.com/openkruise/kruise/pkg/webhook/default_server/sidecarset/mutating"
 )
 
 func init() {
+	if !gate.ResourceEnabled(&appsv1alpha1.SidecarSet{}) {
+		return
+	}
 	for k, v := range mutating.Builders {
 		_, found := builderMap[k]
 		if found {

--- a/pkg/webhook/default_server/add_mutating_statefulset.go
+++ b/pkg/webhook/default_server/add_mutating_statefulset.go
@@ -19,10 +19,15 @@ package defaultserver
 import (
 	"fmt"
 
+	appsv1alpha1 "github.com/openkruise/kruise/pkg/apis/apps/v1alpha1"
+	"github.com/openkruise/kruise/pkg/util/gate"
 	"github.com/openkruise/kruise/pkg/webhook/default_server/statefulset/mutating"
 )
 
 func init() {
+	if !gate.ResourceEnabled(&appsv1alpha1.StatefulSet{}) {
+		return
+	}
 	for k, v := range mutating.Builders {
 		_, found := builderMap[k]
 		if found {

--- a/pkg/webhook/default_server/add_mutating_uniteddeployment.go
+++ b/pkg/webhook/default_server/add_mutating_uniteddeployment.go
@@ -19,10 +19,15 @@ package defaultserver
 import (
 	"fmt"
 
+	appsv1alpha1 "github.com/openkruise/kruise/pkg/apis/apps/v1alpha1"
+	"github.com/openkruise/kruise/pkg/util/gate"
 	"github.com/openkruise/kruise/pkg/webhook/default_server/statefulset/mutating"
 )
 
 func init() {
+	if !gate.ResourceEnabled(&appsv1alpha1.UnitedDeployment{}) {
+		return
+	}
 	for k, v := range mutating.Builders {
 		_, found := builderMap[k]
 		if found {

--- a/pkg/webhook/default_server/add_validating_broadcastjob.go
+++ b/pkg/webhook/default_server/add_validating_broadcastjob.go
@@ -19,10 +19,15 @@ package defaultserver
 import (
 	"fmt"
 
+	appsv1alpha1 "github.com/openkruise/kruise/pkg/apis/apps/v1alpha1"
+	"github.com/openkruise/kruise/pkg/util/gate"
 	"github.com/openkruise/kruise/pkg/webhook/default_server/broadcastjob/validating"
 )
 
 func init() {
+	if !gate.ResourceEnabled(&appsv1alpha1.BroadcastJob{}) {
+		return
+	}
 	for k, v := range validating.Builders {
 		_, found := builderMap[k]
 		if found {

--- a/pkg/webhook/default_server/add_validating_sidecarset.go
+++ b/pkg/webhook/default_server/add_validating_sidecarset.go
@@ -19,10 +19,15 @@ package defaultserver
 import (
 	"fmt"
 
+	appsv1alpha1 "github.com/openkruise/kruise/pkg/apis/apps/v1alpha1"
+	"github.com/openkruise/kruise/pkg/util/gate"
 	"github.com/openkruise/kruise/pkg/webhook/default_server/sidecarset/validating"
 )
 
 func init() {
+	if !gate.ResourceEnabled(&appsv1alpha1.SidecarSet{}) {
+		return
+	}
 	for k, v := range validating.Builders {
 		_, found := builderMap[k]
 		if found {

--- a/pkg/webhook/default_server/add_validating_statefulset.go
+++ b/pkg/webhook/default_server/add_validating_statefulset.go
@@ -19,10 +19,15 @@ package defaultserver
 import (
 	"fmt"
 
+	appsv1alpha1 "github.com/openkruise/kruise/pkg/apis/apps/v1alpha1"
+	"github.com/openkruise/kruise/pkg/util/gate"
 	"github.com/openkruise/kruise/pkg/webhook/default_server/statefulset/validating"
 )
 
 func init() {
+	if !gate.ResourceEnabled(&appsv1alpha1.StatefulSet{}) {
+		return
+	}
 	for k, v := range validating.Builders {
 		_, found := builderMap[k]
 		if found {

--- a/pkg/webhook/default_server/add_validating_uniteddeployment.go
+++ b/pkg/webhook/default_server/add_validating_uniteddeployment.go
@@ -19,10 +19,15 @@ package defaultserver
 import (
 	"fmt"
 
+	appsv1alpha1 "github.com/openkruise/kruise/pkg/apis/apps/v1alpha1"
+	"github.com/openkruise/kruise/pkg/util/gate"
 	"github.com/openkruise/kruise/pkg/webhook/default_server/statefulset/validating"
 )
 
 func init() {
+	if !gate.ResourceEnabled(&appsv1alpha1.UnitedDeployment{}) {
+		return
+	}
 	for k, v := range validating.Builders {
 		_, found := builderMap[k]
 		if found {


### PR DESCRIPTION
Signed-off-by: Siyu Wang <FillZpp.pub@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Support gate for custom resource. 

The controllers and webhooks for a CRD will not be started, if:

1. This CRD does not exist in kueb-apiserver.
2. `CUSTOM_RESOURCE_ENABLE` env is set and this CRD kind is not contained in it.
