### PR TITLE
fix cloneset maxUnavaliable when maxSurge > 0

### DIFF
--- a/pkg/apis/apps/v1alpha1/cloneset_types.go
+++ b/pkg/apis/apps/v1alpha1/cloneset_types.go
@@ -89,7 +89,8 @@ type CloneSetUpdateStrategy struct {
 	Partition *int32 `json:"partition,omitempty"`
 	// The maximum number of pods that can be unavailable during the update.
 	// Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
-	// Absolute number is calculated from percentage by rounding up.
+	// Absolute number is calculated from percentage by rounding up by default.
+	// When maxSurge > 0, absolute number is calculated from percentage by rounding down.
 	// Defaults to 20%.
 	MaxUnavailable *intstr.IntOrString `json:"maxUnavailable,omitempty"`
 	// The maximum number of pods that can be scheduled above the desired replicas during the update.

--- a/pkg/controller/cloneset/update/cloneset_update.go
+++ b/pkg/controller/cloneset/update/cloneset_update.go
@@ -141,8 +141,13 @@ func calculateUpdateCount(coreControl clonesetcore.Control, strategy appsv1alpha
 	}
 	waitUpdateIndexes = waitUpdateIndexes[:(len(waitUpdateIndexes) - partition)]
 
+	roundUp := true
+	if strategy.MaxSurge != nil {
+		maxSurge, _ := intstrutil.GetValueFromIntOrPercent(strategy.MaxSurge, totalReplicas, true)
+		roundUp = maxSurge == 0
+	}
 	maxUnavailable, _ := intstrutil.GetValueFromIntOrPercent(
-		intstrutil.ValueOrDefault(strategy.MaxUnavailable, intstrutil.FromString(appsv1alpha1.DefaultCloneSetMaxUnavailable)), totalReplicas, true)
+		intstrutil.ValueOrDefault(strategy.MaxUnavailable, intstrutil.FromString(appsv1alpha1.DefaultCloneSetMaxUnavailable)), totalReplicas, roundUp)
 	usedSurge := len(pods) - totalReplicas
 
 	var notReadyCount, updateCount int


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
fix cloneset maxUnavaliable when maxSurge is not nil

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #316 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


