### PR TITLE
release ownerRef when pod's labels not macth cloneset's selector

### DIFF
--- a/pkg/controller/cloneset/cloneset_controller_test.go
+++ b/pkg/controller/cloneset/cloneset_controller_test.go
@@ -17,11 +17,14 @@ limitations under the License.
 package cloneset
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 	"time"
 
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/kubernetes/pkg/apis/apps"
 
 	"github.com/onsi/gomega"
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
@@ -37,15 +40,20 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 var c client.Client
 
-var expectedRequest = reconcile.Request{NamespacedName: types.NamespacedName{Name: "foo", Namespace: "default"}}
-
-var images = []string{"nginx:1.9.1", "nginx:1.9.2", "nginx:1.9.3"}
+var (
+	expectedRequest = reconcile.Request{NamespacedName: types.NamespacedName{Name: "foo", Namespace: "default"}}
+	images          = []string{"nginx:1.9.1", "nginx:1.9.2", "nginx:1.9.3"}
+	clonesetUID     = "123"
+	productionLabel = map[string]string{"type": "production"}
+	nilLabel        = map[string]string{}
+)
 
 //const timeout = time.Second * 5
 
@@ -129,6 +137,93 @@ func TestReconcile(t *testing.T) {
 
 	// Test for pods update
 	testUpdate(g, instance)
+}
+
+func TestClaimPods(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	scheme := runtime.NewScheme()
+	appsv1alpha1.AddToScheme(scheme)
+	v1.AddToScheme(scheme)
+
+	instance := &appsv1alpha1.CloneSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: metav1.NamespaceDefault,
+			UID:       types.UID(clonesetUID),
+		},
+		Spec: appsv1alpha1.CloneSetSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: productionLabel},
+		},
+	}
+	appsv1alpha1.SetDefaultsCloneSet(instance)
+
+	type test struct {
+		name    string
+		pods    []*v1.Pod
+		claimed []*v1.Pod
+	}
+	var tests = []test{
+		{
+			name:    "Controller releases claimed pods when selector doesn't match",
+			pods:    []*v1.Pod{newPod("pod1", productionLabel, instance), newPod("pod2", nilLabel, instance)},
+			claimed: []*v1.Pod{newPod("pod1", productionLabel, instance)},
+		},
+		{
+			name:    "Claim pods with correct label",
+			pods:    []*v1.Pod{newPod("pod3", productionLabel, nil), newPod("pod4", nilLabel, nil)},
+			claimed: []*v1.Pod{newPod("pod3", productionLabel, nil)},
+		},
+	}
+
+	for _, test := range tests {
+		initObjs := []runtime.Object{instance}
+		for i := range test.pods {
+			initObjs = append(initObjs, test.pods[i])
+		}
+		fakeClient := fake.NewFakeClientWithScheme(scheme, initObjs...)
+
+		reconciler := &ReconcileCloneSet{
+			Client: fakeClient,
+			scheme: scheme,
+		}
+
+		claimed, err := reconciler.claimPods(instance, test.pods)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		if !reflect.DeepEqual(podToStringSlice(test.claimed), podToStringSlice(claimed)) {
+			t.Errorf("Test case `%s`, claimed wrong pods. Expected %v, got %v", test.name, podToStringSlice(test.claimed), podToStringSlice(claimed))
+		}
+	}
+}
+
+func newPod(podName string, label map[string]string, owner metav1.Object) *v1.Pod {
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Labels:    label,
+			Namespace: metav1.NamespaceDefault,
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:  "test",
+					Image: "foo/bar",
+				},
+			},
+		},
+	}
+	if owner != nil {
+		pod.OwnerReferences = []metav1.OwnerReference{*metav1.NewControllerRef(owner, apps.SchemeGroupVersion.WithKind("Fake"))}
+	}
+	return pod
+}
+
+func podToStringSlice(pods []*v1.Pod) []string {
+	var names []string
+	for _, pod := range pods {
+		names = append(names, pod.Name)
+	}
+	return names
 }
 
 func testScale(g *gomega.GomegaWithT, instance *appsv1alpha1.CloneSet) {


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
If I delete the lable of cloneset's pod,then the label not match the selector of cloneset, it will not delete the pod's ownerRef and create a new pod.
But for the behavior of rs,it will delete ownerRef and create new pod.
so this pr will fix this.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


