### PR TITLE
fix concurrent bug when create many pods concurrently

### DIFF
--- a/pkg/controller/cloneset/utils/cloneset_utils.go
+++ b/pkg/controller/cloneset/utils/cloneset_utils.go
@@ -23,7 +23,7 @@ import (
 
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
 	apps "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"

--- a/pkg/controller/cloneset/utils/cloneset_utils.go
+++ b/pkg/controller/cloneset/utils/cloneset_utils.go
@@ -23,7 +23,7 @@ import (
 
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
 	apps "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"


### PR DESCRIPTION
Signed-off-by: hantmac <hantmac@outlook.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
The ` github.com/json-iterator/go.(*stringCodec).Decode()` does not support concurrency, but when cloneSet scale, it will create pods concurrently, cause data race.
 
![image](https://user-images.githubusercontent.com/7600925/91630951-5b435a00-ea08-11ea-8338-f1eb15197a79.png)


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
May fix https://github.com/openkruise/kruise/issues/349

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.
go test -race .

### Ⅳ. Describe how to verify it
`go test -race .` return ok.
![image](https://user-images.githubusercontent.com/7600925/91630983-9180d980-ea08-11ea-93ee-815d60b98981.png)
 

### Ⅴ. Special notes for reviews


