### PR TITLE
add flag --extra-allowed-pod-number to avoid daemonset pod schedule fail

### DIFF
--- a/pkg/controller/daemonset/daemonset_controller.go
+++ b/pkg/controller/daemonset/daemonset_controller.go
@@ -70,11 +70,14 @@ import (
 func init() {
 	flag.BoolVar(&scheduleDaemonSetPods, "assign-pods-by-scheduler", true, "Use scheduler to assign pod to node.")
 	flag.IntVar(&concurrentReconciles, "daemonset-workers", concurrentReconciles, "Max concurrent workers for DaemonSet controller.")
+	flag.Int64Var(&extraAllowedPodNumber, "daemonset-extra-allowed-pod-number", extraAllowedPodNumber,
+		"Extra allowed number of Pods that can run on one node, ensure daemonset pod to be assigned")
 }
 
 var (
 	concurrentReconciles  = 3
 	scheduleDaemonSetPods bool
+	extraAllowedPodNumber = int64(0)
 
 	// controllerKind contains the schema.GroupVersionKind for this controller type.
 	controllerKind = appsv1alpha1.SchemeGroupVersion.WithKind("DaemonSet")


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Add flag --extra-allowed-pod-number to avoid daemonset pod schedule fail.
Case: 
   set schedule by kruise ds controller itself and user's ds using Suring update type , if pods on node have already rearch the max count limit, the surging pod can not be scheduled to that node. So extra-allowed-pod-number  is needed.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
No

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.
TestGetSchedulerNodeInfo

### Ⅳ. Describe how to verify it
-

### Ⅴ. Special notes for reviews
to suitable 

