### PR TITLE
cloneset partition support up

### DIFF
--- a/pkg/controller/cloneset/update/cloneset_update.go
+++ b/pkg/controller/cloneset/update/cloneset_update.go
@@ -72,6 +72,13 @@ func (c *realControl) Manage(cs *appsv1alpha1.CloneSet,
 		return requeueDuration.Get(), nil
 	}
 
+	var currentRevision *apps.ControllerRevision
+	for _, r := range revisions {
+		if r.Name == cs.Status.CurrentRevision {
+			currentRevision = r
+			break
+		}
+	}
 	// 1. refresh states for all pods
 	var modified bool
 	for _, pod := range pods {
@@ -90,41 +97,57 @@ func (c *realControl) Manage(cs *appsv1alpha1.CloneSet,
 	}
 
 	// 2. find currently updated and not-ready count and all pods waiting to update
-	var waitUpdateIndexes []int
+	var waitUpdateIndexes, updatedIndexes []int
 	for i := range pods {
 		if coreControl.IsPodUpdatePaused(pods[i]) {
 			continue
 		}
 
+		if lifecycle.GetPodLifecycleState(pods[i]) == appspub.LifecycleStatePreparingDelete ||
+			lifecycle.GetPodLifecycleState(pods[i]) == appspub.LifecycleStateUpdated {
+			klog.V(3).Infof("CloneSet %s/%s find pod %s in state %s, so skip to update it",
+				cs.Namespace, cs.Name, pods[i].Name, lifecycle.GetPodLifecycleState(pods[i]))
+			continue
+		}
+
+		if gracePeriod := pods[i].Annotations[appspub.InPlaceUpdateGraceKey]; gracePeriod != "" {
+			klog.V(3).Infof("CloneSet %s/%s find pod %s still in grace period %s, so skip to update it",
+				cs.Namespace, cs.Name, pods[i].Name, gracePeriod)
+			continue
+		}
+
 		if clonesetutils.GetPodRevision("", pods[i]) != updateRevision.Name {
-			switch lifecycle.GetPodLifecycleState(pods[i]) {
-			case appspub.LifecycleStatePreparingDelete, appspub.LifecycleStateUpdated:
-				klog.V(3).Infof("CloneSet %s/%s find pod %s in state %s, so skip to update it",
-					cs.Namespace, cs.Name, pods[i].Name, lifecycle.GetPodLifecycleState(pods[i]))
-			default:
-				if gracePeriod := pods[i].Annotations[appspub.InPlaceUpdateGraceKey]; gracePeriod != "" {
-					klog.V(3).Infof("CloneSet %s/%s find pod %s still in grace period %s, so skip to update it",
-						cs.Namespace, cs.Name, pods[i].Name, gracePeriod)
-				} else {
-					waitUpdateIndexes = append(waitUpdateIndexes, i)
-				}
-			}
+			waitUpdateIndexes = append(waitUpdateIndexes, i)
+		} else {
+			updatedIndexes = append(updatedIndexes, i)
 		}
 	}
 
 	// 3. sort all pods waiting to update
 	waitUpdateIndexes = sortUpdateIndexes(coreControl, cs.Spec.UpdateStrategy, pods, waitUpdateIndexes)
+	updatedIndexes = sortUpdateIndexes(coreControl, cs.Spec.UpdateStrategy, pods, updatedIndexes)
 
 	// 4. calculate max count of pods can update
-	needToUpdateCount := calculateUpdateCount(coreControl, cs.Spec.UpdateStrategy, cs.Spec.MinReadySeconds, int(*cs.Spec.Replicas), waitUpdateIndexes, pods)
-	if needToUpdateCount < len(waitUpdateIndexes) {
-		waitUpdateIndexes = waitUpdateIndexes[:needToUpdateCount]
-	}
+	needToUpdateCount, updateToUpdateRevision := calculateUpdateCount(coreControl, cs.Spec.UpdateStrategy, cs.Spec.MinReadySeconds, int(*cs.Spec.Replicas), waitUpdateIndexes, updatedIndexes, pods)
 
 	// 5. update pods
-	for _, idx := range waitUpdateIndexes {
+	if updateToUpdateRevision {
+		waitUpdateIndexes = waitUpdateIndexes[:needToUpdateCount]
+		for _, idx := range waitUpdateIndexes {
+			pod := pods[idx]
+			if duration, err := c.updatePod(cs, coreControl, currentRevision, updateRevision, revisions, pod, pvcs); err != nil {
+				return requeueDuration.Get(), err
+			} else if duration > 0 {
+				requeueDuration.Update(duration)
+			}
+		}
+		return requeueDuration.Get(), nil
+	}
+
+	updatedIndexes = updatedIndexes[:needToUpdateCount]
+	for _, idx := range updatedIndexes {
 		pod := pods[idx]
-		if duration, err := c.updatePod(cs, coreControl, updateRevision, revisions, pod, pvcs); err != nil {
+		if duration, err := c.updatePod(cs, coreControl, updateRevision, currentRevision, revisions, pod, pvcs); err != nil {
 			return requeueDuration.Get(), err
 		} else if duration > 0 {
 			requeueDuration.Update(duration)
@@ -202,16 +225,11 @@ func sortUpdateIndexes(coreControl clonesetcore.Control, strategy appsv1alpha1.C
 	return waitUpdateIndexes
 }
 
-func calculateUpdateCount(coreControl clonesetcore.Control, strategy appsv1alpha1.CloneSetUpdateStrategy, minReadySeconds int32, totalReplicas int, waitUpdateIndexes []int, pods []*v1.Pod) int {
+func calculateUpdateCount(coreControl clonesetcore.Control, strategy appsv1alpha1.CloneSetUpdateStrategy, minReadySeconds int32, totalReplicas int, waitUpdateIndexes, updatedIndexes []int, pods []*v1.Pod) (int, bool) {
 	partition := 0
 	if strategy.Partition != nil {
 		partition, _ = intstrutil.GetValueFromIntOrPercent(strategy.Partition, totalReplicas, true)
 	}
-
-	if len(waitUpdateIndexes)-partition <= 0 {
-		return 0
-	}
-	waitUpdateIndexes = waitUpdateIndexes[:(len(waitUpdateIndexes) - partition)]
 
 	roundUp := true
 	if strategy.MaxSurge != nil {
@@ -222,24 +240,52 @@ func calculateUpdateCount(coreControl clonesetcore.Control, strategy appsv1alpha
 		intstrutil.ValueOrDefault(strategy.MaxUnavailable, intstrutil.FromString(appsv1alpha1.DefaultCloneSetMaxUnavailable)), totalReplicas, roundUp)
 	usedSurge := len(pods) - totalReplicas
 
-	var notReadyCount, updateCount int
+	var notReadyCount, updateCount, updateToCurrentCount int
 	for _, p := range pods {
 		if !isPodReady(coreControl, p, minReadySeconds) {
 			notReadyCount++
 		}
 	}
-	for _, i := range waitUpdateIndexes {
-		if isPodReady(coreControl, pods[i], minReadySeconds) {
-			if notReadyCount >= (maxUnavailable + usedSurge) {
-				break
-			} else {
-				notReadyCount++
+
+	// update to updatedRevision
+	if partition < len(waitUpdateIndexes) {
+		waitUpdateIndexes = waitUpdateIndexes[:(len(waitUpdateIndexes) - partition)]
+		for _, i := range waitUpdateIndexes {
+			if isPodReady(coreControl, pods[i], minReadySeconds) {
+				if notReadyCount >= (maxUnavailable + usedSurge) {
+					break
+				} else {
+					notReadyCount++
+				}
 			}
+			updateCount++
 		}
-		updateCount++
+		return updateCount, true
 	}
 
-	return updateCount
+	// update to currentRevision
+	if totalReplicas-partition < len(updatedIndexes) {
+		expectedUpdatedCount := totalReplicas - partition
+		if expectedUpdatedCount < 0 {
+			expectedUpdatedCount = 0
+		}
+
+		updatedIndexes = updatedIndexes[:(len(updatedIndexes) - expectedUpdatedCount)]
+
+		for _, i := range updatedIndexes {
+			if isPodReady(coreControl, pods[i], minReadySeconds) {
+				if notReadyCount >= (maxUnavailable + usedSurge) {
+					break
+				} else {
+					notReadyCount++
+				}
+			}
+			updateToCurrentCount++
+		}
+		return updateToCurrentCount, false
+	}
+
+	return 0, true
 }
 
 func isPodReady(coreControl clonesetcore.Control, pod *v1.Pod, minReadySeconds int32) bool {
@@ -251,7 +297,7 @@ func isPodReady(coreControl clonesetcore.Control, pod *v1.Pod, minReadySeconds i
 }
 
 func (c *realControl) updatePod(cs *appsv1alpha1.CloneSet, coreControl clonesetcore.Control,
-	updateRevision *apps.ControllerRevision, revisions []*apps.ControllerRevision,
+	oldRevision, updateRevision *apps.ControllerRevision, revisions []*apps.ControllerRevision,
 	pod *v1.Pod, pvcs []*v1.PersistentVolumeClaim,
 ) (time.Duration, error) {
 

--- a/pkg/controller/cloneset/update/cloneset_update_test.go
+++ b/pkg/controller/cloneset/update/cloneset_update_test.go
@@ -709,53 +709,115 @@ func TestCalculateUpdateCount(t *testing.T) {
 		return &v1.Pod{Status: v1.PodStatus{Phase: v1.PodRunning, Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionTrue}}}}
 	}
 	cases := []struct {
-		strategy          appsv1alpha1.CloneSetUpdateStrategy
-		totalReplicas     int
-		waitUpdateIndexes []int
-		pods              []*v1.Pod
-		expectedResult    int
+		strategy                       appsv1alpha1.CloneSetUpdateStrategy
+		totalReplicas                  int
+		waitUpdateIndexes              []int
+		UpdatedIndexes                 []int
+		pods                           []*v1.Pod
+		expectedResult                 int
+		expectedUpdateToUpdateRevision bool
 	}{
 		{
-			strategy:          appsv1alpha1.CloneSetUpdateStrategy{},
-			totalReplicas:     3,
-			waitUpdateIndexes: []int{0, 1, 2},
-			pods:              []*v1.Pod{readyPod(), readyPod(), readyPod()},
-			expectedResult:    1,
+			strategy:                       appsv1alpha1.CloneSetUpdateStrategy{},
+			totalReplicas:                  3,
+			waitUpdateIndexes:              []int{0, 1, 2},
+			UpdatedIndexes:                 []int{},
+			pods:                           []*v1.Pod{readyPod(), readyPod(), readyPod()},
+			expectedResult:                 1,
+			expectedUpdateToUpdateRevision: true,
 		},
 		{
-			strategy:          appsv1alpha1.CloneSetUpdateStrategy{},
-			totalReplicas:     3,
-			waitUpdateIndexes: []int{0, 1, 2},
-			pods:              []*v1.Pod{readyPod(), {}, readyPod()},
-			expectedResult:    0,
+			strategy:                       appsv1alpha1.CloneSetUpdateStrategy{},
+			totalReplicas:                  3,
+			waitUpdateIndexes:              []int{0, 1, 2},
+			UpdatedIndexes:                 []int{},
+			pods:                           []*v1.Pod{readyPod(), {}, readyPod()},
+			expectedResult:                 0,
+			expectedUpdateToUpdateRevision: true,
 		},
 		{
-			strategy:          appsv1alpha1.CloneSetUpdateStrategy{},
-			totalReplicas:     3,
-			waitUpdateIndexes: []int{0, 1, 2},
-			pods:              []*v1.Pod{{}, readyPod(), readyPod()},
-			expectedResult:    1,
+			strategy:                       appsv1alpha1.CloneSetUpdateStrategy{},
+			totalReplicas:                  3,
+			waitUpdateIndexes:              []int{0, 1, 2},
+			UpdatedIndexes:                 []int{},
+			pods:                           []*v1.Pod{{}, readyPod(), readyPod()},
+			expectedResult:                 1,
+			expectedUpdateToUpdateRevision: true,
 		},
 		{
-			strategy:          appsv1alpha1.CloneSetUpdateStrategy{},
-			totalReplicas:     10,
-			waitUpdateIndexes: []int{0, 1, 2, 3, 4, 5, 6, 7, 8},
-			pods:              []*v1.Pod{{}, readyPod(), readyPod(), readyPod(), readyPod(), readyPod(), readyPod(), readyPod(), {}, readyPod()},
-			expectedResult:    1,
+			strategy:                       appsv1alpha1.CloneSetUpdateStrategy{},
+			totalReplicas:                  10,
+			waitUpdateIndexes:              []int{0, 1, 2, 3, 4, 5, 6, 7, 8},
+			UpdatedIndexes:                 []int{9},
+			pods:                           []*v1.Pod{{}, readyPod(), readyPod(), readyPod(), readyPod(), readyPod(), readyPod(), readyPod(), {}, readyPod()},
+			expectedResult:                 1,
+			expectedUpdateToUpdateRevision: true,
 		},
 		{
-			strategy:          appsv1alpha1.CloneSetUpdateStrategy{Partition: util.GetIntOrStrPointer(intstrutil.FromInt(2)), MaxUnavailable: intstrutil.ValueOrDefault(nil, intstrutil.FromInt(3))},
-			totalReplicas:     3,
-			waitUpdateIndexes: []int{0, 1},
-			pods:              []*v1.Pod{{}, readyPod(), readyPod()},
-			expectedResult:    0,
+			strategy: appsv1alpha1.CloneSetUpdateStrategy{
+				Partition: util.GetIntOrStrPointer(intstrutil.FromInt(6)),
+			},
+			totalReplicas:                  10,
+			waitUpdateIndexes:              []int{0, 1, 2},
+			UpdatedIndexes:                 []int{3, 4, 5, 6, 7, 8, 9},
+			pods:                           []*v1.Pod{readyPod(), readyPod(), readyPod(), readyPod(), readyPod(), readyPod(), readyPod(), readyPod(), readyPod(), readyPod()},
+			expectedResult:                 2,
+			expectedUpdateToUpdateRevision: false,
 		},
 		{
-			strategy:          appsv1alpha1.CloneSetUpdateStrategy{Partition: util.GetIntOrStrPointer(intstrutil.FromInt(2)), MaxUnavailable: intstrutil.ValueOrDefault(nil, intstrutil.FromString("50%"))},
-			totalReplicas:     8,
-			waitUpdateIndexes: []int{0, 1, 2, 3, 4, 5, 6},
-			pods:              []*v1.Pod{{}, readyPod(), {}, readyPod(), readyPod(), readyPod(), readyPod(), {}},
-			expectedResult:    3,
+			strategy: appsv1alpha1.CloneSetUpdateStrategy{
+				Partition:      util.GetIntOrStrPointer(intstrutil.FromInt(6)),
+				MaxUnavailable: intstrutil.ValueOrDefault(nil, intstrutil.FromInt(9)),
+			},
+			totalReplicas:                  10,
+			waitUpdateIndexes:              []int{0, 1, 2},
+			UpdatedIndexes:                 []int{3, 4, 5, 6, 7, 8, 9},
+			pods:                           []*v1.Pod{readyPod(), readyPod(), readyPod(), readyPod(), readyPod(), readyPod(), readyPod(), readyPod(), readyPod(), readyPod()},
+			expectedResult:                 3,
+			expectedUpdateToUpdateRevision: false,
+		},
+		{
+			strategy: appsv1alpha1.CloneSetUpdateStrategy{
+				Partition:      util.GetIntOrStrPointer(intstrutil.FromInt(100)),
+				MaxUnavailable: intstrutil.ValueOrDefault(nil, intstrutil.FromInt(100)),
+			},
+			totalReplicas:                  10,
+			waitUpdateIndexes:              []int{0, 1, 2},
+			UpdatedIndexes:                 []int{3, 4, 5, 6, 7, 8, 9},
+			pods:                           []*v1.Pod{readyPod(), readyPod(), readyPod(), readyPod(), readyPod(), readyPod(), readyPod(), readyPod(), readyPod(), readyPod()},
+			expectedResult:                 7,
+			expectedUpdateToUpdateRevision: false,
+		},
+
+		{
+			strategy: appsv1alpha1.CloneSetUpdateStrategy{
+				Partition:      util.GetIntOrStrPointer(intstrutil.FromInt(4)),
+				MaxUnavailable: intstrutil.ValueOrDefault(nil, intstrutil.FromInt(9)),
+			},
+			totalReplicas:                  10,
+			waitUpdateIndexes:              []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+			UpdatedIndexes:                 []int{},
+			pods:                           []*v1.Pod{readyPod(), readyPod(), readyPod(), readyPod(), readyPod(), readyPod(), readyPod(), readyPod(), readyPod(), readyPod()},
+			expectedResult:                 6,
+			expectedUpdateToUpdateRevision: true,
+		},
+		{
+			strategy:                       appsv1alpha1.CloneSetUpdateStrategy{Partition: util.GetIntOrStrPointer(intstrutil.FromInt(2)), MaxUnavailable: intstrutil.ValueOrDefault(nil, intstrutil.FromInt(3))},
+			totalReplicas:                  3,
+			waitUpdateIndexes:              []int{0, 1},
+			UpdatedIndexes:                 []int{2},
+			pods:                           []*v1.Pod{{}, readyPod(), readyPod()},
+			expectedResult:                 0,
+			expectedUpdateToUpdateRevision: true,
+		},
+		{
+			strategy:                       appsv1alpha1.CloneSetUpdateStrategy{Partition: util.GetIntOrStrPointer(intstrutil.FromInt(2)), MaxUnavailable: intstrutil.ValueOrDefault(nil, intstrutil.FromString("50%"))},
+			totalReplicas:                  8,
+			waitUpdateIndexes:              []int{0, 1, 2, 3, 4, 5, 6},
+			UpdatedIndexes:                 []int{7},
+			pods:                           []*v1.Pod{{}, readyPod(), {}, readyPod(), readyPod(), readyPod(), readyPod(), {}},
+			expectedResult:                 3,
+			expectedUpdateToUpdateRevision: true,
 		},
 		{
 			// maxUnavailable = 0 and maxSurge = 2, usedSurge = 1
@@ -763,10 +825,12 @@ func TestCalculateUpdateCount(t *testing.T) {
 				MaxUnavailable: intstrutil.ValueOrDefault(nil, intstrutil.FromInt(0)),
 				MaxSurge:       intstrutil.ValueOrDefault(nil, intstrutil.FromInt(2)),
 			},
-			totalReplicas:     4,
-			waitUpdateIndexes: []int{0, 1},
-			pods:              []*v1.Pod{readyPod(), readyPod(), readyPod(), readyPod(), readyPod()},
-			expectedResult:    1,
+			totalReplicas:                  4,
+			waitUpdateIndexes:              []int{0, 1},
+			UpdatedIndexes:                 []int{2, 3},
+			pods:                           []*v1.Pod{readyPod(), readyPod(), readyPod(), readyPod(), readyPod()},
+			expectedResult:                 1,
+			expectedUpdateToUpdateRevision: true,
 		},
 		{
 			// maxUnavailable = 1 and maxSurge = 2, usedSurge = 2
@@ -774,18 +838,20 @@ func TestCalculateUpdateCount(t *testing.T) {
 				MaxUnavailable: intstrutil.ValueOrDefault(nil, intstrutil.FromInt(1)),
 				MaxSurge:       intstrutil.ValueOrDefault(nil, intstrutil.FromInt(2)),
 			},
-			totalReplicas:     4,
-			waitUpdateIndexes: []int{0, 1, 2},
-			pods:              []*v1.Pod{readyPod(), readyPod(), readyPod(), readyPod(), readyPod(), readyPod()},
-			expectedResult:    3,
+			totalReplicas:                  4,
+			waitUpdateIndexes:              []int{0, 1, 2},
+			UpdatedIndexes:                 []int{3},
+			pods:                           []*v1.Pod{readyPod(), readyPod(), readyPod(), readyPod(), readyPod(), readyPod()},
+			expectedResult:                 3,
+			expectedUpdateToUpdateRevision: true,
 		},
 	}
 
 	coreControl := clonesetcore.New(&appsv1alpha1.CloneSet{})
 	for i, tc := range cases {
-		res := calculateUpdateCount(coreControl, tc.strategy, 0, tc.totalReplicas, tc.waitUpdateIndexes, tc.pods)
-		if res != tc.expectedResult {
-			t.Fatalf("case #%d failed, expected %d, got %d", i, tc.expectedResult, res)
+		res, updateToUpdateRevision := calculateUpdateCount(coreControl, tc.strategy, 0, tc.totalReplicas, tc.waitUpdateIndexes, tc.UpdatedIndexes, tc.pods)
+		if res != tc.expectedResult || updateToUpdateRevision != tc.expectedUpdateToUpdateRevision {
+			t.Fatalf("case #%d failed, expected %d, got %d, expected %v got %v", i, tc.expectedResult, res, updateToUpdateRevision, tc.expectedUpdateToUpdateRevision)
 		}
 	}
 }


### PR DESCRIPTION
Signed-off-by: JunjunLi <junjunli666@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

#410 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

1. create a cloneset

```
zhoushua@B-H3KJLVDL-0114 k8s % kubectl get pod
NAME                    READY   STATUS    RESTARTS   AGE
guestbook-clone-fc7w9   1/1     Running   0          2m46s
guestbook-clone-jvqsj   1/1     Running   0          2m46s
guestbook-clone-mnbx7   1/1     Running   0          2m46s
guestbook-clone-tr2x5   1/1     Running   0          2m46s
guestbook-clone-vsk2l   1/1     Running   0          2m46s
guestbook-clone-zw2tq   1/1     Running   0          2m46s
```

2. update cloneset
replicas: 6
partition: 50%
image:v2
```
zhoushua@B-H3KJLVDL-0114 k8s % kubectl get pod
NAME                    READY   STATUS    RESTARTS   AGE
guestbook-clone-fc7w9   1/1     Running   0          2m58s
guestbook-clone-jvqsj   1/1     Running   0          2m58s
guestbook-clone-mnbx7   1/1     Running   0          2m58s
guestbook-clone-tr2x5   1/1     Running   1          2m58s
guestbook-clone-vsk2l   1/1     Running   1          2m58s
guestbook-clone-zw2tq   1/1     Running   1          2m58s
```

3. set partiton 4


```
zhoushua@B-H3KJLVDL-0114 k8s % kubectl get pod   -w
NAME                    READY   STATUS    RESTARTS   AGE
guestbook-clone-fc7w9   1/1     Running   0          3m38s
guestbook-clone-jvqsj   1/1     Running   0          3m38s
guestbook-clone-mnbx7   1/1     Running   0          3m38s
guestbook-clone-tr2x5   1/1     Running   1          3m38s
guestbook-clone-vsk2l   1/1     Running   1          3m38s
guestbook-clone-zw2tq   1/1     Running   2          3m38s                                                                                                
zhoushua@B-H3KJLVDL-0114 k8s % kubectl get pod  --show-labels
NAME                    READY   STATUS    RESTARTS   AGE     LABELS
guestbook-clone-fc7w9   1/1     Running   0          3m53s   app.kubernetes.io/name=guestbook-clone,apps.kruise.io/cloneset-instance-id=fc7w9,controller-revision-hash=guestbook-clone-56dfcdfff9,lifecycle.apps.kruise.io/state=Normal
guestbook-clone-jvqsj   1/1     Running   0          3m53s   app.kubernetes.io/name=guestbook-clone,apps.kruise.io/cloneset-instance-id=jvqsj,controller-revision-hash=guestbook-clone-56dfcdfff9,lifecycle.apps.kruise.io/state=Normal
guestbook-clone-mnbx7   1/1     Running   0          3m53s   app.kubernetes.io/name=guestbook-clone,apps.kruise.io/cloneset-instance-id=mnbx7,controller-revision-hash=guestbook-clone-56dfcdfff9,lifecycle.apps.kruise.io/state=Normal
guestbook-clone-tr2x5   1/1     Running   1          3m53s   app.kubernetes.io/name=guestbook-clone,apps.kruise.io/cloneset-instance-id=tr2x5,controller-revision-hash=guestbook-clone-64598d67b,lifecycle.apps.kruise.io/state=Normal
guestbook-clone-vsk2l   1/1     Running   1          3m53s   app.kubernetes.io/name=guestbook-clone,apps.kruise.io/cloneset-instance-id=vsk2l,controller-revision-hash=guestbook-clone-64598d67b,lifecycle.apps.kruise.io/state=Normal
guestbook-clone-zw2tq   1/1     Running   2          3m53s   app.kubernetes.io/name=guestbook-clone,apps.kruise.io/cloneset-instance-id=zw2tq,controller-revision-hash=guestbook-clone-56dfcdfff9,lifecycle.apps.kruise.io/state=Normal
```

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


