### PR TITLE
Multi-arch support

### DIFF
--- a/BUILDING_MULTI_ARCH.md
+++ b/BUILDING_MULTI_ARCH.md
@@ -1,0 +1,39 @@
+# BUILDING MULTI-ARCHITECTURE IMAGES
+
+While the test Docker images for OpenKruise can be built by running:
+
+```
+make docker-build
+```
+
+the stable images are build for multiple architectures (and automatically pushed to the repository) by
+
+```
+make docker-multiarch
+```
+
+However, there are several options and requirements for building these images, which are explained here.
+
+## BUILDERS
+
+We use `docker buildx` to build images for multiple architectures. At the moment, this is considered an
+experimental feature by Docker, and as such it requires access to experimental features to be enabled
+in the daemon.json file.
+
+By default, this will use BuildKit and QEMU emulation support to build the image for each architecture
+locally. However, for faster building, it is possible to use native nodes to build each architecture,
+either simple remote Docker instances or a Kubernetes cluster. For information on how to set this up,
+please see the blog article here:
+
+<https://www.docker.com/blog/multi-arch-images/>
+
+And/or the command reference here:
+
+<https://docs.docker.com/engine/reference/commandline/buildx_create/>
+
+## BUILD OPTIONS
+
+### PLATFORMS
+
+The PLATFORMS variable can be set to a comma-separated list of platforms for which images should be
+built when running the multi-arch build. If unset, it defaults to _linux/amd64,linux/arm64,linux/arm_.

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY pkg/ pkg/
 COPY vendor/ vendor/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -mod=vendor -a -o manager main.go
+RUN CGO_ENABLED=0 GO111MODULE=on go build -mod=vendor -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 
 # Image URL to use all building/pushing image targets
 IMG ?= openkruise/kruise-manager:test
+# Platforms to build the image for
+PLATFORMS ?= linux/amd64,linux/arm64,linux/arm
 # Produce CRDs that work for API servers that supports v1beta1 CRD and conversion, requires k8s 1.13 or later.
 CRD_OPTIONS ?= "crd"
 
@@ -65,6 +67,10 @@ docker-build: test
 # Push the docker image
 docker-push:
 	docker push ${IMG}
+
+# Build and push the multiarchitecture docker images and manifest.
+docker-multiarch:
+	docker buildx build --pull --no-cache --platform=$(PLATFORMS) --push . -t $(IMG)
 
 # find or download controller-gen
 # download controller-gen if necessary


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
This PR adds support for building multi-arch images using `docker buildx`, by default including images for the linux/amd64, linux/arm64, and linux/arm platforms.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
Fixes #300 .

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.
No test cases have been added since no code changes were made and tests are run before packaging.

### Ⅳ. Describe how to verify it
This PR can be verified by testing the resulting images in use in a cluster matching their appropriate platforms.

(Of the platforms specified by default, I have personally tested the linux/amd64 and linux/arm images on my local cluster and confirmed that they work correctly; I have not been able to test the linux/arm64 image as I do not have a machine of that architecture.)
