### PR TITLE
CloneSet: not create excessive pods when updating with maxSurge

### DIFF
--- a/pkg/controller/cloneset/scale/cloneset_scale_util.go
+++ b/pkg/controller/cloneset/scale/cloneset_scale_util.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog"
 	kubecontroller "k8s.io/kubernetes/pkg/controller"
+	"k8s.io/utils/integer"
 )
 
 func getPodsToDelete(cs *appsv1alpha1.CloneSet, pods []*v1.Pod) []*v1.Pod {
@@ -78,6 +79,7 @@ func calculateDiffs(cs *appsv1alpha1.CloneSet, revConsistent bool, totalPods int
 		if currentRevDiff > 0 {
 			if cs.Spec.UpdateStrategy.MaxSurge != nil {
 				maxSurge, _ = intstrutil.GetValueFromIntOrPercent(cs.Spec.UpdateStrategy.MaxSurge, int(*cs.Spec.Replicas), true)
+				maxSurge = integer.IntMin(maxSurge, currentRevDiff)
 			}
 		}
 	}

--- a/pkg/controller/cloneset/scale/cloneset_scale_util_test.go
+++ b/pkg/controller/cloneset/scale/cloneset_scale_util_test.go
@@ -56,6 +56,7 @@ func TestGetOrGenAvailableIDs(t *testing.T) {
 func TestCalculateDiffs(t *testing.T) {
 	intOrStr0 := intstr.FromInt(0)
 	intOrStr1 := intstr.FromInt(1)
+	intOrStr2 := intstr.FromInt(2)
 
 	cases := []struct {
 		name                   string
@@ -201,6 +202,23 @@ func TestCalculateDiffs(t *testing.T) {
 			notUpdatedPods:         6,
 			expectedTotalDiff:      -2,
 			expectedCurrentRevDiff: -2,
+		},
+		{
+			name: "scale out with maxSurge < currentRevDiff",
+			cs: &appsv1alpha1.CloneSet{
+				Spec: appsv1alpha1.CloneSetSpec{
+					Replicas: utilpointer.Int32Ptr(1),
+					UpdateStrategy: appsv1alpha1.CloneSetUpdateStrategy{
+						MaxSurge:  &intOrStr2,
+						Partition: utilpointer.Int32Ptr(0),
+					},
+				},
+			},
+			revConsistent:          false,
+			totalPods:              1,
+			notUpdatedPods:         1,
+			expectedTotalDiff:      -1,
+			expectedCurrentRevDiff: 1,
 		},
 		{
 			name: "scale in with revConsistent 1",

--- a/pkg/controller/cloneset/update/cloneset_update.go
+++ b/pkg/controller/cloneset/update/cloneset_update.go
@@ -144,10 +144,7 @@ func calculateUpdateCount(coreControl clonesetcore.Control, strategy appsv1alpha
 
 	maxUnavailable, _ := intstrutil.GetValueFromIntOrPercent(
 		intstrutil.ValueOrDefault(strategy.MaxUnavailable, intstrutil.FromString(appsv1alpha1.DefaultCloneSetMaxUnavailable)), totalReplicas, true)
-	var maxSurge int
-	if strategy.MaxSurge != nil {
-		maxSurge, _ = intstrutil.GetValueFromIntOrPercent(strategy.MaxSurge, totalReplicas, true)
-	}
+	usedSurge := len(pods) - totalReplicas
 
 	var notReadyCount, updateCount int
 	for _, p := range pods {
@@ -157,7 +154,7 @@ func calculateUpdateCount(coreControl clonesetcore.Control, strategy appsv1alpha
 	}
 	for _, i := range waitUpdateIndexes {
 		if coreControl.IsPodUpdateReady(pods[i], minReadySeconds) {
-			if notReadyCount >= (maxUnavailable + maxSurge) {
+			if notReadyCount >= (maxUnavailable + usedSurge) {
 				break
 			} else {
 				notReadyCount++

--- a/pkg/controller/cloneset/update/cloneset_update_test.go
+++ b/pkg/controller/cloneset/update/cloneset_update_test.go
@@ -625,11 +625,26 @@ func TestCalculateUpdateCount(t *testing.T) {
 			expectedResult:    3,
 		},
 		{
-			strategy:          appsv1alpha1.CloneSetUpdateStrategy{MaxSurge: intstrutil.ValueOrDefault(nil, intstrutil.FromInt(2))},
+			// maxUnavailable = 0 and maxSurge = 2, usedSurge = 1
+			strategy: appsv1alpha1.CloneSetUpdateStrategy{
+				MaxUnavailable: intstrutil.ValueOrDefault(nil, intstrutil.FromInt(0)),
+				MaxSurge:       intstrutil.ValueOrDefault(nil, intstrutil.FromInt(2)),
+			},
 			totalReplicas:     4,
 			waitUpdateIndexes: []int{0, 1},
-			pods:              []*v1.Pod{readyPod(), readyPod(), readyPod(), readyPod()},
-			expectedResult:    2,
+			pods:              []*v1.Pod{readyPod(), readyPod(), readyPod(), readyPod(), readyPod()},
+			expectedResult:    1,
+		},
+		{
+			// maxUnavailable = 1 and maxSurge = 2, usedSurge = 2
+			strategy: appsv1alpha1.CloneSetUpdateStrategy{
+				MaxUnavailable: intstrutil.ValueOrDefault(nil, intstrutil.FromInt(1)),
+				MaxSurge:       intstrutil.ValueOrDefault(nil, intstrutil.FromInt(2)),
+			},
+			totalReplicas:     4,
+			waitUpdateIndexes: []int{0, 1, 2},
+			pods:              []*v1.Pod{readyPod(), readyPod(), readyPod(), readyPod(), readyPod(), readyPod()},
+			expectedResult:    3,
 		},
 	}
 


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Update 2 `v1` pods to `v2` with

`replicas = 2, partition = 1, maxSurge = 2, maxUnavailable = 0`

Now it will create 2 `v2` pods first to use all maxSurge and then delete 1 `v1` and 1 `v2` pod. 

We should only create 1 `v2` pod at first instead.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it