### PR TITLE
fix calculateUpdateCount() not consider maxSurge

### DIFF
--- a/pkg/controller/cloneset/update/cloneset_update.go
+++ b/pkg/controller/cloneset/update/cloneset_update.go
@@ -144,6 +144,10 @@ func calculateUpdateCount(coreControl clonesetcore.Control, strategy appsv1alpha
 
 	maxUnavailable, _ := intstrutil.GetValueFromIntOrPercent(
 		intstrutil.ValueOrDefault(strategy.MaxUnavailable, intstrutil.FromString(appsv1alpha1.DefaultCloneSetMaxUnavailable)), totalReplicas, true)
+	var maxSurge int
+	if strategy.MaxSurge != nil {
+		maxSurge, _ = intstrutil.GetValueFromIntOrPercent(strategy.MaxSurge, totalReplicas, true)
+	}
 
 	var notReadyCount, updateCount int
 	for _, p := range pods {
@@ -153,7 +157,7 @@ func calculateUpdateCount(coreControl clonesetcore.Control, strategy appsv1alpha
 	}
 	for _, i := range waitUpdateIndexes {
 		if coreControl.IsPodUpdateReady(pods[i], minReadySeconds) {
-			if notReadyCount >= maxUnavailable {
+			if notReadyCount >= (maxUnavailable + maxSurge) {
 				break
 			} else {
 				notReadyCount++

--- a/pkg/controller/cloneset/update/cloneset_update_test.go
+++ b/pkg/controller/cloneset/update/cloneset_update_test.go
@@ -624,6 +624,13 @@ func TestCalculateUpdateCount(t *testing.T) {
 			pods:              []*v1.Pod{{}, readyPod(), {}, readyPod(), readyPod(), readyPod(), readyPod(), {}},
 			expectedResult:    3,
 		},
+		{
+			strategy:          appsv1alpha1.CloneSetUpdateStrategy{MaxSurge: intstrutil.ValueOrDefault(nil, intstrutil.FromInt(2))},
+			totalReplicas:     4,
+			waitUpdateIndexes: []int{0, 1},
+			pods:              []*v1.Pod{readyPod(), readyPod(), readyPod(), readyPod()},
+			expectedResult:    2,
+		},
 	}
 
 	coreControl := clonesetcore.New(&appsv1alpha1.CloneSet{})


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
For CloneSet with maxSurge updateStrategy. `calculateUpdateCount` function not return the correct pod count can update.

For example:

```yaml
apiVersion: apps.kruise.io/v1alpha1
kind: CloneSet
metadata:
  labels:
    app: sample
  name: sample
  namespace: default
spec:
  replicas: 5
  selector:
    matchLabels:
      app: sample
  updateStrategy:
    maxUnavailable: 0
    maxSurge: 2
  minReadySeconds: 10
  template:
    metadata:
      labels:
        app: sample
    spec:
      containers:
      - name: nginx
        image: nginx:alpine
        resources:
          limits:
            cpu: "0.1"
          requests:
            cpu: "0.1"
```
1. Apply this configures. 5 pods were created.
2. Modify cpu limits to "0.2". 2 new version pods were created.
3. After 10 seconds, reach minReadySeconds, no old version pods could be updated.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.
Unit test has been added.

### Ⅳ. Describe how to verify it
Same operations as above. Expect 2 old pods can be updated once and always keep 5 ready pods.