### PR TITLE
the default sidecarset updateStrategy is set to RollingUpdate

### DIFF
--- a/apis/apps/v1alpha1/sidecarset_types.go
+++ b/apis/apps/v1alpha1/sidecarset_types.go
@@ -108,7 +108,8 @@ type SidecarContainerUpgradeStrategy struct {
 type SidecarSetUpdateStrategy struct {
 	// Type is NotUpdate, the SidecarSet don't update the injected pods,
 	// it will only inject sidecar container into the newly created pods.
-	// Type is RollingUpdate, the SidecarSet will update the injected pods to the latest version on RollingUpdate Strategy
+	// Type is RollingUpdate, the SidecarSet will update the injected pods to the latest version on RollingUpdate Strategy.
+	// default is RollingUpdate
 	Type SidecarSetUpdateStrategyType `json:"type,omitempty"`
 
 	// Paused indicates that the SidecarSet is paused to update the injected pods,

--- a/config/crd/bases/apps.kruise.io_sidecarsets.yaml
+++ b/config/crd/bases/apps.kruise.io_sidecarsets.yaml
@@ -288,7 +288,7 @@ spec:
                     injected pods, it will only inject sidecar container into the
                     newly created pods. Type is RollingUpdate, the SidecarSet will
                     update the injected pods to the latest version on RollingUpdate
-                    Strategy
+                    Strategy. default is RollingUpdate
                   type: string
               type: object
             volumes:

--- a/pkg/controller/sidecarset/sidecarset_processor_test.go
+++ b/pkg/controller/sidecarset/sidecarset_processor_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/openkruise/kruise/pkg/util/expectations"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -262,6 +263,11 @@ func TestScopeNamespacePods(t *testing.T) {
 
 func TestCanUpgradePods(t *testing.T) {
 	sidecarSet := factorySidecarSet()
+	sidecarSet.Annotations[sidecarcontrol.SidecarSetHashWithoutImageAnnotation] = "without-bbb"
+	sidecarSet.Spec.Strategy.MaxUnavailable = &intstr.IntOrString{
+		Type:   intstr.String,
+		StrVal: "50%",
+	}
 	fakeClient := fake.NewFakeClientWithScheme(scheme, sidecarSet)
 	pods := factoryPodsCommon(100, 0, sidecarSet)
 	exps := expectations.NewUpdateExpectations(sidecarcontrol.GetPodSidecarSetRevision)

--- a/pkg/controller/sidecarset/sidecarset_strategy_test.go
+++ b/pkg/controller/sidecarset/sidecarset_strategy_test.go
@@ -42,7 +42,8 @@ func factoryPodsCommon(count, upgraded int, sidecarSet *appsv1alpha1.SidecarSet)
 		pod := &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
-					sidecarcontrol.SidecarSetHashAnnotation: `{"test-sidecarset":{"hash":"aaa"}}`,
+					sidecarcontrol.SidecarSetHashAnnotation:             `{"test-sidecarset":{"hash":"aaa"}}`,
+					sidecarcontrol.SidecarSetHashWithoutImageAnnotation: `{"test-sidecarset":{"hash":"without-aaa"}}`,
 				},
 				Name: fmt.Sprintf("pod-%d", i),
 				Labels: map[string]string{
@@ -111,7 +112,7 @@ func factorySidecarSet() *appsv1alpha1.SidecarSet {
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
 				sidecarcontrol.SidecarSetHashAnnotation:             "bbb",
-				sidecarcontrol.SidecarSetHashWithoutImageAnnotation: "without-bbb",
+				sidecarcontrol.SidecarSetHashWithoutImageAnnotation: "without-aaa",
 			},
 			Name:   "test-sidecarset",
 			Labels: map[string]string{},
@@ -129,7 +130,7 @@ func factorySidecarSet() *appsv1alpha1.SidecarSet {
 				MatchLabels: map[string]string{"app": "sidecar"},
 			},
 			Strategy: appsv1alpha1.SidecarSetUpdateStrategy{
-				Type: appsv1alpha1.RollingUpdateSidecarSetStrategyType,
+				//Type: appsv1alpha1.RollingUpdateSidecarSetStrategyType,
 			},
 		},
 	}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
1. the default sidecarset updateStrategy is set to RollingUpdate
2. NotUpdate strategy also can update SidecarSet.Status
3. the default strategy MaxUnavailable is set to 1


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


