### PR TITLE
Add GetScale/UpdateScale to scalable resources

### DIFF
--- a/apis/apps/v1alpha1/cloneset_types.go
+++ b/apis/apps/v1alpha1/cloneset_types.go
@@ -238,6 +238,8 @@ type CloneSetCondition struct {
 }
 
 // +genclient
+// +genclient:method=GetScale,verb=get,subresource=scale,result=k8s.io/api/autoscaling/v1.Scale
+// +genclient:method=UpdateScale,verb=update,subresource=scale,input=k8s.io/api/autoscaling/v1.Scale,result=k8s.io/api/autoscaling/v1.Scale
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.labelSelector

--- a/apis/apps/v1alpha1/statefulset_types.go
+++ b/apis/apps/v1alpha1/statefulset_types.go
@@ -226,6 +226,8 @@ const (
 )
 
 // +genclient
+// +genclient:method=GetScale,verb=get,subresource=scale,result=k8s.io/api/autoscaling/v1.Scale
+// +genclient:method=UpdateScale,verb=update,subresource=scale,input=k8s.io/api/autoscaling/v1.Scale,result=k8s.io/api/autoscaling/v1.Scale
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.labelSelector

--- a/apis/apps/v1alpha1/uniteddeployment_types.go
+++ b/apis/apps/v1alpha1/uniteddeployment_types.go
@@ -241,6 +241,8 @@ type UpdateStatus struct {
 }
 
 // +genclient
+// +genclient:method=GetScale,verb=get,subresource=scale,result=k8s.io/api/autoscaling/v1.Scale
+// +genclient:method=UpdateScale,verb=update,subresource=scale,input=k8s.io/api/autoscaling/v1.Scale,result=k8s.io/api/autoscaling/v1.Scale
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.selector

--- a/apis/apps/v1beta1/doc.go
+++ b/apis/apps/v1beta1/doc.go
@@ -15,4 +15,5 @@ limitations under the License.
 */
 
 // +groupName=apps.kruise.io
+// +k8s:defaulter-gen=TypeMeta
 package v1beta1

--- a/apis/apps/v1beta1/doc.go
+++ b/apis/apps/v1beta1/doc.go
@@ -15,5 +15,4 @@ limitations under the License.
 */
 
 // +groupName=apps.kruise.io
-// +k8s:defaulter-gen=TypeMeta
 package v1beta1

--- a/apis/apps/v1beta1/statefulset_types.go
+++ b/apis/apps/v1beta1/statefulset_types.go
@@ -235,6 +235,9 @@ const (
 )
 
 // +genclient
+// +genclient:method=GetScale,verb=get,subresource=scale,result=k8s.io/api/autoscaling/v1.Scale
+// +genclient:method=UpdateScale,verb=update,subresource=scale,input=k8s.io/api/autoscaling/v1.Scale,result=k8s.io/api/autoscaling/v1.Scale
+
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.labelSelector

--- a/apis/apps/v1beta1/statefulset_types.go
+++ b/apis/apps/v1beta1/statefulset_types.go
@@ -237,7 +237,6 @@ const (
 // +genclient
 // +genclient:method=GetScale,verb=get,subresource=scale,result=k8s.io/api/autoscaling/v1.Scale
 // +genclient:method=UpdateScale,verb=update,subresource=scale,input=k8s.io/api/autoscaling/v1.Scale,result=k8s.io/api/autoscaling/v1.Scale
-
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.labelSelector

--- a/pkg/client/clientset/versioned/typed/apps/v1alpha1/cloneset.go
+++ b/pkg/client/clientset/versioned/typed/apps/v1alpha1/cloneset.go
@@ -22,6 +22,7 @@ import (
 
 	v1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
 	scheme "github.com/openkruise/kruise/pkg/client/clientset/versioned/scheme"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
@@ -45,6 +46,9 @@ type CloneSetInterface interface {
 	List(opts v1.ListOptions) (*v1alpha1.CloneSetList, error)
 	Watch(opts v1.ListOptions) (watch.Interface, error)
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1alpha1.CloneSet, err error)
+	GetScale(cloneSetName string, options v1.GetOptions) (*autoscalingv1.Scale, error)
+	UpdateScale(cloneSetName string, scale *autoscalingv1.Scale) (*autoscalingv1.Scale, error)
+
 	CloneSetExpansion
 }
 
@@ -184,6 +188,34 @@ func (c *cloneSets) Patch(name string, pt types.PatchType, data []byte, subresou
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
+		Do().
+		Into(result)
+	return
+}
+
+// GetScale takes name of the cloneSet, and returns the corresponding autoscalingv1.Scale object, and an error if there is any.
+func (c *cloneSets) GetScale(cloneSetName string, options v1.GetOptions) (result *autoscalingv1.Scale, err error) {
+	result = &autoscalingv1.Scale{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("clonesets").
+		Name(cloneSetName).
+		SubResource("scale").
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// UpdateScale takes the top resource name and the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if there is any.
+func (c *cloneSets) UpdateScale(cloneSetName string, scale *autoscalingv1.Scale) (result *autoscalingv1.Scale, err error) {
+	result = &autoscalingv1.Scale{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("clonesets").
+		Name(cloneSetName).
+		SubResource("scale").
+		Body(scale).
 		Do().
 		Into(result)
 	return

--- a/pkg/client/clientset/versioned/typed/apps/v1alpha1/fake/fake_cloneset.go
+++ b/pkg/client/clientset/versioned/typed/apps/v1alpha1/fake/fake_cloneset.go
@@ -19,6 +19,7 @@ package fake
 
 import (
 	v1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
@@ -136,4 +137,26 @@ func (c *FakeCloneSets) Patch(name string, pt types.PatchType, data []byte, subr
 		return nil, err
 	}
 	return obj.(*v1alpha1.CloneSet), err
+}
+
+// GetScale takes name of the cloneSet, and returns the corresponding scale object, and an error if there is any.
+func (c *FakeCloneSets) GetScale(cloneSetName string, options v1.GetOptions) (result *autoscalingv1.Scale, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewGetSubresourceAction(clonesetsResource, c.ns, "scale", cloneSetName), &autoscalingv1.Scale{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*autoscalingv1.Scale), err
+}
+
+// UpdateScale takes the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if there is any.
+func (c *FakeCloneSets) UpdateScale(cloneSetName string, scale *autoscalingv1.Scale) (result *autoscalingv1.Scale, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(clonesetsResource, "scale", c.ns, scale), &autoscalingv1.Scale{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*autoscalingv1.Scale), err
 }

--- a/pkg/client/clientset/versioned/typed/apps/v1alpha1/fake/fake_statefulset.go
+++ b/pkg/client/clientset/versioned/typed/apps/v1alpha1/fake/fake_statefulset.go
@@ -19,6 +19,7 @@ package fake
 
 import (
 	v1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
@@ -136,4 +137,26 @@ func (c *FakeStatefulSets) Patch(name string, pt types.PatchType, data []byte, s
 		return nil, err
 	}
 	return obj.(*v1alpha1.StatefulSet), err
+}
+
+// GetScale takes name of the statefulSet, and returns the corresponding scale object, and an error if there is any.
+func (c *FakeStatefulSets) GetScale(statefulSetName string, options v1.GetOptions) (result *autoscalingv1.Scale, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewGetSubresourceAction(statefulsetsResource, c.ns, "scale", statefulSetName), &autoscalingv1.Scale{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*autoscalingv1.Scale), err
+}
+
+// UpdateScale takes the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if there is any.
+func (c *FakeStatefulSets) UpdateScale(statefulSetName string, scale *autoscalingv1.Scale) (result *autoscalingv1.Scale, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(statefulsetsResource, "scale", c.ns, scale), &autoscalingv1.Scale{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*autoscalingv1.Scale), err
 }

--- a/pkg/client/clientset/versioned/typed/apps/v1alpha1/fake/fake_uniteddeployment.go
+++ b/pkg/client/clientset/versioned/typed/apps/v1alpha1/fake/fake_uniteddeployment.go
@@ -19,6 +19,7 @@ package fake
 
 import (
 	v1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
@@ -136,4 +137,26 @@ func (c *FakeUnitedDeployments) Patch(name string, pt types.PatchType, data []by
 		return nil, err
 	}
 	return obj.(*v1alpha1.UnitedDeployment), err
+}
+
+// GetScale takes name of the unitedDeployment, and returns the corresponding scale object, and an error if there is any.
+func (c *FakeUnitedDeployments) GetScale(unitedDeploymentName string, options v1.GetOptions) (result *autoscalingv1.Scale, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewGetSubresourceAction(uniteddeploymentsResource, c.ns, "scale", unitedDeploymentName), &autoscalingv1.Scale{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*autoscalingv1.Scale), err
+}
+
+// UpdateScale takes the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if there is any.
+func (c *FakeUnitedDeployments) UpdateScale(unitedDeploymentName string, scale *autoscalingv1.Scale) (result *autoscalingv1.Scale, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(uniteddeploymentsResource, "scale", c.ns, scale), &autoscalingv1.Scale{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*autoscalingv1.Scale), err
 }

--- a/pkg/client/clientset/versioned/typed/apps/v1alpha1/statefulset.go
+++ b/pkg/client/clientset/versioned/typed/apps/v1alpha1/statefulset.go
@@ -22,6 +22,7 @@ import (
 
 	v1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
 	scheme "github.com/openkruise/kruise/pkg/client/clientset/versioned/scheme"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
@@ -45,6 +46,9 @@ type StatefulSetInterface interface {
 	List(opts v1.ListOptions) (*v1alpha1.StatefulSetList, error)
 	Watch(opts v1.ListOptions) (watch.Interface, error)
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1alpha1.StatefulSet, err error)
+	GetScale(statefulSetName string, options v1.GetOptions) (*autoscalingv1.Scale, error)
+	UpdateScale(statefulSetName string, scale *autoscalingv1.Scale) (*autoscalingv1.Scale, error)
+
 	StatefulSetExpansion
 }
 
@@ -184,6 +188,34 @@ func (c *statefulSets) Patch(name string, pt types.PatchType, data []byte, subre
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
+		Do().
+		Into(result)
+	return
+}
+
+// GetScale takes name of the statefulSet, and returns the corresponding autoscalingv1.Scale object, and an error if there is any.
+func (c *statefulSets) GetScale(statefulSetName string, options v1.GetOptions) (result *autoscalingv1.Scale, err error) {
+	result = &autoscalingv1.Scale{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("statefulsets").
+		Name(statefulSetName).
+		SubResource("scale").
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// UpdateScale takes the top resource name and the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if there is any.
+func (c *statefulSets) UpdateScale(statefulSetName string, scale *autoscalingv1.Scale) (result *autoscalingv1.Scale, err error) {
+	result = &autoscalingv1.Scale{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("statefulsets").
+		Name(statefulSetName).
+		SubResource("scale").
+		Body(scale).
 		Do().
 		Into(result)
 	return

--- a/pkg/client/clientset/versioned/typed/apps/v1beta1/fake/fake_statefulset.go
+++ b/pkg/client/clientset/versioned/typed/apps/v1beta1/fake/fake_statefulset.go
@@ -19,6 +19,7 @@ package fake
 
 import (
 	v1beta1 "github.com/openkruise/kruise/apis/apps/v1beta1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
@@ -136,4 +137,26 @@ func (c *FakeStatefulSets) Patch(name string, pt types.PatchType, data []byte, s
 		return nil, err
 	}
 	return obj.(*v1beta1.StatefulSet), err
+}
+
+// GetScale takes name of the statefulSet, and returns the corresponding scale object, and an error if there is any.
+func (c *FakeStatefulSets) GetScale(statefulSetName string, options v1.GetOptions) (result *autoscalingv1.Scale, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewGetSubresourceAction(statefulsetsResource, c.ns, "scale", statefulSetName), &autoscalingv1.Scale{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*autoscalingv1.Scale), err
+}
+
+// UpdateScale takes the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if there is any.
+func (c *FakeStatefulSets) UpdateScale(statefulSetName string, scale *autoscalingv1.Scale) (result *autoscalingv1.Scale, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(statefulsetsResource, "scale", c.ns, scale), &autoscalingv1.Scale{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*autoscalingv1.Scale), err
 }

--- a/pkg/client/clientset/versioned/typed/apps/v1beta1/statefulset.go
+++ b/pkg/client/clientset/versioned/typed/apps/v1beta1/statefulset.go
@@ -22,6 +22,7 @@ import (
 
 	v1beta1 "github.com/openkruise/kruise/apis/apps/v1beta1"
 	scheme "github.com/openkruise/kruise/pkg/client/clientset/versioned/scheme"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
@@ -45,6 +46,9 @@ type StatefulSetInterface interface {
 	List(opts v1.ListOptions) (*v1beta1.StatefulSetList, error)
 	Watch(opts v1.ListOptions) (watch.Interface, error)
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta1.StatefulSet, err error)
+	GetScale(statefulSetName string, options v1.GetOptions) (*autoscalingv1.Scale, error)
+	UpdateScale(statefulSetName string, scale *autoscalingv1.Scale) (*autoscalingv1.Scale, error)
+
 	StatefulSetExpansion
 }
 
@@ -184,6 +188,34 @@ func (c *statefulSets) Patch(name string, pt types.PatchType, data []byte, subre
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
+		Do().
+		Into(result)
+	return
+}
+
+// GetScale takes name of the statefulSet, and returns the corresponding autoscalingv1.Scale object, and an error if there is any.
+func (c *statefulSets) GetScale(statefulSetName string, options v1.GetOptions) (result *autoscalingv1.Scale, err error) {
+	result = &autoscalingv1.Scale{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("statefulsets").
+		Name(statefulSetName).
+		SubResource("scale").
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// UpdateScale takes the top resource name and the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if there is any.
+func (c *statefulSets) UpdateScale(statefulSetName string, scale *autoscalingv1.Scale) (result *autoscalingv1.Scale, err error) {
+	result = &autoscalingv1.Scale{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("statefulsets").
+		Name(statefulSetName).
+		SubResource("scale").
+		Body(scale).
 		Do().
 		Into(result)
 	return


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Add `GetScale`/`UpdateScale` to scalable resources. These verbs for clientSet maybe useful some day, espacially for [HPA](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/autoscaling/horizontal-pod-autoscaler.md#scale-subresource). These two interfaces are also implemented by the clientSet of built-in resources in k8s, such as [statefulSet](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/statefulset.go#L51-L52).

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.
This PR only add `GetScale`/`UpdateScaleverbs` to generated clientSet , won't bring any side effects.

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


