### PR TITLE
`str` is []byte, it is redundant to convert it to []byte

### DIFF
--- a/pkg/controller/cloneset/revision/cloneset_revision.go
+++ b/pkg/controller/cloneset/revision/cloneset_revision.go
@@ -82,7 +82,7 @@ func (c *realControl) getPatch(cs *appsv1alpha1.CloneSet, coreControl clonesetco
 		return nil, err
 	}
 	var raw map[string]interface{}
-	_ = json.Unmarshal([]byte(str), &raw)
+	_ = json.Unmarshal(str, &raw)
 	objCopy := make(map[string]interface{})
 	specCopy := make(map[string]interface{})
 	spec := raw["spec"].(map[string]interface{})

--- a/pkg/webhook/util/writer/certwriter.go
+++ b/pkg/webhook/util/writer/certwriter.go
@@ -119,7 +119,7 @@ func validCert(certs *generator.Artifacts, dnsName string) bool {
 	if !pool.AppendCertsFromPEM(certs.CACert) {
 		return false
 	}
-	block, _ := pem.Decode([]byte(certs.Cert))
+	block, _ := pem.Decode(certs.Cert)
 	if block == nil {
 		return false
 	}


### PR DESCRIPTION
Signed-off-by: hantmac <hantmac@outlook.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

`str` is []byte, it is redundant to convert it to []byte

