### PR TITLE
add 'k8s.io/code-generator' dependency file

### DIFF
--- a/hack/tools.go
+++ b/hack/tools.go
@@ -1,0 +1,22 @@
+// +build tools
+
+/*
+Copyright 2020 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This package imports things required by build scripts, to force `go mod` to see them as dependencies
+package hack
+
+import _ "k8s.io/code-generator"

--- a/scripts/generate_client.sh
+++ b/scripts/generate_client.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
 
-printf 'package hack\nimport "k8s.io/code-generator"\n' > ./hack/hold.go
 go mod vendor
 retVal=$?
-rm -f ./hack/hold.go
 if [ $retVal -ne 0 ]; then
     exit $retVal
 fi


### PR DESCRIPTION
just like example in offical repo

https://github.com/kubernetes/sample-controller/blob/master/hack/tools.go

add this file to make sure 'k8s.io/code-generator' would not be wiped out by tpying 'go mod tidy'