### PR TITLE
BugFix: [daemonset] ignore failed pod and add nodes matching update selector to queue

### DIFF
--- a/pkg/controller/daemonset/daemonset_controller.go
+++ b/pkg/controller/daemonset/daemonset_controller.go
@@ -1057,3 +1057,5 @@ func (dsc *ReconcileDaemonSet) cleanupHistory(ds *appsv1alpha1.DaemonSet, old []
 	}
 	return nil
 }
+
+//

--- a/pkg/controller/daemonset/daemonset_event_handler.go
+++ b/pkg/controller/daemonset/daemonset_event_handler.go
@@ -64,7 +64,7 @@ func (e *podEventHandler) Create(evt event.CreateEvent, q workqueue.RateLimiting
 		return
 	}
 
-	// Otherwise, it's an orphan. Get a list of all matching CloneSets and sync
+	// Otherwise, it's an orphan. Get a list of all matching DaemonSets and sync
 	// them to see if anyone wants to adopt it.
 	// DO NOT observe creation because no controller should be waiting for an
 	// orphan.
@@ -282,7 +282,8 @@ func (e *nodeEventHandler) Update(evt event.UpdateEvent, q workqueue.RateLimitin
 		if err != nil {
 			continue
 		}
-		if (CanNodeBeDeployed(oldNode, &ds) != CanNodeBeDeployed(curNode, &ds)) || (oldShouldSchedule != currentShouldSchedule) || (oldShouldContinueRunning != currentShouldContinueRunning) {
+		if (CanNodeBeDeployed(oldNode, &ds) != CanNodeBeDeployed(curNode, &ds)) || (oldShouldSchedule != currentShouldSchedule) || (oldShouldContinueRunning != currentShouldContinueRunning) ||
+			(NodeShouldUpdateBySelector(oldNode, &ds) != NodeShouldUpdateBySelector(curNode, &ds)) {
 			klog.V(6).Infof("update node: %s triggers DaemonSet %s/%s to reconcile.", curNode.Name, ds.GetNamespace(), ds.GetName())
 			q.Add(reconcile.Request{NamespacedName: types.NamespacedName{
 				Name:      ds.GetName(),


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
1. BugFix: fix daemonset bugs like k8s controller manager, see [issue](https://github.com/kubernetes/kubernetes/pull/78170)
2. BugFix: when kruise daemonset is updating by selector, put the updating node to the work queue if it matchs the update selector

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.
Add unit test TestNodeShouldUpdateBySelector in daemonset_util_test.go

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


