### PR TITLE
add pod label validation in broadcastjob

### DIFF
--- a/pkg/controller/broadcastjob/broadcastjob_controller.go
+++ b/pkg/controller/broadcastjob/broadcastjob_controller.go
@@ -53,6 +53,11 @@ func init() {
 	flag.IntVar(&concurrentReconciles, "broadcastjob-workers", concurrentReconciles, "Max concurrent workers for BroadCastJob controller.")
 }
 
+const (
+	JobNameLabelKey       = "broadcastjob-name"
+	ControllerUIDLabelKey = "broadcastjob-controller-uid"
+)
+
 var (
 	concurrentReconciles = 3
 	controllerKind       = appsv1alpha1.SchemeGroupVersion.WithKind("BroadcastJob")
@@ -546,8 +551,8 @@ func (r *ReconcileBroadcastJob) getNodeToPodMap(pods []*corev1.Pod, job *appsv1a
 
 func labelsAsMap(job *appsv1alpha1.BroadcastJob) map[string]string {
 	return map[string]string{
-		"job-name":       job.Name,
-		"controller-uid": string(job.UID),
+		JobNameLabelKey:       job.Name,
+		ControllerUIDLabelKey: string(job.UID),
 	}
 }
 

--- a/pkg/controller/broadcastjob/broadcastjob_controller_test.go
+++ b/pkg/controller/broadcastjob/broadcastjob_controller_test.go
@@ -95,7 +95,7 @@ func TestReconcileJobCreatePodAbsolute(t *testing.T) {
 	// 1 new pod created, because parallelism is 2,
 	assert.Equal(t, 2, len(podList.Items))
 	// The new pod has the job-name label
-	assert.Equal(t, "job1", podList.Items[0].Labels["job-name"])
+	assert.Equal(t, "job1", podList.Items[0].Labels[JobNameLabelKey])
 	// 3 desired pods, one for each node
 	assert.Equal(t, int32(3), retrievedJob.Status.Desired)
 	assert.NotNil(t, retrievedJob.Status.StartTime)
@@ -155,7 +155,7 @@ func TestReconcileJobCreatePodPercentage(t *testing.T) {
 	// 1 new pod created, because parallelism is 2,
 	assert.Equal(t, 2, len(podList.Items))
 	// The new pod has the job-name label
-	assert.Equal(t, "job1", podList.Items[0].Labels["job-name"])
+	assert.Equal(t, "job1", podList.Items[0].Labels[JobNameLabelKey])
 	// 3 desired pods, one for each node
 	assert.Equal(t, int32(5), retrievedJob.Status.Desired)
 	assert.NotNil(t, retrievedJob.Status.StartTime)

--- a/pkg/webhook/broadcastjob/validating/broadcastjob_create_update_handler.go
+++ b/pkg/webhook/broadcastjob/validating/broadcastjob_create_update_handler.go
@@ -23,6 +23,7 @@ import (
 	"regexp"
 
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
+	"github.com/openkruise/kruise/pkg/controller/broadcastjob"
 	v1 "k8s.io/api/core/v1"
 	genericvalidation "k8s.io/apimachinery/pkg/api/validation"
 	validationutil "k8s.io/apimachinery/pkg/util/validation"
@@ -94,14 +95,20 @@ func validateBroadcastJobSpec(spec *appsv1alpha1.BroadcastJobSpec, fldPath *fiel
 		allErrs = append(allErrs, field.Invalid(fldPath.Root(), spec.Template, fmt.Sprintf("Convert_v1_PodTemplateSpec_To_core_PodTemplateSpec failed: %v", err)))
 		return allErrs
 	}
-	allErrs = append(allErrs, corevalidation.ValidatePodTemplateSpec(coreTemplate, fldPath.Child("template"))...)
 	if spec.Template.Spec.RestartPolicy != v1.RestartPolicyOnFailure &&
 		spec.Template.Spec.RestartPolicy != v1.RestartPolicyNever {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("template").Child("spec").Child("restartPolicy"),
 			spec.Template.Spec.RestartPolicy,
 			"pod restartPolicy can only be Never or OnFailure"))
 	}
-	return allErrs
+	if spec.Template.Labels != nil {
+		if spec.Template.Labels[broadcastjob.JobNameLabelKey] != "" || spec.Template.Labels[broadcastjob.ControllerUIDLabelKey] != "" {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("template").Child("metadata").Child("labels"),
+				spec.Template.Labels,
+				fmt.Sprintf("\"%s\" and \"%s\" are not allowed to preset in pod labels", broadcastjob.JobNameLabelKey, broadcastjob.ControllerUIDLabelKey)))
+		}
+	}
+	return append(allErrs, corevalidation.ValidatePodTemplateSpec(coreTemplate, fldPath.Child("template"))...)
 }
 
 func convertPodTemplateSpec(template *v1.PodTemplateSpec) (*core.PodTemplateSpec, error) {

--- a/pkg/webhook/broadcastjob/validating/broadcastjob_test.go
+++ b/pkg/webhook/broadcastjob/validating/broadcastjob_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2019 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validating
+
+import (
+	"testing"
+
+	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+var valInt32 int32 = 1
+var valInt64 int64 = 2
+
+func TestValidateBroadcastJobSpec(t *testing.T) {
+	bjSpec1 := &appsv1alpha1.BroadcastJobSpec{
+		Parallelism: nil,
+		Template: v1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					"broadcastjob-name":           "bjtest",
+					"broadcastjob-controller-uid": "1234",
+				},
+			},
+			Spec: v1.PodSpec{
+				RestartPolicy: v1.RestartPolicyAlways,
+			},
+		},
+		CompletionPolicy: appsv1alpha1.CompletionPolicy{
+			Type:                    appsv1alpha1.Never,
+			TTLSecondsAfterFinished: &valInt32,
+			ActiveDeadlineSeconds:   &valInt64,
+		},
+		Paused:        false,
+		FailurePolicy: appsv1alpha1.FailurePolicy{},
+	}
+	fieldErrorList := validateBroadcastJobSpec(bjSpec1, field.NewPath("spec"))
+	assert.NotNil(t, fieldErrorList, nil)
+	assert.Equal(t, fieldErrorList[0].Field, "spec.completionPolicy.ttlSecondsAfterFinished")
+	assert.Equal(t, fieldErrorList[1].Field, "spec.completionPolicy.activeDeadlineSeconds")
+	assert.Equal(t, fieldErrorList[2].Field, "spec.template.spec.restartPolicy")
+	assert.Equal(t, fieldErrorList[3].Field, "spec.template.metadata.labels")
+}


### PR DESCRIPTION
since "job-name" and "controller-uid"  are selector for bj to find related pods,these two labels should not allow to preset, otherwise something may exceed user expectations.