### PR TITLE
check ownerReference for filtered pods in broadcastjob 

### DIFF
--- a/pkg/controller/broadcastjob/broadcastjob_controller.go
+++ b/pkg/controller/broadcastjob/broadcastjob_controller.go
@@ -189,7 +189,11 @@ func (r *ReconcileBroadcastJob) Reconcile(request reconcile.Request) (reconcile.
 	// convert pod list to a slice of pointers
 	var pods []*corev1.Pod
 	for i := range podList.Items {
-		pods = append(pods, &podList.Items[i])
+		pod := &podList.Items[i]
+		controllerRef := metav1.GetControllerOf(pod)
+		if controllerRef != nil && controllerRef.Kind == job.Kind && controllerRef.UID == job.UID {
+			pods = append(pods, pod)
+		}
 	}
 
 	// Get the map (nodeName -> Pod) for pods with node assigned

--- a/pkg/controller/broadcastjob/broadcastjob_controller_test.go
+++ b/pkg/controller/broadcastjob/broadcastjob_controller_test.go
@@ -605,6 +605,9 @@ func createPod(job1 *appsv1alpha1.BroadcastJob, podName, nodeName string, phase 
 			Name:      podName,
 			Labels:    labelsAsMap(job1),
 			Namespace: "default",
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(job1, appsv1alpha1.SchemeGroupVersion.WithKind("BroadcastJob")),
+			},
 		},
 		Spec: v1.PodSpec{
 			NodeName: nodeName,


### PR DESCRIPTION
check ownerReference for filtered pods in broadcastjob in case there're orphan pods which also meet label requirements

