### PR TITLE
Fix revision label when collision

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,6 @@ bin
 *.swp
 *.swo
 *~
+.vscode
 
 .DS_Store

--- a/pkg/controller/uniteddeployment/revision.go
+++ b/pkg/controller/uniteddeployment/revision.go
@@ -187,6 +187,7 @@ func (r *ReconcileUnitedDeployment) createControllerRevision(parent metav1.Objec
 		hash := history.HashControllerRevision(revision, collisionCount)
 		// Update the revisions name
 		clone.Name = history.ControllerRevisionName(parent.GetName(), hash)
+		clone.Labels[history.ControllerRevisionHashLabel] = hash
 		err = r.Client.Create(context.TODO(), clone)
 		if errors.IsAlreadyExists(err) {
 			exists := &apps.ControllerRevision{}


### PR DESCRIPTION
Signed-off-by: LeoLiuYan <929908264@qq.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Use `**collisionCount++` to calculate the hash value of `controllerRevision` if there is a collision happen,  and we should change the hash label of that `controllerRevision` object.

### Ⅱ. Does this pull request fix one issue?


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


