### PR TITLE
fix kustomize failed to load resources not in root or below

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -17,17 +17,9 @@ namePrefix: kruise-
 # files that kustomize reads, modifies and emits as a
 # YAML string, with resources separated by document
 # markers ("---").
-resources:
-- ../rbac/rbac_role.yaml
-- ../rbac/rbac_role_binding.yaml
-- ../manager/webhookconfiguration.yaml
-- ../manager/manager.yaml
-  # Comment the following 3 lines if you want to disable
-  # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
-  # which protects your /metrics endpoint.
-#- ../rbac/auth_proxy_service.yaml
-#- ../rbac/auth_proxy_role.yaml
-#- ../rbac/auth_proxy_role_binding.yaml
+bases:
+- ../rbac
+- ../manager
 
 patches:
 - manager_image_patch.yaml

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - manager.yaml
+  - webhookconfiguration.yaml

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+resources:
+  - rbac_role.yaml
+  - rbac_role_binding.yaml
+  # Comment the following 3 lines if you want to disable
+  # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
+  # which protects your /metrics endpoint.
+  # - auth_proxy_service.yaml
+  # - auth_proxy_role.yaml
+  # - auth_proxy_role_binding.yaml


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Fix kustomize disallows certain file loading go up out of root(https://github.com/kubernetes-sigs/kustomize/pull/700)


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

NONE

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


before the patch, `make deploy` works for certain kustomize version, e.g. v1.0.8

```
# kubectl version 1.16, use kustomize 2.0.3
$ kubectl  kustomize config/default/
Error: rawResources failed to read Resources: Load from path ../rbac/rbac_role.yaml failed: security; file '../rbac/rbac_role.yaml' is not in or below '/home/wyc/go/src/github.com/openkruise/kruise/config/default'

# for kustomize >=2.0.0
$ kustomize_2.0.0_linux_amd64 build config/default/
Error: rawResources failed to read Resources: Load from path ../rbac/rbac_role.yaml failed: security; file '../rbac/rbac_role.yaml' is not in or below '/home/wyc/go/src/github.com/openkruise/kruise/config/default'

# for kustomize >=3.0
$ kustomize_3.6.1_linux_amd64 build config/default/
Error: accumulating resources: accumulateFile "accumulating resources from '../rbac/rbac_role.yaml': security; file '/home/wyc/go/src/github.com/openkruise/kruise/config/rbac/rbac_role.yaml' is not in or below '/home/wyc/go/src/github.com/openkruise/kruise/config/default'", loader.New "Error loading ../rbac/rbac_role.yaml with git: url lacks host: ../rbac/rbac_role.yaml, dir: got file 'rbac_role.yaml', but '/home/wyc/go/src/github.com/openkruise/kruise/config/rbac/rbac_role.yaml' must be a directory to be a root, get: invalid source string: ../rbac/rbac_role.yaml"
```

after this patch, it should works for all kustomzie versions.


### Ⅳ. Describe how to verify it

verify the behavior unchanged

```
# before:
wyc@3600:~/go/src/github.com/openkruise/kruise ((HEAD detached at github/master)) (go1.14)#72$ kustomize_1.0.8_linux_amd64 build config/default/  > 1.yaml
2020/06/13 18:10:32 Adding nameprefix to Namespace resource will be deprecated in next release.

# after:
wyc@3600:~/go/src/github.com/openkruise/kruise ((HEAD detached at github/master)) (go1.14)#73$ git checkout master 
Previous HEAD position was 26ee25e9 Improve README and add contributing (#288)
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
wyc@3600:~/go/src/github.com/openkruise/kruise (master) (go1.14)#74$ git log --oneline github/master...master
4340b09c (HEAD -> master, origin/master) fix kustomize failed to load resources not in root or below
wyc@3600:~/go/src/github.com/openkruise/kruise (master) (go1.14)#75$ kustomize_1.0.8_linux_amd64 build config/default/  > 2.yaml
2020/06/13 18:10:52 Adding nameprefix to Namespace resource will be deprecated in next release.
wyc@3600:~/go/src/github.com/openkruise/kruise (master) (go1.14)#76$ kustomize_2.0.0_linux_amd64 build config/default/ > 3.yaml
wyc@3600:~/go/src/github.com/openkruise/kruise (master) (go1.14)#77$ kustomize_3.6.1_linux_amd64 build config/default/ > 4.yaml

# diff
wyc@3600:~/go/src/github.com/openkruise/kruise (master) (go1.14)#78$ diff 1.yaml 2.yaml
wyc@3600:~/go/src/github.com/openkruise/kruise (master) (go1.14)#79$ diff 2.yaml 3.yaml
379a380,447
> apiVersion: apps/v1
> kind: StatefulSet
> metadata:
>   labels:
>     control-plane: controller-manager
>     controller-tools.k8s.io: "1.0"
>   name: kruise-controller-manager
>   namespace: kruise-system
> spec:
>   replicas: 1
>   selector:
>     matchLabels:
>       control-plane: controller-manager
>       controller-tools.k8s.io: "1.0"
>   serviceName: kruise-controller-manager-service
>   template:
>     metadata:
>       annotations:
>         prometheus.io/scrape: "true"
>       labels:
>         control-plane: controller-manager
>         controller-tools.k8s.io: "1.0"
>     spec:
>       containers:
>       - args:
>         - --metrics-addr=127.0.0.1:8080
>         - --logtostderr=true
>         - --v=4
>         command:
>         - /manager
>         env:
>         - name: POD_NAMESPACE
>           valueFrom:
>             fieldRef:
>               fieldPath: metadata.namespace
>         - name: SECRET_NAME
>           value: kruise-webhook-server-secret
>         image: openkruise/kruise-manager:test
>         imagePullPolicy: Always
>         name: manager
>         ports:
>         - containerPort: 8080
>           name: metrics
>           protocol: TCP
>         - containerPort: 9876
>           name: webhook-server
>           protocol: TCP
>         readinessProbe:
>           tcpSocket:
>             port: 9876
>         resources:
>           limits:
>             cpu: 100m
>             memory: 1Gi
>           requests:
>             cpu: 100m
>             memory: 100Mi
>         volumeMounts:
>         - mountPath: /tmp/cert
>           name: cert
>           readOnly: true
>       terminationGracePeriodSeconds: 10
>       volumes:
>       - name: cert
>         secret:
>           defaultMode: 420
>           secretName: kruise-webhook-server-secret
> ---
502,569d569
< ---
< apiVersion: apps/v1
< kind: StatefulSet
< metadata:
<   labels:
<     control-plane: controller-manager
<     controller-tools.k8s.io: "1.0"
<   name: kruise-controller-manager
<   namespace: kruise-system
< spec:
<   replicas: 1
<   selector:
<     matchLabels:
<       control-plane: controller-manager
<       controller-tools.k8s.io: "1.0"
<   serviceName: kruise-controller-manager-service
<   template:
<     metadata:
<       annotations:
<         prometheus.io/scrape: "true"
<       labels:
<         control-plane: controller-manager
<         controller-tools.k8s.io: "1.0"
<     spec:
<       containers:
<       - args:
<         - --metrics-addr=127.0.0.1:8080
<         - --logtostderr=true
<         - --v=4
<         command:
<         - /manager
<         env:
<         - name: POD_NAMESPACE
<           valueFrom:
<             fieldRef:
<               fieldPath: metadata.namespace
<         - name: SECRET_NAME
<           value: kruise-webhook-server-secret
<         image: openkruise/kruise-manager:test
<         imagePullPolicy: Always
<         name: manager
<         ports:
<         - containerPort: 8080
<           name: metrics
<           protocol: TCP
<         - containerPort: 9876
<           name: webhook-server
<           protocol: TCP
<         readinessProbe:
<           tcpSocket:
<             port: 9876
<         resources:
<           limits:
<             cpu: 100m
<             memory: 1Gi
<           requests:
<             cpu: 100m
<             memory: 100Mi
<         volumeMounts:
<         - mountPath: /tmp/cert
<           name: cert
<           readOnly: true
<       terminationGracePeriodSeconds: 10
<       volumes:
<       - name: cert
<         secret:
<           defaultMode: 420
<           secretName: kruise-webhook-server-secret
wyc@3600:~/go/src/github.com/openkruise/kruise (master) (go1.14)#80$ diff  3.yaml 4.yaml
452d451
<   namespace: kruise-system
458d456
<   namespace: kruise-system

```

1.yaml and 2.yaml are same
2.yaml and 3.yaml are equivalent with different orders
3.yaml and 4.yaml are equivalent, 4.yaml drops namespace from mutating/validating webhookconfiguration, this ok because those API are cluster scoped.

### Ⅴ. Special notes for reviews

NONE

