### PR TITLE
Avoid to use nil to update status

### DIFF
--- a/pkg/controller/statefulset/stateful_set_control.go
+++ b/pkg/controller/statefulset/stateful_set_control.go
@@ -278,11 +278,11 @@ func (ssc *defaultStatefulSetControl) updateStatefulSet(
 	// get the current and update revisions of the set.
 	currentSet, err := ApplyRevision(set, currentRevision)
 	if err != nil {
-		return nil, err
+		return set.Status.DeepCopy(), err
 	}
 	updateSet, err := ApplyRevision(set, updateRevision)
 	if err != nil {
-		return nil, err
+		return set.Status.DeepCopy(), err
 	}
 
 	// set the generation, and revisions in the returned status


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Follow #164 with [code](https://github.com/openkruise/kruise/blob/dab47dcb0b863df867de87ce6d82eab93208791b/pkg/controller/statefulset/stateful_set_control.go#L109)
```
        status, getStatusErr := ssc.updateStatefulSet(set, currentRevision, updateRevision, collisionCount, pods, revisions)
	updateStateusErr := ssc.updateStatefulSetStatus(set, status)
```

if status is nil,  at last, when checking if sts is completed in [completeRollingUpdate](https://github.com/openkruise/kruise/blob/dab47dcb0b863df867de87ce6d82eab93208791b/pkg/controller/statefulset/stateful_set_utils.go#L381), it will panic, so try to avoid it.

### Ⅱ. Does this pull request fix one issue?


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


