### PR TITLE
cloneset add currentRerevision

### DIFF
--- a/apis/apps/v1alpha1/cloneset_types.go
+++ b/apis/apps/v1alpha1/cloneset_types.go
@@ -201,6 +201,9 @@ type CloneSetStatus struct {
 	// UpdateRevision, if not empty, indicates the latest revision of the CloneSet.
 	UpdateRevision string `json:"updateRevision,omitempty"`
 
+	// currentRevision, if not empty, indicates the current revision version of the CloneSet.
+	CurrentRevision string `json:"currentRevision,omitempty"`
+
 	// CollisionCount is the count of hash collisions for the CloneSet. The CloneSet controller
 	// uses this field as a collision avoidance mechanism when it needs to create the name for the
 	// newest ControllerRevision.

--- a/config/crd/bases/apps.kruise.io_clonesets.yaml
+++ b/config/crd/bases/apps.kruise.io_clonesets.yaml
@@ -403,6 +403,10 @@ spec:
                 - type
                 type: object
               type: array
+            currentRevision:
+              description: currentRevision, if not empty, indicates the current revision
+                version of the CloneSet.
+              type: string
             labelSelector:
               description: LabelSelector is label selectors for query over pods that
                 should match the replica count used by HPA.

--- a/pkg/controller/cloneset/cloneset_controller.go
+++ b/pkg/controller/cloneset/cloneset_controller.go
@@ -272,6 +272,7 @@ func (r *ReconcileCloneSet) doReconcile(request reconcile.Request) (res reconcil
 
 	newStatus := appsv1alpha1.CloneSetStatus{
 		ObservedGeneration: instance.Generation,
+		CurrentRevision:    currentRevision.Name,
 		UpdateRevision:     updateRevision.Name,
 		CollisionCount:     new(int32),
 		LabelSelector:      selector.String(),
@@ -400,12 +401,8 @@ func (r *ReconcileCloneSet) getActiveRevisions(cs *appsv1alpha1.CloneSet, revisi
 
 	// attempt to find the revision that corresponds to the current revision
 	for i := range revisions {
-		if revisions[i].Name == updateRevision.Name {
-			continue
-		}
-		if podsRevisions.Has(revisions[i].Name) {
+		if revisions[i].Name == cs.Status.CurrentRevision {
 			currentRevision = revisions[i]
-			break
 		}
 	}
 

--- a/pkg/controller/cloneset/cloneset_status.go
+++ b/pkg/controller/cloneset/cloneset_status.go
@@ -45,8 +45,8 @@ type realStatusUpdater struct {
 func (r *realStatusUpdater) UpdateCloneSetStatus(cs *appsv1alpha1.CloneSet, newStatus *appsv1alpha1.CloneSetStatus, pods []*v1.Pod) error {
 	r.calculateStatus(cs, newStatus, pods)
 	if r.inconsistentStatus(cs, newStatus) {
-		klog.Infof("To update CloneSet status for  %s/%s, replicas=%d ready=%d available=%d updated=%d updatedReady=%d, revisions update=%s",
-			cs.Namespace, cs.Name, newStatus.Replicas, newStatus.ReadyReplicas, newStatus.AvailableReplicas, newStatus.UpdatedReplicas, newStatus.UpdatedReadyReplicas, newStatus.UpdateRevision)
+		klog.Infof("To update CloneSet status for  %s/%s, replicas=%d ready=%d available=%d updated=%d updatedReady=%d, revisions current=%s update=%s",
+			cs.Namespace, cs.Name, newStatus.Replicas, newStatus.ReadyReplicas, newStatus.AvailableReplicas, newStatus.UpdatedReplicas, newStatus.UpdatedReadyReplicas, newStatus.CurrentRevision, newStatus.UpdateRevision)
 		if err := r.updateStatus(cs, newStatus); err != nil {
 			return err
 		}
@@ -76,6 +76,7 @@ func (r *realStatusUpdater) inconsistentStatus(cs *appsv1alpha1.CloneSet, newSta
 		newStatus.UpdatedReadyReplicas != oldStatus.UpdatedReadyReplicas ||
 		newStatus.UpdatedReplicas != oldStatus.UpdatedReplicas ||
 		newStatus.UpdateRevision != oldStatus.UpdateRevision ||
+		newStatus.CurrentRevision != oldStatus.CurrentRevision ||
 		newStatus.LabelSelector != oldStatus.LabelSelector
 }
 


### PR DESCRIPTION
Signed-off-by: JunjunLi <junjunli666@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

cloneset add status revision

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

cloneset add currentRerevision

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it

```
zhoushua@B-H3KJLVDL-0114 k8s % kubectl get pod --show-labels
NAME                    READY   STATUS    RESTARTS   AGE     LABELS
guestbook-clone-5jmwt   1/1     Running   1          6m51s   app.kubernetes.io/name=guestbook-clone,apps.kruise.io/cloneset-instance-id=5jmwt,controller-revision-hash=guestbook-clone-64598d67b,lifecycle.apps.kruise.io/state=Normal
guestbook-clone-6wzgw   1/1     Running   2          6m51s   app.kubernetes.io/name=guestbook-clone,apps.kruise.io/cloneset-instance-id=6wzgw,controller-revision-hash=guestbook-clone-5c98948d5d,lifecycle.apps.kruise.io/state=Normal
guestbook-clone-jvdxg   1/1     Running   0          6m51s   app.kubernetes.io/name=guestbook-clone,apps.kruise.io/cloneset-instance-id=jvdxg,controller-revision-hash=guestbook-clone-56dfcdfff9,lifecycle.apps.kruise.io/state=Normal
guestbook-clone-kvgj8   1/1     Running   0          6m51s   app.kubernetes.io/name=guestbook-clone,apps.kruise.io/cloneset-instance-id=kvgj8,controller-revision-hash=guestbook-clone-56dfcdfff9,lifecycle.apps.kruise.io/state=Normal
guestbook-clone-n42sp   1/1     Running   0          6m51s   app.kubernetes.io/name=guestbook-clone,apps.kruise.io/cloneset-instance-id=n42sp,controller-revision-hash=guestbook-clone-56dfcdfff9,lifecycle.apps.kruise.io/state=Normal
guestbook-clone-q9lp4   1/1     Running   2          6m51s   app.kubernetes.io/name=guestbook-clone,apps.kruise.io/cloneset-instance-id=q9lp4,controller-revision-hash=guestbook-clone-5c98948d5d,lifecycle.apps.kruise.io/state=Normal
```


```
status:
  availableReplicas: 6
  collisionCount: 0
  currentRevision: guestbook-clone-56dfcdfff9
  labelSelector: app.kubernetes.io/name=guestbook-clone
  observedGeneration: 4
  readyReplicas: 6
  replicas: 6
  updateRevision: guestbook-clone-5c98948d5d
  updatedReadyReplicas: 2
  updatedReplicas: 2
```


### Ⅴ. Special notes for reviews


