### PR TITLE
delete useless incrementalAllocate function, and  return if GetAllocatedReplicas false

### DIFF
--- a/pkg/controller/uniteddeployment/allocator.go
+++ b/pkg/controller/uniteddeployment/allocator.go
@@ -57,7 +57,7 @@ func (n subsetInfos) Swap(i, j int) {
 // GetAllocatedReplicas returns a mapping from subset to next replicas.
 // Next replicas is allocated by replicasAllocator, which will consider the current replicas of each subset and
 // new replicas indicated from UnitedDeployment.Spec.Topology.Subsets.
-func GetAllocatedReplicas(nameToSubset *map[string]*Subset, ud *appsv1alpha1.UnitedDeployment) (*map[string]int32, bool, string) {
+func GetAllocatedReplicas(nameToSubset *map[string]*Subset, ud *appsv1alpha1.UnitedDeployment) (*map[string]int32, error) {
 	subsetInfos := getSubsetInfos(nameToSubset, ud)
 	specifiedReplicas := getSpecifiedSubsetReplicas(ud)
 
@@ -74,9 +74,9 @@ type replicasAllocator struct {
 	subsets *subsetInfos
 }
 
-func (s *replicasAllocator) effectiveReplicas(replicas int32, subsetReplicasLimits *map[string]int32) (bool, string) {
+func (s *replicasAllocator) validateReplicas(replicas int32, subsetReplicasLimits *map[string]int32) error {
 	if subsetReplicasLimits == nil {
-		return true, ""
+		return nil
 	}
 
 	var specifiedReplicas int32
@@ -85,7 +85,8 @@ func (s *replicasAllocator) effectiveReplicas(replicas int32, subsetReplicasLimi
 	}
 
 	if specifiedReplicas > replicas {
-		return false, fmt.Sprintf("Specified subsets' replica (%d) is greater than UnitedDeployment replica (%d)", specifiedReplicas, replicas)
+		return fmt.Errorf("Specified subsets' replica (%d) is greater than UnitedDeployment replica (%d)",
+			specifiedReplicas, replicas)
 	} else if specifiedReplicas < replicas {
 		specifiedCount := 0
 		for _, subset := range *s.subsets {
@@ -95,11 +96,12 @@ func (s *replicasAllocator) effectiveReplicas(replicas int32, subsetReplicasLimi
 		}
 
 		if specifiedCount == len(*s.subsets) {
-			return false, fmt.Sprintf("Specified subsets' replica (%d) is less than UnitedDeployment replica (%d)", specifiedReplicas, replicas)
+			return fmt.Errorf("Specified subsets' replica (%d) is less than UnitedDeployment replica (%d)",
+				specifiedReplicas, replicas)
 		}
 	}
 
-	return true, ""
+	return nil
 }
 
 func getSpecifiedSubsetReplicas(ud *appsv1alpha1.UnitedDeployment) *(map[string]int32) {
@@ -137,16 +139,16 @@ func getSubsetInfos(nameToSubset *map[string]*Subset, ud *appsv1alpha1.UnitedDep
 	return &infos
 }
 
-// AllocateReplicas will first try to check the specifiedSubsetReplicas is effective or not.
-// If effective, normalAllocate will be called. It will apply these specified replicas, then average the rest replicas to left unspecified subsets.
-// If not, it will incrementally allocate all of the replicas. The current replicas spread situation will be considered,
-// in order to make the scaling smoothly
-func (s *replicasAllocator) AllocateReplicas(replicas int32, specifiedSubsetReplicas *map[string]int32) (*map[string]int32, bool, string) {
-	if effective, reason := s.effectiveReplicas(replicas, specifiedSubsetReplicas); !effective {
-		return s.incrementalAllocate(replicas), false, reason
+// AllocateReplicas will first try to check the specifiedSubsetReplicas is valid or not.
+// If valid , normalAllocate will be called. It will apply these specified replicas, then average the rest replicas to left unspecified subsets.
+// If not, it will return error
+func (s *replicasAllocator) AllocateReplicas(replicas int32, specifiedSubsetReplicas *map[string]int32) (
+	*map[string]int32, error) {
+	if err := s.validateReplicas(replicas, specifiedSubsetReplicas); err != nil {
+		return nil, err
 	}
 
-	return s.normalAllocate(replicas, specifiedSubsetReplicas), true, ""
+	return s.normalAllocate(replicas, specifiedSubsetReplicas), nil
 }
 
 func (s *replicasAllocator) normalAllocate(expectedReplicas int32, specifiedSubsetReplicas *map[string]int32) *map[string]int32 {
@@ -186,78 +188,6 @@ func (s *replicasAllocator) normalAllocate(expectedReplicas int32, specifiedSubs
 
 			if leftSubsetCount == 0 {
 				break
-			}
-		}
-	}
-
-	return s.toSubsetReplicaMap()
-}
-
-func (s *replicasAllocator) incrementalAllocate(expectedReplicas int32) *map[string]int32 {
-	var currentReplicas int32
-	for _, nts := range *s.subsets {
-		currentReplicas += nts.Replicas
-	}
-
-	consideredLen := len(*s.subsets)
-	diff := expectedReplicas - currentReplicas
-
-	var average int32
-	var reminder int32
-	var i int
-	var leftSubsetsCount int32
-	if diff > 0 {
-		// UnitedDeployment is supposed to scale out replicas.
-		// The policy here is try to allocate the new replicas as even as possible.
-		// But this policy is also try not to affect the subset which has the replicas more than the average.
-		// So it starts from the biggest index subset, which has the most replicas.
-		for i = consideredLen - 1; i >= 0; i-- {
-			// Consider the subsets from index 0 to i
-			leftSubsetsCount = int32(i) + 1
-			average = expectedReplicas / leftSubsetsCount
-			consideredAverage := average
-			reminder = expectedReplicas % leftSubsetsCount
-			if reminder > 0 {
-				consideredAverage++
-			}
-			// If the i th subset, which currently have the most replicas, has more replicas than the average, give up this try.
-			if consideredAverage < s.subsets.Get(i).Replicas {
-				expectedReplicas -= s.subsets.Get(i).Replicas
-				continue
-			}
-			break
-		}
-
-		for j := i; j > -1; j-- {
-			if reminder > 0 {
-				s.subsets.Get(j).Replicas = average + 1
-				reminder--
-			} else {
-				s.subsets.Get(j).Replicas = average
-			}
-		}
-
-	} else if diff < 0 {
-		// Right now, UnitedDeployment is scaling in.
-		// It is also considering to allocate the replicas as average as possible. But this time, it is scaling in,
-		// so the subsets which have the less replicas than the average replicas are not supposed to be bothered.
-		for i = 0; i < consideredLen; i++ {
-			leftSubsetsCount = int32(consideredLen - i)
-			average = expectedReplicas / leftSubsetsCount
-			reminder = expectedReplicas % leftSubsetsCount
-			if average > s.subsets.Get(i).Replicas {
-				expectedReplicas -= s.subsets.Get(i).Replicas
-				continue
-			}
-			break
-		}
-
-		for j := i; j < consideredLen; j++ {
-			if leftSubsetsCount <= reminder {
-				s.subsets.Get(j).Replicas = average + 1
-			} else {
-				s.subsets.Get(j).Replicas = average
-				leftSubsetsCount--
 			}
 		}
 	}


### PR DESCRIPTION



<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

because uniteddeployment webhook has restricted the relationship with Replicas and Subset。

so effectiveReplicas() function always return true.

and incrementalAllocate() function is useless.

so if effectiveReplicas() return false, return this reconcile.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


