### PR TITLE
Fix script for old bash version

### DIFF
--- a/scripts/check_go_version
+++ b/scripts/check_go_version
@@ -64,9 +64,9 @@ check_at_least_version() {
 
     # Compare versions
     VERS_LEAST="$PROG_NAME version '$CUR_VERS' should be at least '$MIN_VERS'"
-    test "$CUR_MAJ" -gt $(("$MIN_MAJ" - 1)) || die_upgrade "$VERS_LEAST"
+    test "$CUR_MAJ" -gt $(expr "$MIN_MAJ" - 1) || die_upgrade "$VERS_LEAST"
     test "$CUR_MAJ" -gt "$MIN_MAJ" || {
-        test "$CUR_MIN" -gt $(("$MIN_MIN" - 1)) || die_upgrade "$VERS_LEAST"
+        test "$CUR_MIN" -gt $(expr "$MIN_MIN" - 1) || die_upgrade "$VERS_LEAST"
         test "$CUR_MIN" -gt "$MIN_MIN" || {
             test "$CUR_FIX" -ge "$MIN_FIX" || die_upgrade "$VERS_LEAST"
         }


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

It is unfortunate that MAC installs a 10 years old version 3.2 bash as default due to some license issues. We should not force users to update bash in order to run `make`. 

This change reverts the check_go_version script to previous version in order to make the script work in default MAC environment.
