### PR TITLE
Remove cloneset scale race condition on bool

### DIFF
--- a/pkg/controller/cloneset/scale/cloneset_scale.go
+++ b/pkg/controller/cloneset/scale/cloneset_scale.go
@@ -126,7 +126,6 @@ func (r *realControl) createPods(
 		podsCreationChan <- p
 	}
 
-	var created bool
 	successPodNames := sync.Map{}
 	_, err = clonesetutils.DoItSlowly(len(newPods), initialBatchSize, func() error {
 		pod := <-podsCreationChan
@@ -140,7 +139,7 @@ func (r *realControl) createPods(
 		if createErr = r.createOnePod(cs, pod, existingPVCNames); createErr != nil {
 			return createErr
 		}
-		created = true
+
 		successPodNames.Store(pod.Name, struct{}{})
 		return nil
 	})
@@ -152,7 +151,10 @@ func (r *realControl) createPods(
 		}
 	}
 
-	return created, err
+	if err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func (r *realControl) createOnePod(cs *appsv1alpha1.CloneSet, pod *v1.Pod, existingPVCNames sets.String) error {

--- a/pkg/controller/cloneset/scale/cloneset_scale.go
+++ b/pkg/controller/cloneset/scale/cloneset_scale.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
 	clonesetcore "github.com/openkruise/kruise/pkg/controller/cloneset/core"
@@ -126,6 +127,7 @@ func (r *realControl) createPods(
 		podsCreationChan <- p
 	}
 
+	var created int64
 	successPodNames := sync.Map{}
 	_, err = clonesetutils.DoItSlowly(len(newPods), initialBatchSize, func() error {
 		pod := <-podsCreationChan
@@ -140,6 +142,8 @@ func (r *realControl) createPods(
 			return createErr
 		}
 
+		atomic.AddInt64(&created, 1)
+
 		successPodNames.Store(pod.Name, struct{}{})
 		return nil
 	})
@@ -151,10 +155,10 @@ func (r *realControl) createPods(
 		}
 	}
 
-	if err != nil {
+	if created == 0 {
 		return false, err
 	}
-	return true, nil
+	return true, err
 }
 
 func (r *realControl) createOnePod(cs *appsv1alpha1.CloneSet, pod *v1.Pod, existingPVCNames sets.String) error {


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Removes a race condition in the CreatePods flow with concurrent access to the created boolean

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
None

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.
identified with `go test -race .`

### Ⅳ. Describe how to verify it
`go test -race .` no longer fails.

### Ⅴ. Special notes for reviews
I don't believe the created boolean was used for anything other than a global flag, but if so, this might need to be updated.

