### PR TITLE
Optimize 'ApplyRevision' logic in revisionControl

### DIFF
--- a/pkg/controller/cloneset/revision/cloneset_revision.go
+++ b/pkg/controller/cloneset/revision/cloneset_revision.go
@@ -96,7 +96,11 @@ func (c *realControl) getPatch(cs *appsv1alpha1.CloneSet, coreControl clonesetco
 
 func (c *realControl) ApplyRevision(cs *appsv1alpha1.CloneSet, revision *apps.ControllerRevision) (*appsv1alpha1.CloneSet, error) {
 	clone := cs.DeepCopy()
-	patched, err := strategicpatch.StrategicMergePatch([]byte(runtime.EncodeOrDie(patchCodec, clone)), revision.Data.Raw, clone)
+	cloneBytes, err := runtime.Encode(patchCodec, clone)
+	if err != nil {
+		return nil, err
+	}
+	patched, err := strategicpatch.StrategicMergePatch(cloneBytes, revision.Data.Raw, clone)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
it seems not reasonable to cause panic in deployment sync logic and its useless to transform bytes to string and back to bytes


