### PR TITLE
cloneset partition support up

### DIFF
--- a/pkg/controller/cloneset/update/cloneset_update_test.go
+++ b/pkg/controller/cloneset/update/cloneset_update_test.go
@@ -639,53 +639,67 @@ func TestCalculateUpdateCount(t *testing.T) {
 		return &v1.Pod{Status: v1.PodStatus{Phase: v1.PodRunning, Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionTrue}}}}
 	}
 	cases := []struct {
-		strategy          appsv1alpha1.CloneSetUpdateStrategy
-		totalReplicas     int
-		waitUpdateIndexes []int
-		pods              []*v1.Pod
-		expectedResult    int
+		strategy                       appsv1alpha1.CloneSetUpdateStrategy
+		totalReplicas                  int
+		waitUpdateIndexes              []int
+		UpdatedIndexes                 []int
+		pods                           []*v1.Pod
+		expectedResult                 int
+		expectedUpdateToUpdateRevision bool
 	}{
 		{
-			strategy:          appsv1alpha1.CloneSetUpdateStrategy{},
-			totalReplicas:     3,
-			waitUpdateIndexes: []int{0, 1, 2},
-			pods:              []*v1.Pod{readyPod(), readyPod(), readyPod()},
-			expectedResult:    1,
+			strategy:                       appsv1alpha1.CloneSetUpdateStrategy{},
+			totalReplicas:                  3,
+			waitUpdateIndexes:              []int{0, 1, 2},
+			UpdatedIndexes:                 []int{},
+			pods:                           []*v1.Pod{readyPod(), readyPod(), readyPod()},
+			expectedResult:                 1,
+			expectedUpdateToUpdateRevision: true,
 		},
 		{
-			strategy:          appsv1alpha1.CloneSetUpdateStrategy{},
-			totalReplicas:     3,
-			waitUpdateIndexes: []int{0, 1, 2},
-			pods:              []*v1.Pod{readyPod(), {}, readyPod()},
-			expectedResult:    0,
+			strategy:                       appsv1alpha1.CloneSetUpdateStrategy{},
+			totalReplicas:                  3,
+			waitUpdateIndexes:              []int{0, 1, 2},
+			UpdatedIndexes:                 []int{},
+			pods:                           []*v1.Pod{readyPod(), {}, readyPod()},
+			expectedResult:                 0,
+			expectedUpdateToUpdateRevision: true,
 		},
 		{
-			strategy:          appsv1alpha1.CloneSetUpdateStrategy{},
-			totalReplicas:     3,
-			waitUpdateIndexes: []int{0, 1, 2},
-			pods:              []*v1.Pod{{}, readyPod(), readyPod()},
-			expectedResult:    1,
+			strategy:                       appsv1alpha1.CloneSetUpdateStrategy{},
+			totalReplicas:                  3,
+			waitUpdateIndexes:              []int{0, 1, 2},
+			UpdatedIndexes:                 []int{},
+			pods:                           []*v1.Pod{{}, readyPod(), readyPod()},
+			expectedResult:                 1,
+			expectedUpdateToUpdateRevision: true,
 		},
 		{
-			strategy:          appsv1alpha1.CloneSetUpdateStrategy{},
-			totalReplicas:     10,
-			waitUpdateIndexes: []int{0, 1, 2, 3, 4, 5, 6, 7, 8},
-			pods:              []*v1.Pod{{}, readyPod(), readyPod(), readyPod(), readyPod(), readyPod(), readyPod(), readyPod(), {}, readyPod()},
-			expectedResult:    1,
+			strategy:                       appsv1alpha1.CloneSetUpdateStrategy{},
+			totalReplicas:                  10,
+			waitUpdateIndexes:              []int{0, 1, 2, 3, 4, 5, 6, 7, 8},
+			UpdatedIndexes:                 []int{9},
+			pods:                           []*v1.Pod{{}, readyPod(), readyPod(), readyPod(), readyPod(), readyPod(), readyPod(), readyPod(), {}, readyPod()},
+			expectedResult:                 1,
+			expectedUpdateToUpdateRevision: true,
 		},
 		{
-			strategy:          appsv1alpha1.CloneSetUpdateStrategy{Partition: util.GetIntOrStrPointer(intstrutil.FromInt(2)), MaxUnavailable: intstrutil.ValueOrDefault(nil, intstrutil.FromInt(3))},
-			totalReplicas:     3,
-			waitUpdateIndexes: []int{0, 1},
-			pods:              []*v1.Pod{{}, readyPod(), readyPod()},
-			expectedResult:    0,
+			strategy:                       appsv1alpha1.CloneSetUpdateStrategy{Partition: util.GetIntOrStrPointer(intstrutil.FromInt(2)), MaxUnavailable: intstrutil.ValueOrDefault(nil, intstrutil.FromInt(3))},
+			totalReplicas:                  3,
+			waitUpdateIndexes:              []int{0, 1},
+			UpdatedIndexes:                 []int{2},
+			pods:                           []*v1.Pod{{}, readyPod(), readyPod()},
+			expectedResult:                 0,
+			expectedUpdateToUpdateRevision: true,
 		},
 		{
-			strategy:          appsv1alpha1.CloneSetUpdateStrategy{Partition: util.GetIntOrStrPointer(intstrutil.FromInt(2)), MaxUnavailable: intstrutil.ValueOrDefault(nil, intstrutil.FromString("50%"))},
-			totalReplicas:     8,
-			waitUpdateIndexes: []int{0, 1, 2, 3, 4, 5, 6},
-			pods:              []*v1.Pod{{}, readyPod(), {}, readyPod(), readyPod(), readyPod(), readyPod(), {}},
-			expectedResult:    3,
+			strategy:                       appsv1alpha1.CloneSetUpdateStrategy{Partition: util.GetIntOrStrPointer(intstrutil.FromInt(2)), MaxUnavailable: intstrutil.ValueOrDefault(nil, intstrutil.FromString("50%"))},
+			totalReplicas:                  8,
+			waitUpdateIndexes:              []int{0, 1, 2, 3, 4, 5, 6},
+			UpdatedIndexes:                 []int{7},
+			pods:                           []*v1.Pod{{}, readyPod(), {}, readyPod(), readyPod(), readyPod(), readyPod(), {}},
+			expectedResult:                 3,
+			expectedUpdateToUpdateRevision: true,
 		},
 		{
 			// maxUnavailable = 0 and maxSurge = 2, usedSurge = 1
@@ -693,10 +707,12 @@ func TestCalculateUpdateCount(t *testing.T) {
 				MaxUnavailable: intstrutil.ValueOrDefault(nil, intstrutil.FromInt(0)),
 				MaxSurge:       intstrutil.ValueOrDefault(nil, intstrutil.FromInt(2)),
 			},
-			totalReplicas:     4,
-			waitUpdateIndexes: []int{0, 1},
-			pods:              []*v1.Pod{readyPod(), readyPod(), readyPod(), readyPod(), readyPod()},
-			expectedResult:    1,
+			totalReplicas:                  4,
+			waitUpdateIndexes:              []int{0, 1},
+			UpdatedIndexes:                 []int{2, 3},
+			pods:                           []*v1.Pod{readyPod(), readyPod(), readyPod(), readyPod(), readyPod()},
+			expectedResult:                 1,
+			expectedUpdateToUpdateRevision: true,
 		},
 		{
 			// maxUnavailable = 1 and maxSurge = 2, usedSurge = 2
@@ -704,18 +720,20 @@ func TestCalculateUpdateCount(t *testing.T) {
 				MaxUnavailable: intstrutil.ValueOrDefault(nil, intstrutil.FromInt(1)),
 				MaxSurge:       intstrutil.ValueOrDefault(nil, intstrutil.FromInt(2)),
 			},
-			totalReplicas:     4,
-			waitUpdateIndexes: []int{0, 1, 2},
-			pods:              []*v1.Pod{readyPod(), readyPod(), readyPod(), readyPod(), readyPod(), readyPod()},
-			expectedResult:    3,
+			totalReplicas:                  4,
+			waitUpdateIndexes:              []int{0, 1, 2},
+			UpdatedIndexes:                 []int{3},
+			pods:                           []*v1.Pod{readyPod(), readyPod(), readyPod(), readyPod(), readyPod(), readyPod()},
+			expectedResult:                 3,
+			expectedUpdateToUpdateRevision: true,
 		},
 	}
 
 	coreControl := clonesetcore.New(&appsv1alpha1.CloneSet{})
 	for i, tc := range cases {
-		res := calculateUpdateCount(coreControl, tc.strategy, 0, tc.totalReplicas, tc.waitUpdateIndexes, tc.pods)
-		if res != tc.expectedResult {
-			t.Fatalf("case #%d failed, expected %d, got %d", i, tc.expectedResult, res)
+		res, updateToUpdateRevision := calculateUpdateCount(coreControl, tc.strategy, 0, tc.totalReplicas, tc.waitUpdateIndexes, tc.UpdatedIndexes, tc.pods)
+		if res != tc.expectedResult || updateToUpdateRevision != tc.expectedUpdateToUpdateRevision {
+			t.Fatalf("case #%d failed, expected %d %v, got %v", i, tc.expectedResult, res, tc.expectedUpdateToUpdateRevision)
 		}
 	}
 }


### PR DESCRIPTION
Signed-off-by: JunjunLi <junjunli666@gmail.com>

cloneset partition support up

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

#410 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

1. create a cloneset
```
zhoushua@B-H3KJLVDL-0114 k8s % kubectl get pod
NAME                    READY   STATUS    RESTARTS   AGE
guestbook-clone-fc7w9   1/1     Running   0          2m46s
guestbook-clone-jvqsj   1/1     Running   0          2m46s
guestbook-clone-mnbx7   1/1     Running   0          2m46s
guestbook-clone-tr2x5   1/1     Running   0          2m46s
guestbook-clone-vsk2l   1/1     Running   0          2m46s
guestbook-clone-zw2tq   1/1     Running   0          2m46s
```

2. update cloneset
replicas: 6
partition: 50%
image:v2

```
zhoushua@B-H3KJLVDL-0114 k8s % kubectl get pod
NAME                    READY   STATUS    RESTARTS   AGE
guestbook-clone-fc7w9   1/1     Running   0          2m58s
guestbook-clone-jvqsj   1/1     Running   0          2m58s
guestbook-clone-mnbx7   1/1     Running   0          2m58s
guestbook-clone-tr2x5   1/1     Running   1          2m58s
guestbook-clone-vsk2l   1/1     Running   1          2m58s
guestbook-clone-zw2tq   1/1     Running   1          2m58s

```

3. set partiton 4

```
zhoushua@B-H3KJLVDL-0114 k8s % kubectl get pod   -w
NAME                    READY   STATUS    RESTARTS   AGE
guestbook-clone-fc7w9   1/1     Running   0          3m38s
guestbook-clone-jvqsj   1/1     Running   0          3m38s
guestbook-clone-mnbx7   1/1     Running   0          3m38s
guestbook-clone-tr2x5   1/1     Running   1          3m38s
guestbook-clone-vsk2l   1/1     Running   1          3m38s
guestbook-clone-zw2tq   1/1     Running   2          3m38s                                                                                                
zhoushua@B-H3KJLVDL-0114 k8s % kubectl get pod  --show-labels
NAME                    READY   STATUS    RESTARTS   AGE     LABELS
guestbook-clone-fc7w9   1/1     Running   0          3m53s   app.kubernetes.io/name=guestbook-clone,apps.kruise.io/cloneset-instance-id=fc7w9,controller-revision-hash=guestbook-clone-56dfcdfff9,lifecycle.apps.kruise.io/state=Normal
guestbook-clone-jvqsj   1/1     Running   0          3m53s   app.kubernetes.io/name=guestbook-clone,apps.kruise.io/cloneset-instance-id=jvqsj,controller-revision-hash=guestbook-clone-56dfcdfff9,lifecycle.apps.kruise.io/state=Normal
guestbook-clone-mnbx7   1/1     Running   0          3m53s   app.kubernetes.io/name=guestbook-clone,apps.kruise.io/cloneset-instance-id=mnbx7,controller-revision-hash=guestbook-clone-56dfcdfff9,lifecycle.apps.kruise.io/state=Normal
guestbook-clone-tr2x5   1/1     Running   1          3m53s   app.kubernetes.io/name=guestbook-clone,apps.kruise.io/cloneset-instance-id=tr2x5,controller-revision-hash=guestbook-clone-64598d67b,lifecycle.apps.kruise.io/state=Normal
guestbook-clone-vsk2l   1/1     Running   1          3m53s   app.kubernetes.io/name=guestbook-clone,apps.kruise.io/cloneset-instance-id=vsk2l,controller-revision-hash=guestbook-clone-64598d67b,lifecycle.apps.kruise.io/state=Normal
guestbook-clone-zw2tq   1/1     Running   2          3m53s   app.kubernetes.io/name=guestbook-clone,apps.kruise.io/cloneset-instance-id=zw2tq,controller-revision-hash=guestbook-clone-56dfcdfff9,lifecycle.apps.kruise.io/state=Normal
```

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


