### PR TITLE
Fix broken UTs

### DIFF
--- a/pkg/controller/cloneset/cloneset_controller_test.go
+++ b/pkg/controller/cloneset/cloneset_controller_test.go
@@ -312,7 +312,7 @@ func checkInstances(g *gomega.GomegaWithT, cs *appsv1alpha1.CloneSet, podNum int
 		pods, err = clonesetutils.GetActivePods(c, opts)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 		return len(pods)
-	}, time.Second*3, time.Millisecond*500).Should(gomega.Equal(podNum))
+	}, time.Second*10, time.Millisecond*500).Should(gomega.Equal(podNum))
 
 	var pvcs []*v1.PersistentVolumeClaim
 	g.Eventually(func() int {

--- a/pkg/controller/uniteddeployment/uniteddeployment_controller_cloneset_test.go
+++ b/pkg/controller/uniteddeployment/uniteddeployment_controller_cloneset_test.go
@@ -202,6 +202,7 @@ func TestTemplateTypeSwtichToCS(t *testing.T) {
 			},
 		},
 		Spec: appsv1alpha1.CloneSetSpec{
+			Replicas: &one,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"name": caseName,


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

This change fixes to UTs.

1) The cloneset testscale UT will scale from 1 Pod to 5 Pods. The timeout of 3 seconds can be too small for the scaling to complete occasionally. Therefore, this change increases the timeout to 10seconds.

2) In uniteddeployment for cloneset UT,  the TestTemplateTypeSwtichToCS test does not specify the `replica` in CloneSetSpec, which is a required field for cloneset. This change fixes it.

