### PR TITLE
Cloneset pvc concurrent write

### DIFF
--- a/pkg/controller/cloneset/scale/cloneset_scale.go
+++ b/pkg/controller/cloneset/scale/cloneset_scale.go
@@ -45,6 +45,7 @@ type realControl struct {
 	client.Client
 	recorder record.EventRecorder
 	exp      expectations.ScaleExpectations
+	mu       sync.Mutex
 }
 
 func (r *realControl) Manage(
@@ -168,6 +169,8 @@ func (r *realControl) createOnePod(cs *appsv1alpha1.CloneSet, pod *v1.Pod, exist
 			continue
 		}
 		r.exp.ExpectScale(clonesetutils.GetControllerKey(cs), expectations.Create, c.Name)
+		r.mu.Lock()
+		defer r.mu.Unlock()
 		if err := r.Create(context.TODO(), &c); err != nil {
 			r.exp.ObserveScale(clonesetutils.GetControllerKey(cs), expectations.Create, c.Name)
 			r.recorder.Eventf(cs, v1.EventTypeWarning, "FailedCreate", "failed to create pvc: %v, pvc: %v", err, util.DumpJSON(c))

--- a/pkg/controller/cloneset/scale/cloneset_scale.go
+++ b/pkg/controller/cloneset/scale/cloneset_scale.go
@@ -172,7 +172,6 @@ func (r *realControl) createOnePod(cs *appsv1alpha1.CloneSet, pod *v1.Pod, exist
 			continue
 		}
 		r.exp.ExpectScale(clonesetutils.GetControllerKey(cs), expectations.Create, c.Name)
-
 		if err := r.Create(context.TODO(), &c); err != nil {
 			r.exp.ObserveScale(clonesetutils.GetControllerKey(cs), expectations.Create, c.Name)
 			r.recorder.Eventf(cs, v1.EventTypeWarning, "FailedCreate", "failed to create pvc: %v, pvc: %v", err, util.DumpJSON(c))


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Add locking around Cloneset PVC and Pod Creation

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
Fixes #349 #320 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.
I'm not sure how to add testing as this appears to be a race condition that occurs when the kube api server takes too long to respond.

### Ⅳ. Describe how to verify it
I've manually scaled up a cloneset that previously failed with both error conditions above.

### Ⅴ. Special notes for reviews
I added the locking to CreatePods instead of CreateOnePod to a) make it more clear that pretty much everything in that function requires locking and b) there is already 2 other thread sensitive sections just below the CreateOnePod call in CreatePods (atomic.Add and the successPodNames.Store)
