### PR TITLE
some adjustment for cloneset update validation

### DIFF
--- a/pkg/webhook/cloneset/validating/validation.go
+++ b/pkg/webhook/cloneset/validating/validation.go
@@ -3,12 +3,12 @@ package validating
 import (
 	"context"
 	"fmt"
-	"reflect"
 
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
 	clonesetcore "github.com/openkruise/kruise/pkg/controller/cloneset/core"
 	"github.com/openkruise/kruise/pkg/util"
 	v1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	unversionedvalidation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
@@ -160,8 +160,9 @@ func (h *CloneSetCreateUpdateHandler) validateCloneSetUpdate(cloneSet, oldCloneS
 	clone.Spec.UpdateStrategy = oldCloneSet.Spec.UpdateStrategy
 	clone.Spec.MinReadySeconds = oldCloneSet.Spec.MinReadySeconds
 	clone.Spec.Lifecycle = oldCloneSet.Spec.Lifecycle
-	if !reflect.DeepEqual(clone.Spec, oldCloneSet.Spec) {
-		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec"), "updates to cloneset spec for fields other than 'replicas', 'template', 'lifecycle', 'scaleStrategy', and 'updateStrategy' are forbidden"))
+	clone.Spec.RevisionHistoryLimit = oldCloneSet.Spec.RevisionHistoryLimit
+	if !apiequality.Semantic.DeepEqual(clone.Spec, oldCloneSet.Spec) {
+		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec"), "updates to cloneset spec for fields other than 'replicas', 'template', 'lifecycle', 'scaleStrategy', 'updateStrategy', 'minReadySeconds' and 'revisionHistoryLimit' are forbidden"))
 	}
 
 	coreControl := clonesetcore.New(cloneSet)

--- a/pkg/webhook/cloneset/validating/validation_test.go
+++ b/pkg/webhook/cloneset/validating/validation_test.go
@@ -160,10 +160,15 @@ func TestValidate(t *testing.T) {
 			},
 		},
 		{
+			// test for all acceptable CloneSetSpec changes
 			spec: &appsv1alpha1.CloneSetSpec{
-				Replicas: &val1,
-				Selector: &metav1.LabelSelector{MatchLabels: validLabels},
-				Template: validPodTemplate.Template,
+				Replicas:             &val1,
+				Selector:             &metav1.LabelSelector{MatchLabels: validLabels},
+				Template:             validPodTemplate.Template,
+				RevisionHistoryLimit: &val1,
+				ScaleStrategy: appsv1alpha1.CloneSetScaleStrategy{
+					PodsToDelete: []string{"p0"},
+				},
 				UpdateStrategy: appsv1alpha1.CloneSetUpdateStrategy{
 					Type:           appsv1alpha1.InPlaceOnlyCloneSetUpdateStrategyType,
 					Partition:      &val2,
@@ -171,11 +176,16 @@ func TestValidate(t *testing.T) {
 				},
 			},
 			oldSpec: &appsv1alpha1.CloneSetSpec{
-				Replicas: &val1,
-				Selector: &metav1.LabelSelector{MatchLabels: validLabels},
-				Template: validPodTemplate1.Template,
+				Replicas:             &val2,
+				Selector:             &metav1.LabelSelector{MatchLabels: validLabels},
+				Template:             validPodTemplate1.Template,
+				RevisionHistoryLimit: &val2,
+				ScaleStrategy: appsv1alpha1.CloneSetScaleStrategy{
+					PodsToDelete: []string{"p1"},
+				},
+
 				UpdateStrategy: appsv1alpha1.CloneSetUpdateStrategy{
-					Type:           appsv1alpha1.InPlaceOnlyCloneSetUpdateStrategyType,
+					Type:           appsv1alpha1.RecreateCloneSetUpdateStrategyType,
 					Partition:      &val2,
 					MaxUnavailable: &intOrStr1,
 				},
@@ -323,30 +333,6 @@ func TestValidate(t *testing.T) {
 			},
 		},
 		"invalid-cloneset-update-1": {
-			spec: &appsv1alpha1.CloneSetSpec{
-				Replicas:             &val1,
-				Selector:             &metav1.LabelSelector{MatchLabels: validLabels},
-				RevisionHistoryLimit: &val2,
-				Template:             validPodTemplate.Template,
-				UpdateStrategy: appsv1alpha1.CloneSetUpdateStrategy{
-					Type:           appsv1alpha1.InPlaceIfPossibleCloneSetUpdateStrategyType,
-					Partition:      &val2,
-					MaxUnavailable: &intOrStr1,
-				},
-			},
-			oldSpec: &appsv1alpha1.CloneSetSpec{
-				Replicas:             &val1,
-				Selector:             &metav1.LabelSelector{MatchLabels: validLabels},
-				RevisionHistoryLimit: &val1,
-				Template:             validPodTemplate.Template,
-				UpdateStrategy: appsv1alpha1.CloneSetUpdateStrategy{
-					Type:           appsv1alpha1.InPlaceIfPossibleCloneSetUpdateStrategyType,
-					Partition:      &val2,
-					MaxUnavailable: &intOrStr1,
-				},
-			},
-		},
-		"invalid-cloneset-update-2": {
 			spec: &appsv1alpha1.CloneSetSpec{
 				Replicas: &val1,
 				Selector: &metav1.LabelSelector{MatchLabels: validLabels},


### PR DESCRIPTION
1. use Semantic.DeepEqual instead of reflect.DeepEqual
2. revisionHistoryLimit should be editable like native deployment
3. complete forbidden hint

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


