### PR TITLE
add CloneSetHashOnlyRevisionName feature-gate

### DIFF
--- a/pkg/controller/cloneset/cloneset_status.go
+++ b/pkg/controller/cloneset/cloneset_status.go
@@ -22,6 +22,7 @@ import (
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
 	clonesetcore "github.com/openkruise/kruise/pkg/controller/cloneset/core"
 	clonesetutils "github.com/openkruise/kruise/pkg/controller/cloneset/utils"
+	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
@@ -31,7 +32,7 @@ import (
 
 // StatusUpdater is interface for updating CloneSet status.
 type StatusUpdater interface {
-	UpdateCloneSetStatus(cs *appsv1alpha1.CloneSet, newStatus *appsv1alpha1.CloneSetStatus, pods []*v1.Pod) error
+	UpdateCloneSetStatus(cs *appsv1alpha1.CloneSet, newStatus *appsv1alpha1.CloneSetStatus, updateRevision *apps.ControllerRevision, pods []*v1.Pod) error
 }
 
 func newStatusUpdater(c client.Client) StatusUpdater {
@@ -42,8 +43,8 @@ type realStatusUpdater struct {
 	client.Client
 }
 
-func (r *realStatusUpdater) UpdateCloneSetStatus(cs *appsv1alpha1.CloneSet, newStatus *appsv1alpha1.CloneSetStatus, pods []*v1.Pod) error {
-	r.calculateStatus(cs, newStatus, pods)
+func (r *realStatusUpdater) UpdateCloneSetStatus(cs *appsv1alpha1.CloneSet, newStatus *appsv1alpha1.CloneSetStatus, updateRevision *apps.ControllerRevision, pods []*v1.Pod) error {
+	r.calculateStatus(cs, newStatus, updateRevision, pods)
 	if r.inconsistentStatus(cs, newStatus) {
 		klog.Infof("To update CloneSet status for  %s/%s, replicas=%d ready=%d available=%d updated=%d updatedReady=%d, revisions current=%s update=%s",
 			cs.Namespace, cs.Name, newStatus.Replicas, newStatus.ReadyReplicas, newStatus.AvailableReplicas, newStatus.UpdatedReplicas, newStatus.UpdatedReadyReplicas, newStatus.CurrentRevision, newStatus.UpdateRevision)
@@ -80,7 +81,7 @@ func (r *realStatusUpdater) inconsistentStatus(cs *appsv1alpha1.CloneSet, newSta
 		newStatus.LabelSelector != oldStatus.LabelSelector
 }
 
-func (r *realStatusUpdater) calculateStatus(cs *appsv1alpha1.CloneSet, newStatus *appsv1alpha1.CloneSetStatus, pods []*v1.Pod) {
+func (r *realStatusUpdater) calculateStatus(cs *appsv1alpha1.CloneSet, newStatus *appsv1alpha1.CloneSetStatus, updateRevision *apps.ControllerRevision, pods []*v1.Pod) {
 	coreControl := clonesetcore.New(cs)
 	for _, pod := range pods {
 		newStatus.Replicas++
@@ -90,10 +91,10 @@ func (r *realStatusUpdater) calculateStatus(cs *appsv1alpha1.CloneSet, newStatus
 		if coreControl.IsPodUpdateReady(pod, cs.Spec.MinReadySeconds) {
 			newStatus.AvailableReplicas++
 		}
-		if clonesetutils.GetPodRevision("", pod) == newStatus.UpdateRevision {
+		if clonesetutils.GetPodRevision("", pod) == clonesetutils.GetRevisionLabel(updateRevision) {
 			newStatus.UpdatedReplicas++
 		}
-		if clonesetutils.GetPodRevision("", pod) == newStatus.UpdateRevision && coreControl.IsPodUpdateReady(pod, 0) {
+		if clonesetutils.GetPodRevision("", pod) == clonesetutils.GetRevisionLabel(updateRevision) && coreControl.IsPodUpdateReady(pod, 0) {
 			newStatus.UpdatedReadyReplicas++
 		}
 	}

--- a/pkg/controller/cloneset/utils/cloneset_utils.go
+++ b/pkg/controller/cloneset/utils/cloneset_utils.go
@@ -22,7 +22,9 @@ import (
 	"sync"
 
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
+	"github.com/openkruise/kruise/pkg/features"
 	"github.com/openkruise/kruise/pkg/util/expectations"
+	utilfeature "github.com/openkruise/kruise/pkg/util/feature"
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	kubecontroller "k8s.io/kubernetes/pkg/controller"
+	"k8s.io/kubernetes/pkg/controller/history"
 	"k8s.io/utils/integer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -78,6 +81,15 @@ func GetPodsRevisions(pods []*v1.Pod) sets.String {
 		revisions.Insert(GetPodRevision("", p))
 	}
 	return revisions
+}
+
+// GetRevisionLabel return revision hash label value from revision to create pods.
+// https://github.com/openkruise/kruise/issues/531
+func GetRevisionLabel(revision *apps.ControllerRevision) string {
+	if utilfeature.DefaultFeatureGate.Enabled(features.CloneSetHashOnlyRevisionName) {
+		return revision.Labels[history.ControllerRevisionHashLabel]
+	}
+	return revision.Name
 }
 
 // NextRevision finds the next valid revision number based on revisions. If the length of revisions

--- a/pkg/features/kruise_features.go
+++ b/pkg/features/kruise_features.go
@@ -32,11 +32,15 @@ const (
 
 	// PodWebhook enables webhook for Pods creations. This is also related to SidecarSet.
 	PodWebhook featuregate.Feature = "PodWebhook"
+
+	// CloneSetHashOnlyRevisionName enables CloneSet controller only set revision hash name to pod.
+	CloneSetHashOnlyRevisionName featuregate.Feature = "CloneSetHashOnlyRevisionName"
 )
 
 var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	PodWebhook:   {Default: true, PreRelease: featuregate.Beta},
-	KruiseDaemon: {Default: true, PreRelease: featuregate.Beta},
+	PodWebhook:                   {Default: true, PreRelease: featuregate.Beta},
+	KruiseDaemon:                 {Default: true, PreRelease: featuregate.Beta},
+	CloneSetHashOnlyRevisionName: {Default: false, PreRelease: featuregate.Beta},
 }
 
 func init() {


### PR DESCRIPTION

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Add ClonetSetSimpleRevisionLabel featrue-gate, default value is false. If enabled, CloneSet will create pod with simple revision hash label not including it's name.

So we can create CloneSet with name length greater than 63.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
Fixes https://github.com/openkruise/kruise/issues/531

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


