### PR TITLE
Use latest ubuntu LTS image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -mod=vendor -a
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 #FROM gcr.io/distroless/static:nonroot
-FROM ubuntu:latest
+FROM ubuntu:20.04
 WORKDIR /
 COPY --from=builder /workspace/manager .
 ENTRYPOINT ["/manager"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -mod=vendor -a
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 #FROM gcr.io/distroless/static:nonroot
-FROM ubuntu:20.04
+FROM ubuntu:latest
 WORKDIR /
 COPY --from=builder /workspace/manager .
 ENTRYPOINT ["/manager"]

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ generate: controller-gen
 
 # Build the docker image
 docker-build: test
-	docker build . -t ${IMG}
+	docker build --pull --no-cache . -t ${IMG}
 
 # Push the docker image
 docker-push:


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
To follow Dockerfile best practices, pin the manager Dockerfile to explicitly use the latest ubuntu 20.04 LTS image. The current `openkruise/kruise-manager:v0.6.1` image is built on ubuntu 18.04 even though the Dockerfile references `ubuntu:latest`.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
#406 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it
Build the docker image
`docker build . -t openkruise/kruise-manager:test`

Verify the image's output contains `VERSION_ID=20.04`:
`docker run --rm  --entrypoint "/bin/cat"  openkruise/kruise-manager:test /etc/os-release`

### Ⅴ. Special notes for reviews


