### PR TITLE
bcj add PodFitsResources predicates

### DIFF
--- a/pkg/controller/broadcastjob/broadcastjob_controller_test.go
+++ b/pkg/controller/broadcastjob/broadcastjob_controller_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -578,6 +579,11 @@ func createNode(nodeName string) *v1.Node {
 	node3 := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: nodeName,
+		},
+		Status: v1.NodeStatus{
+			Allocatable: v1.ResourceList{
+				"pods": resource.MustParse("10"),
+			},
 		},
 	}
 	return node3


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
In this case, it is found that the Pod of BroadcastJob is assigned to a node, and then due to Kubelet's insufficient resources in executing predicate, the POD is always in the state of failed, and when Kubelet's resources are enough, the POD state is still in the state of Failed

```
NAME                                    READY   STATUS                     RESTARTS   AGE
broadcastjob-update-host-4ns4j          0/1     Completed                  0          5h1m
broadcastjob-update-host-5ph6p          0/1     Completed                  0          9m35s
broadcastjob-update-host-657mz          0/1     Completed                  0          29d
broadcastjob-update-host-6kp5p          0/1     UnexpecteAdmissionError    0          10m
broadcastjob-update-host-8pnk2          0/1     Completed                  0          10m
```
PodFitsResources checks if a node has sufficient resources, such as cpu, memory, gpu, opaque int resources etc to run a pod.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


