### PR TITLE
feat:  reduce reference path of AddToScheme

### DIFF
--- a/pkg/apis/addtoscheme_apps_v1alpha1.go
+++ b/pkg/apis/addtoscheme_apps_v1alpha1.go
@@ -22,5 +22,5 @@ import (
 
 func init() {
 	// Register the types with the Scheme so the components can map objects to GroupVersionKinds and back
-	AddToSchemes = append(AddToSchemes, v1alpha1.SchemeBuilder.AddToScheme)
+	AddToSchemes = append(AddToSchemes, v1alpha1.AddToScheme)
 }


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
As we know,  v1alpha1.SchemeBuilder.AddToScheme is the same to v1alpha1.AddToScheme,  the reference path of AddToScheme should more concise.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


