### PR TITLE
support secret cert for webhook with vip

### DIFF
--- a/pkg/webhook/util/util.go
+++ b/pkg/webhook/util/util.go
@@ -66,3 +66,7 @@ func GetCertDir() string {
 	}
 	return "/tmp/kruise-webhook-certs"
 }
+
+func GetCertWriter() string {
+	return os.Getenv("WEBHOOK_CERT_WRITER")
+}

--- a/pkg/webhook/util/writer/fs.go
+++ b/pkg/webhook/util/writer/fs.go
@@ -29,6 +29,10 @@ import (
 	"k8s.io/klog"
 )
 
+const (
+	FsCertWriter = "fs"
+)
+
 // fsCertWriter provisions the certificate by reading and writing to the filesystem.
 type fsCertWriter struct {
 	// dnsName is the DNS name that the certificate is for.

--- a/pkg/webhook/util/writer/secret.go
+++ b/pkg/webhook/util/writer/secret.go
@@ -29,6 +29,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const (
+	SecretCertWriter = "secret"
+)
+
 // secretCertWriter provisions the certificate by reading and writing to the k8s secrets.
 type secretCertWriter struct {
 	*SecretCertWriterOptions


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
As discussed in [last PR](https://github.com/openkruise/kruise/pull/430). A new ENV is brought out to offer user a choice to select cert writer.

Now, we can use secretCertWriter with webhook host which is the vip of pods.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


