### PR TITLE
cloneset add inplaceUpdate count in pod annotations

### DIFF
--- a/apis/apps/pub/inplace_update.go
+++ b/apis/apps/pub/inplace_update.go
@@ -35,6 +35,12 @@ const (
 	// InPlaceUpdateGraceKey records the spec that Pod should be updated when
 	// grace period ends.
 	InPlaceUpdateGraceKey string = "inplace-update-grace"
+
+	// InPlaceUpdating like a lock to mark InPlaceUpdating state.
+	InPlaceUpdating string = "inplace-updateing"
+
+	// InPlaceUpdateCount records the count of inplace-update.
+	InPlaceUpdateCount string = "inplace-update-count"
 )
 
 // InPlaceUpdateState records latest inplace-update state, including old statuses of containers.

--- a/pkg/controller/cloneset/update/cloneset_update.go
+++ b/pkg/controller/cloneset/update/cloneset_update.go
@@ -150,7 +150,7 @@ func (c *realControl) refreshPodState(cs *appsv1alpha1.CloneSet, coreControl clo
 		if opts != nil && opts.CustomizeCheckUpdateCompleted != nil {
 			checkFunc = opts.CustomizeCheckUpdateCompleted
 		}
-		if checkFunc(pod) == nil {
+		if _, err := checkFunc(pod); err == nil {
 			if cs.Spec.Lifecycle != nil && !lifecycle.IsPodHooked(cs.Spec.Lifecycle.InPlaceUpdate, pod) {
 				state = appspub.LifecycleStateUpdated
 			} else {
@@ -282,8 +282,10 @@ func (c *realControl) updatePod(cs *appsv1alpha1.CloneSet, coreControl clonesetc
 			res := c.inplaceControl.Update(pod, oldRevision, updateRevision, opts)
 			if res.InPlaceUpdate {
 				if res.UpdateErr == nil {
-					c.recorder.Eventf(cs, v1.EventTypeNormal, "SuccessfulUpdatePodInPlace", "successfully update pod %s in-place(revision %v)", pod.Name, updateRevision.Name)
-					clonesetutils.UpdateExpectations.ExpectUpdated(clonesetutils.GetControllerKey(cs), updateRevision.Name, pod)
+					if res.InPlaceUpdating == false {
+						c.recorder.Eventf(cs, v1.EventTypeNormal, "SuccessfulUpdatePodInPlace", "successfully update pod %s in-place(revision %v)", pod.Name, updateRevision.Name)
+						clonesetutils.UpdateExpectations.ExpectUpdated(clonesetutils.GetControllerKey(cs), updateRevision.Name, pod)
+					}
 					return res.DelayDuration, nil
 				}
 

--- a/pkg/controller/cloneset/update/cloneset_update_test.go
+++ b/pkg/controller/cloneset/update/cloneset_update_test.go
@@ -286,7 +286,7 @@ func TestMange(t *testing.T) {
 							appsv1alpha1.CloneSetInstanceID:     "id-0",
 							appspub.LifecycleStateKey:           string(appspub.LifecycleStateUpdating),
 						},
-						Annotations: map[string]string{appspub.InPlaceUpdateStateKey: util.DumpJSON(appspub.InPlaceUpdateState{
+						Annotations: map[string]string{appspub.InPlaceUpdating: "true", appspub.InPlaceUpdateStateKey: util.DumpJSON(appspub.InPlaceUpdateState{
 							Revision:              "rev-new",
 							UpdateTimestamp:       now,
 							LastContainerStatuses: map[string]appspub.InPlaceUpdateContainerStatus{"c1": {ImageID: "image-id-xyz"}},
@@ -368,6 +368,7 @@ func TestMange(t *testing.T) {
 								UpdateTimestamp:       now,
 								LastContainerStatuses: map[string]appspub.InPlaceUpdateContainerStatus{"c1": {ImageID: "image-id-xyz"}},
 							}),
+							appspub.InPlaceUpdating:       "true",
 							appspub.InPlaceUpdateGraceKey: `{"revision":"rev-new","containerImages":{"c1":"foo2"},"graceSeconds":3630}`,
 						},
 						ResourceVersion: "2",

--- a/pkg/controller/statefulset/stateful_set_control.go
+++ b/pkg/controller/statefulset/stateful_set_control.go
@@ -640,7 +640,7 @@ func (ssc *defaultStatefulSetControl) updateStatefulSet(
 
 		if getPodRevision(replicas[target]) != updateRevision.Name || !isHealthy(replicas[target]) {
 			unavailablePods = append(unavailablePods, replicas[target].Name)
-		} else if completedErr := inplaceupdate.CheckInPlaceUpdateCompleted(
+		} else if _, completedErr := inplaceupdate.CheckInPlaceUpdateCompleted(
 			replicas[target]); completedErr != nil {
 			klog.V(4).Infof("StatefulSet %s/%s check Pod %s in-place update not-ready: %v",
 				set.Namespace,

--- a/pkg/util/inplaceupdate/inplace_utils_test.go
+++ b/pkg/util/inplaceupdate/inplace_utils_test.go
@@ -211,12 +211,12 @@ func TestCheckInPlaceUpdateCompleted(t *testing.T) {
 	}
 
 	for _, p := range succeedPods {
-		if err := CheckInPlaceUpdateCompleted(p); err != nil {
+		if _, err := CheckInPlaceUpdateCompleted(p); err != nil {
 			t.Errorf("pod %s expected check success, got %v", p.Name, err)
 		}
 	}
 	for _, p := range failPods {
-		if err := CheckInPlaceUpdateCompleted(p); err == nil {
+		if _, err := CheckInPlaceUpdateCompleted(p); err == nil {
 			t.Errorf("pod %s expected check failure, got no error", p.Name)
 		}
 	}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
In the pod's containerStatuses, the restartCount calc with normal restart and inplaceUpdate. 
So I put inplaceUpdateCount to pod annotation to distinguish it.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


