### PR TITLE
Make sure maxUnavailable should not less than 1

### DIFF
--- a/pkg/controller/statefulset/stateful_set_control.go
+++ b/pkg/controller/statefulset/stateful_set_control.go
@@ -547,6 +547,11 @@ func (ssc *defaultStatefulSetControl) updateStatefulSet(
 		if err != nil {
 			return &status, err
 		}
+		// maxUnavailable should not less than 1
+		if maxUnavailable < 1 {
+			maxUnavailable = 1
+		}
+
 		if set.Spec.UpdateStrategy.RollingUpdate.Paused {
 			return &status, nil
 		}


### PR DESCRIPTION
Signed-off-by: Siyu Wang <FillZpp.pub@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Make sure maxUnavailable for StatefulSet should not less than 1
