### PR TITLE
adopt matching pods

### DIFF
--- a/pkg/controller/cloneset/cloneset_controller.go
+++ b/pkg/controller/cloneset/cloneset_controller.go
@@ -229,6 +229,9 @@ func (r *ReconcileCloneSet) doReconcile(request reconcile.Request) (res reconcil
 	// list all pods to include the pods that don't match the cs`s selector
 	// anymore but has the stale controller ref.
 	filteredPods, err := r.getAllActivePodsInNamespace(instance)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
 
 	filteredPods, err = r.claimPods(instance, filteredPods)
 	if err != nil {

--- a/pkg/controller/cloneset/cloneset_controller.go
+++ b/pkg/controller/cloneset/cloneset_controller.go
@@ -538,7 +538,7 @@ func (r *ReconcileCloneSet) claimPods(instance *appsv1alpha1.CloneSet, pods []*v
 
 func (r *ReconcileCloneSet) getAllActivePodsInNamespace(cs *appsv1alpha1.CloneSet) ([]*v1.Pod, error) {
 	opts := &client.ListOptions{
-		Namespace:     cs.Namespace,
+		Namespace: cs.Namespace,
 	}
 
 	filteredPods, err := clonesetutils.GetActivePodsInCache(r.Client, opts)

--- a/pkg/controller/cloneset/cloneset_controller_test.go
+++ b/pkg/controller/cloneset/cloneset_controller_test.go
@@ -143,8 +143,10 @@ func TestClaimPods(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	scheme := runtime.NewScheme()
-	appsv1alpha1.AddToScheme(scheme)
-	v1.AddToScheme(scheme)
+	err := appsv1alpha1.AddToScheme(scheme)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	err = v1.AddToScheme(scheme)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
 
 	instance := &appsv1alpha1.CloneSet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -159,14 +161,14 @@ func TestClaimPods(t *testing.T) {
 	appsv1alpha1.SetDefaultsCloneSet(instance)
 
 	type test struct {
-		name    string
-		pods    []*v1.Pod
+		name              string
+		pods              []*v1.Pod
 		released, adopted []string
 	}
 	var tests = []test{
 		{
-			name:    "pods owned by cloneSet are released during claiming when selector doesn't match",
-			pods:    []*v1.Pod{newPod("pod1", productionLabel, instance, scheme), newPod("pod2", nilLabel, instance, scheme)},
+			name:     "pods owned by cloneSet are released during claiming when selector doesn't match",
+			pods:     []*v1.Pod{newPod("pod1", productionLabel, instance, scheme), newPod("pod2", nilLabel, instance, scheme)},
 			released: []string{"pod2"},
 		},
 		{
@@ -216,7 +218,7 @@ func TestClaimPods(t *testing.T) {
 			g.Expect(releasedPod.GetOwnerReferences()).To(gomega.HaveLen(0))
 		}
 
-		// before claiming, adopted pods are owned by cloneSet
+		// after claiming, adopted pods are owned by cloneSet
 		for _, r := range test.adopted {
 			adoptedPod := &v1.Pod{}
 			err := fakeClient.Get(context.TODO(), types.NamespacedName{Namespace: metav1.NamespaceDefault, Name: r}, adoptedPod)

--- a/pkg/controller/cloneset/utils/cloneset_utils.go
+++ b/pkg/controller/cloneset/utils/cloneset_utils.go
@@ -56,6 +56,21 @@ func GetActivePods(reader client.Reader, opts *client.ListOptions) ([]*v1.Pod, e
 	}
 
 	// Ignore inactive pods
+	return filterActivePods(podList), nil
+}
+
+// GetActivePodsInCache returns all active pods in cache which match opts.
+func GetActivePodsInCache(cl client.Client, opts *client.ListOptions) ([]*v1.Pod, error) {
+	podList := &v1.PodList{}
+	if err := cl.List(context.TODO(), podList, opts); err != nil {
+		return nil, err
+	}
+
+	// Ignore inactive pods
+	return filterActivePods(podList), nil
+}
+
+func filterActivePods(podList *v1.PodList) []*v1.Pod {
 	var activePods []*v1.Pod
 	for i, pod := range podList.Items {
 		// Consider all rebuild pod as active pod, should not recreate
@@ -63,7 +78,7 @@ func GetActivePods(reader client.Reader, opts *client.ListOptions) ([]*v1.Pod, e
 			activePods = append(activePods, &podList.Items[i])
 		}
 	}
-	return activePods, nil
+	return activePods
 }
 
 // GetPodRevision returns revision hash of this pod.


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
This PR fixed an issue that once a pod without an owner matches the label selector of a cloneSet, it is not adopted by the cloneSet. Which does not match the behavior of a Deployment/ReplicaSet

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.
Improved the test case `TestClaimPods`

### Ⅳ. Describe how to verify it
1. remove a label (a label which has impact on selector) of a pod owned by a cloneSet
2. check that the pod is released (has no owner)
3. add the label back
4. check that the pod is adopted by the origin cloneSet (has the same owner again)

### Ⅴ. Special notes for reviews

