### PR TITLE
Add init containers to the sidecarset

### DIFF
--- a/apis/apps/v1alpha1/defaults.go
+++ b/apis/apps/v1alpha1/defaults.go
@@ -28,6 +28,10 @@ import (
 func SetDefaultsSidecarSet(obj *SidecarSet) {
 	setSidecarSetUpdateStratety(&obj.Spec.Strategy)
 
+	for i := range obj.Spec.InitContainers {
+		setSidecarDefaultContainer(&obj.Spec.InitContainers[i])
+	}
+
 	for i := range obj.Spec.Containers {
 		setSidecarDefaultContainer(&obj.Spec.Containers[i])
 	}

--- a/apis/apps/v1alpha1/sidecarset_types.go
+++ b/apis/apps/v1alpha1/sidecarset_types.go
@@ -27,6 +27,9 @@ type SidecarSetSpec struct {
 	// selector is a label query over pods that should be injected
 	Selector *metav1.LabelSelector `json:"selector,omitempty"`
 
+	// Containers is the list of init containers to be injected into the selected pod
+	InitContainers []SidecarContainer `json:"initContainers,omitempty"`
+
 	// Containers is the list of sidecar containers to be injected into the selected pod
 	Containers []SidecarContainer `json:"containers,omitempty"`
 

--- a/apis/apps/v1alpha1/sidecarset_types.go
+++ b/apis/apps/v1alpha1/sidecarset_types.go
@@ -28,7 +28,8 @@ type SidecarSetSpec struct {
 	Selector *metav1.LabelSelector `json:"selector,omitempty"`
 
 	// Containers is the list of init containers to be injected into the selected pod
-	// We will sort them by their name in ascending order
+	// We will inject those containers by their name in ascending order
+	// We only inject init containers when a new pod is created, it does not apply to any existing pod
 	InitContainers []SidecarContainer `json:"initContainers,omitempty"`
 
 	// Containers is the list of sidecar containers to be injected into the selected pod

--- a/apis/apps/v1alpha1/sidecarset_types.go
+++ b/apis/apps/v1alpha1/sidecarset_types.go
@@ -28,6 +28,7 @@ type SidecarSetSpec struct {
 	Selector *metav1.LabelSelector `json:"selector,omitempty"`
 
 	// Containers is the list of init containers to be injected into the selected pod
+	// We will sort them by their name in ascending order
 	InitContainers []SidecarContainer `json:"initContainers,omitempty"`
 
 	// Containers is the list of sidecar containers to be injected into the selected pod

--- a/apis/apps/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/apps/v1alpha1/zz_generated.deepcopy.go
@@ -1352,6 +1352,13 @@ func (in *SidecarSetSpec) DeepCopyInto(out *SidecarSetSpec) {
 		*out = new(v1.LabelSelector)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.InitContainers != nil {
+		in, out := &in.InitContainers, &out.InitContainers
+		*out = make([]SidecarContainer, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.Containers != nil {
 		in, out := &in.Containers, &out.Containers
 		*out = make([]SidecarContainer, len(*in))

--- a/config/crd/bases/apps.kruise.io_clonesets.yaml
+++ b/config/crd/bases/apps.kruise.io_clonesets.yaml
@@ -75,6 +75,8 @@ spec:
                 in-place update.
               properties:
                 inPlaceUpdate:
+                  description: InPlaceUpdate is the hook before Pod to update and
+                    after Pod has been updated.
                   properties:
                     finalizersHandler:
                       items:
@@ -86,6 +88,7 @@ spec:
                       type: object
                   type: object
                 preDelete:
+                  description: PreDelete is the hook before Pod to be deleted.
                   properties:
                     finalizersHandler:
                       items:

--- a/config/crd/bases/apps.kruise.io_sidecarsets.yaml
+++ b/config/crd/bases/apps.kruise.io_sidecarsets.yaml
@@ -63,6 +63,13 @@ spec:
                 description: SidecarContainer defines the container of Sidecar
                 type: object
               type: array
+            initContainers:
+              description: Containers is the list of sidecar containers to be injected
+                into the selected pod
+              items:
+                description: SidecarContainer defines the container of Sidecar
+                type: object
+              type: array
             paused:
               description: Paused indicates that the sidecarset is paused and will
                 not be processed by the sidecarset controller.

--- a/config/crd/bases/apps.kruise.io_sidecarsets.yaml
+++ b/config/crd/bases/apps.kruise.io_sidecarsets.yaml
@@ -64,8 +64,10 @@ spec:
                 type: object
               type: array
             initContainers:
-              description: Containers is the list of sidecar containers to be injected
-                into the selected pod
+              description: Containers is the list of init containers to be injected
+                into the selected pod We will inject those containers by their name
+                in ascending order We only inject init containers when a new pod is
+                created, it does not apply to any existing pod
               items:
                 description: SidecarContainer defines the container of Sidecar
                 type: object

--- a/config/samples/apps_v1alpha1_sidecarset.yaml
+++ b/config/samples/apps_v1alpha1_sidecarset.yaml
@@ -1,9 +1,25 @@
 apiVersion: apps.kruise.io/v1alpha1
 kind: SidecarSet
 metadata:
-  labels:
-    controller-tools.k8s.io: "1.0"
-  name: sidecarset-sample
+  name: guestbook-sidecar
 spec:
-  # Add fields here
-  foo: bar
+  selector: # select the pods to be injected with sidecar containers
+    matchLabels:
+      app.kubernetes.io/name: guestbook-with-sidecar
+  initContainers:
+    - name: init-myservice
+      image: busybox:1.28
+      command: ['sh', '-c', 'echo The app is running! && sleep 360']
+  containers:
+    - name: guestbook-sidecar
+      image: openkruise/guestbook:sidecar
+      imagePullPolicy: Always
+      ports:
+        - name: sidecar-server
+          containerPort: 4000 # different from main guestbook containerPort which is 3000
+      volumeMounts:
+        - name: log-volume
+          mountPath: /var/log
+  volumes:
+    - name: log-volume
+      emptyDir: {}

--- a/pkg/webhook/pod/mutating/pod_create_handler_test.go
+++ b/pkg/webhook/pod/mutating/pod_create_handler_test.go
@@ -47,6 +47,20 @@ func TestSidecarSetMutatePod(t *testing.T) {
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{"app": "nginx"},
 			},
+			InitContainers: []appsv1alpha1.SidecarContainer{
+				{
+					Container: corev1.Container{
+						Name:  "init1",
+						Image: "init-image1",
+					},
+				},
+				{
+					Container: corev1.Container{
+						Name:  "init3",
+						Image: "init-image3",
+					},
+				},
+			},
 			Containers: []appsv1alpha1.SidecarContainer{
 				{
 					Container: corev1.Container{
@@ -75,6 +89,14 @@ func TestSidecarSetMutatePod(t *testing.T) {
 		Spec: appsv1alpha1.SidecarSetSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{"app": "nginx"},
+			},
+			InitContainers: []appsv1alpha1.SidecarContainer{
+				{
+					Container: corev1.Container{
+						Name:  "init2",
+						Image: "init-image2",
+					},
+				},
 			},
 			Containers: []appsv1alpha1.SidecarContainer{
 				{
@@ -125,6 +147,18 @@ func TestSidecarSetMutatePod(t *testing.T) {
 	_ = podHandler.mutatingPodFn(context.TODO(), pod1)
 	_ = podHandler.mutatingPodFn(context.TODO(), pod2)
 
+	if len(pod1.Spec.InitContainers) != 3 {
+		t.Errorf("expect 3 init containers, but got %v", len(pod1.Spec.InitContainers))
+	}
+	if pod1.Spec.InitContainers[0].Name != "init1" {
+		t.Errorf("expect first init container `init1`, but got %s", pod1.Spec.InitContainers[0].Name)
+	}
+	if pod1.Spec.InitContainers[1].Name != "init2" {
+		t.Errorf("expect first init container `init2`, but got %s", pod1.Spec.InitContainers[0].Name)
+	}
+	if pod1.Spec.InitContainers[2].Name != "init3" {
+		t.Errorf("expect first init container `init3`, but got %s", pod1.Spec.InitContainers[0].Name)
+	}
 	if len(pod1.Spec.Containers) != 3 {
 		t.Errorf("expect 3 containers, but got %v", len(pod1.Spec.Containers))
 	}

--- a/pkg/webhook/sidecarset/mutating/hash.go
+++ b/pkg/webhook/sidecarset/mutating/hash.go
@@ -37,12 +37,10 @@ func SidecarSetHash(sidecarSet *appsv1alpha1.SidecarSet) (string, error) {
 	return h, nil
 }
 
-// SidecarSetHashWithoutImage calculates hash without sidecars's image
+// SidecarSetHashWithoutImage calculates hash without sidecars's container image
+// This is used to determine if the sidecar reconcile needs to update a pod image
 func SidecarSetHashWithoutImage(sidecarSet *appsv1alpha1.SidecarSet) (string, error) {
 	ss := sidecarSet.DeepCopy()
-	for i := range ss.Spec.InitContainers {
-		ss.Spec.InitContainers[i].Image = ""
-	}
 	for i := range ss.Spec.Containers {
 		ss.Spec.Containers[i].Image = ""
 	}

--- a/pkg/webhook/sidecarset/mutating/hash.go
+++ b/pkg/webhook/sidecarset/mutating/hash.go
@@ -40,6 +40,9 @@ func SidecarSetHash(sidecarSet *appsv1alpha1.SidecarSet) (string, error) {
 // SidecarSetHashWithoutImage calculates hash without sidecars's image
 func SidecarSetHashWithoutImage(sidecarSet *appsv1alpha1.SidecarSet) (string, error) {
 	ss := sidecarSet.DeepCopy()
+	for i := range ss.Spec.InitContainers {
+		ss.Spec.InitContainers[i].Image = ""
+	}
 	for i := range ss.Spec.Containers {
 		ss.Spec.Containers[i].Image = ""
 	}
@@ -48,7 +51,7 @@ func SidecarSetHashWithoutImage(sidecarSet *appsv1alpha1.SidecarSet) (string, er
 
 func encodeSidecarSet(sidecarSet *appsv1alpha1.SidecarSet) (string, error) {
 	// json.Marshal sorts the keys in a stable order in the encoding
-	m := map[string]interface{}{"containers": sidecarSet.Spec.Containers}
+	m := map[string]interface{}{"initContainers": sidecarSet.Spec.InitContainers, "containers": sidecarSet.Spec.Containers}
 	data, err := json.Marshal(m)
 	if err != nil {
 		return "", err

--- a/pkg/webhook/sidecarset/mutating/hash.go
+++ b/pkg/webhook/sidecarset/mutating/hash.go
@@ -29,7 +29,7 @@ import (
 // SidecarSetHash returns a hash of the SidecarSet.
 // The Containers are taken into account.
 func SidecarSetHash(sidecarSet *appsv1alpha1.SidecarSet) (string, error) {
-	encoded, err := encodeSidecarSet(sidecarSet)
+	encoded, err := encodeSidecarSet(sidecarSet, true)
 	if err != nil {
 		return "", err
 	}
@@ -37,19 +37,26 @@ func SidecarSetHash(sidecarSet *appsv1alpha1.SidecarSet) (string, error) {
 	return h, nil
 }
 
-// SidecarSetHashWithoutImage calculates hash without sidecars's container image
-// This is used to determine if the sidecar reconcile needs to update a pod image
+// SidecarSetHashWithoutImage calculates sidecars's container hash without its image
+// we use this to determine if the sidecar reconcile needs to update a pod image
 func SidecarSetHashWithoutImage(sidecarSet *appsv1alpha1.SidecarSet) (string, error) {
 	ss := sidecarSet.DeepCopy()
 	for i := range ss.Spec.Containers {
 		ss.Spec.Containers[i].Image = ""
 	}
-	return SidecarSetHash(ss)
+	encoded, err := encodeSidecarSet(ss, false)
+	if err != nil {
+		return "", err
+	}
+	return rand.SafeEncodeString(hash(encoded)), nil
 }
 
-func encodeSidecarSet(sidecarSet *appsv1alpha1.SidecarSet) (string, error) {
+func encodeSidecarSet(sidecarSet *appsv1alpha1.SidecarSet, includeInit bool) (string, error) {
 	// json.Marshal sorts the keys in a stable order in the encoding
-	m := map[string]interface{}{"initContainers": sidecarSet.Spec.InitContainers, "containers": sidecarSet.Spec.Containers}
+	m := map[string]interface{}{"containers": sidecarSet.Spec.Containers}
+	if includeInit {
+		m["initContainers"] = sidecarSet.Spec.InitContainers
+	}
 	data, err := json.Marshal(m)
 	if err != nil {
 		return "", err

--- a/pkg/webhook/sidecarset/mutating/sidecarset_mutating_test.go
+++ b/pkg/webhook/sidecarset/mutating/sidecarset_mutating_test.go
@@ -64,8 +64,8 @@ func TestSidecarSetHash(t *testing.T) {
 	if expectedOutputSidecarSet.Annotations == nil {
 		expectedOutputSidecarSet.Annotations = make(map[string]string)
 	}
-	expectedOutputSidecarSet.Annotations[SidecarSetHashAnnotation] = "vd6xbxv9w5f8794x5v852cf9288x4v8d926zw2bbcc8545847xw4w7f4xdbx5z6b"
-	expectedOutputSidecarSet.Annotations[SidecarSetHashWithoutImageAnnotation] = "cfd67dc8z844x4f7cd9f7b624x5ddxxd97wdwv45x48z49cx4942w5c8z84v2dzx"
+	expectedOutputSidecarSet.Annotations[SidecarSetHashAnnotation] = "8f92wdb9w96824dvw54566vx89wcxd6b75cd4ccxbv4zcvbd7fvfffw4v889dcz2"
+	expectedOutputSidecarSet.Annotations[SidecarSetHashWithoutImageAnnotation] = "vz6x4f662ccff44456ff4727dwb54z7f42c8wf94cw629bwbb5876fwc2cw7vz78"
 
 	if err := setHashSidecarSet(sidecarSet); err != nil {
 		t.Errorf("got error %v", err)

--- a/pkg/webhook/sidecarset/mutating/sidecarset_mutating_test.go
+++ b/pkg/webhook/sidecarset/mutating/sidecarset_mutating_test.go
@@ -13,6 +13,14 @@ import (
 var (
 	sidecarSetDemo = &appsv1alpha1.SidecarSet{
 		Spec: appsv1alpha1.SidecarSetSpec{
+			InitContainers: []appsv1alpha1.SidecarContainer{
+				{
+					Container: corev1.Container{
+						Name:  "test-init-containers",
+						Image: "test-init-image:latest",
+					},
+				},
+			},
 			Containers: []appsv1alpha1.SidecarContainer{
 				{
 					Container: corev1.Container{
@@ -32,6 +40,9 @@ func TestSidecarSetDefault(t *testing.T) {
 	expectedOutputSidecarSet.Spec.Containers[0].TerminationMessagePath = corev1.TerminationMessagePathDefault
 	expectedOutputSidecarSet.Spec.Containers[0].TerminationMessagePolicy = corev1.TerminationMessageReadFile
 	expectedOutputSidecarSet.Spec.Containers[0].ImagePullPolicy = corev1.PullIfNotPresent
+	expectedOutputSidecarSet.Spec.InitContainers[0].TerminationMessagePath = corev1.TerminationMessagePathDefault
+	expectedOutputSidecarSet.Spec.InitContainers[0].TerminationMessagePolicy = corev1.TerminationMessageReadFile
+	expectedOutputSidecarSet.Spec.InitContainers[0].ImagePullPolicy = corev1.PullAlways
 	maxUnavailable := intstr.FromInt(1)
 	expectedOutputSidecarSet.Spec.Strategy = appsv1alpha1.SidecarSetUpdateStrategy{
 		RollingUpdate: &appsv1alpha1.RollingUpdateSidecarSet{

--- a/pkg/webhook/sidecarset/mutating/sidecarset_mutating_test.go
+++ b/pkg/webhook/sidecarset/mutating/sidecarset_mutating_test.go
@@ -65,7 +65,7 @@ func TestSidecarSetHash(t *testing.T) {
 		expectedOutputSidecarSet.Annotations = make(map[string]string)
 	}
 	expectedOutputSidecarSet.Annotations[SidecarSetHashAnnotation] = "8f92wdb9w96824dvw54566vx89wcxd6b75cd4ccxbv4zcvbd7fvfffw4v889dcz2"
-	expectedOutputSidecarSet.Annotations[SidecarSetHashWithoutImageAnnotation] = "vz6x4f662ccff44456ff4727dwb54z7f42c8wf94cw629bwbb5876fwc2cw7vz78"
+	expectedOutputSidecarSet.Annotations[SidecarSetHashWithoutImageAnnotation] = "cfd67dc8z844x4f7cd9f7b624x5ddxxd97wdwv45x48z49cx4942w5c8z84v2dzx"
 
 	if err := setHashSidecarSet(sidecarSet); err != nil {
 		t.Errorf("got error %v", err)
@@ -73,5 +73,41 @@ func TestSidecarSetHash(t *testing.T) {
 
 	if !reflect.DeepEqual(expectedOutputSidecarSet, sidecarSet) {
 		t.Errorf("\nexpect:\n%+v\nbut got:\n%+v", expectedOutputSidecarSet, sidecarSet)
+	}
+}
+
+func TestSidecarSetHashWithoutImage(t *testing.T) {
+	hashDemo, err := SidecarSetHashWithoutImage(sidecarSetDemo)
+	if err != nil {
+		t.Errorf("SidecarSetHashWithoutImage got error %v", err)
+	}
+	// change the container image alone won't change the hashWithoutImage value
+	sidecarSet := sidecarSetDemo.DeepCopy()
+	sidecarSet.Spec.Containers[0].Image = "test-image:v2"
+	hashNew, err := SidecarSetHashWithoutImage(sidecarSet)
+	if err != nil {
+		t.Errorf("SidecarSetHashWithoutImage got error %v", err)
+	}
+	if hashNew != hashDemo {
+		t.Errorf("\nexpect:\n%+v\nbut got:\n%+v", hashDemo, hashNew)
+	}
+	// change any of the init container won't change the hashWithoutImage value
+	sidecarSet.Spec.InitContainers[0].Image = "test-init-image:v1"
+	sidecarSet.Spec.InitContainers[0].Command = []string{"sh", "-c", "ls -l"}
+	hashNew, err = SidecarSetHashWithoutImage(sidecarSet)
+	if err != nil {
+		t.Errorf("SidecarSetHashWithoutImage got error %v", err)
+	}
+	if hashNew != hashDemo {
+		t.Errorf("\nexpect:\n%+v\nbut got:\n%+v", hashDemo, hashNew)
+	}
+	// change the other part of container will change the hashWithoutImage value
+	sidecarSet.Spec.Containers[0].WorkingDir = "/tmp"
+	hashNew, err = SidecarSetHashWithoutImage(sidecarSet)
+	if err != nil {
+		t.Errorf("SidecarSetHashWithoutImage got error %v", err)
+	}
+	if hashNew == hashDemo {
+		t.Errorf("\ndon't expect:\n%+v\nbut got:\n%+v", hashDemo, hashNew)
 	}
 }

--- a/pkg/webhook/sidecarset/validating/sidecarset_create_update_handler.go
+++ b/pkg/webhook/sidecarset/validating/sidecarset_create_update_handler.go
@@ -100,6 +100,7 @@ func validateSidecarSetSpec(obj *appsv1alpha1.SidecarSet, fldPath *field.Path) f
 	vols, vErrs := getCoreVolumes(spec.Volumes, fldPath.Child("volumes"))
 	allErrs = append(allErrs, vErrs...)
 	allErrs = append(allErrs, validateContainersForSidecarSet(spec.Containers, vols, fldPath.Child("containers"))...)
+	allErrs = append(allErrs, validateContainersForSidecarSet(spec.InitContainers, vols, fldPath.Child("initContainers"))...)
 
 	return allErrs
 }

--- a/pkg/webhook/sidecarset/validating/sidecarset_validating_test.go
+++ b/pkg/webhook/sidecarset/validating/sidecarset_validating_test.go
@@ -38,6 +38,60 @@ func TestValidateSidecarSet(t *testing.T) {
 				},
 			},
 		},
+		"wrong-init-containers": {
+			ObjectMeta: metav1.ObjectMeta{Name: "test-sidecarset"},
+			Spec: appsv1alpha1.SidecarSetSpec{
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"a": "b"},
+				},
+				Strategy: appsv1alpha1.SidecarSetUpdateStrategy{
+					RollingUpdate: &appsv1alpha1.RollingUpdateSidecarSet{
+						MaxUnavailable: &maxUnavailable,
+					},
+				},
+				InitContainers: []appsv1alpha1.SidecarContainer{
+					{
+						Container: corev1.Container{
+							Name:            "test-initcontainer",
+							Image:           "test-initimage",
+							ImagePullPolicy: corev1.PullIfNotPresent,
+						},
+					},
+				},
+				Containers: []appsv1alpha1.SidecarContainer{
+					{
+						Container: corev1.Container{
+							Name:                     "test-sidecar",
+							Image:                    "test-image",
+							ImagePullPolicy:          corev1.PullIfNotPresent,
+							TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+						},
+					},
+				},
+			},
+		},
+		"wrong-init-containers-only": {
+			ObjectMeta: metav1.ObjectMeta{Name: "test-sidecarset"},
+			Spec: appsv1alpha1.SidecarSetSpec{
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"a": "b"},
+				},
+				Strategy: appsv1alpha1.SidecarSetUpdateStrategy{
+					RollingUpdate: &appsv1alpha1.RollingUpdateSidecarSet{
+						MaxUnavailable: &maxUnavailable,
+					},
+				},
+				InitContainers: []appsv1alpha1.SidecarContainer{
+					{
+						Container: corev1.Container{
+							Name:            "test-initcontainer",
+							Image:           "test-initimage",
+							ImagePullPolicy: corev1.PullIfNotPresent,
+						},
+					},
+				},
+			},
+		},
 		"wrong-containers": {
 			ObjectMeta: metav1.ObjectMeta{Name: "test-sidecarset"},
 			Spec: appsv1alpha1.SidecarSetSpec{


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
Add an initContainer section to the sidecar spec so that users can use it to inject init containers alongside sidecar containers.

### Ⅱ. Does this pull request fix one issue?

Yes, https://github.com/openkruise/kruise/issues/366

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.
Unit tests are added to every code path

### Ⅳ. Describe how to verify it
build and push an image of the new 
```
make docker-build docker-push IMG=nerdyyatrice/kruise:v0.1
helm install kruise charts/kruise/v0.6.0 --set manager.image.repository=nerdyyatrice/kruise,manager.image.tag=v0.1
```

Sidecar example:  config/samples/apps_v1alpha1_sidecarset.yaml 

1. Apply the sidecar with an init container that runs for 5 mins
2. Apply a statefulset
3. Observe that pods are waiting for the init container to finish
4. Change the initContainer runtime to 1 min
5. Observe that no pod changes
6. Expand the statefulSet
7. Observe that the new pods wait for 1 min instead of 5
8. Subtmit a sidecarset with only initContainers
9. Observe that no pod changes
10. Expand the statefulSet and observe that new pods has the init container
11. Add containers back to the sideCarset
12. Change both the command and images of the initContainer and the container image
13. Observe that the new version of the container image is picked up by the exiting pod


### Ⅴ. Special notes for reviews


