### PR TITLE
Optimize in-place update for CloneSet and Advanced StatefulSet

### DIFF
--- a/apis/apps/pub/inplace_update.go
+++ b/apis/apps/pub/inplace_update.go
@@ -30,11 +30,15 @@ const (
 
 	// InPlaceUpdateStateKey records the state of inplace-update.
 	// The value of annotation is InPlaceUpdateState.
-	InPlaceUpdateStateKey string = "inplace-update-state"
+	InPlaceUpdateStateKey string = "apps.kruise.io/inplace-update-state"
+	// TODO: will be removed since v1.0.0
+	InPlaceUpdateStateKeyOld string = "inplace-update-state"
 
 	// InPlaceUpdateGraceKey records the spec that Pod should be updated when
 	// grace period ends.
-	InPlaceUpdateGraceKey string = "inplace-update-grace"
+	InPlaceUpdateGraceKey string = "apps.kruise.io/inplace-update-grace"
+	// TODO: will be removed since v1.0.0
+	InPlaceUpdateGraceKeyOld string = "inplace-update-grace"
 )
 
 // InPlaceUpdateState records latest inplace-update state, including old statuses of containers.
@@ -61,4 +65,25 @@ type InPlaceUpdateStrategy struct {
 	// GracePeriodSeconds is the timespan between set Pod status to not-ready and update images in Pod spec
 	// when in-place update a Pod.
 	GracePeriodSeconds int32 `json:"gracePeriodSeconds,omitempty"`
+}
+
+func GetInPlaceUpdateState(obj metav1.Object) (string, bool) {
+	if v, ok := obj.GetAnnotations()[InPlaceUpdateStateKey]; ok {
+		return v, ok
+	}
+	v, ok := obj.GetAnnotations()[InPlaceUpdateStateKeyOld]
+	return v, ok
+}
+
+func GetInPlaceUpdateGrace(obj metav1.Object) (string, bool) {
+	if v, ok := obj.GetAnnotations()[InPlaceUpdateGraceKey]; ok {
+		return v, ok
+	}
+	v, ok := obj.GetAnnotations()[InPlaceUpdateGraceKeyOld]
+	return v, ok
+}
+
+func RemoveInPlaceUpdateGrace(obj metav1.Object) {
+	delete(obj.GetAnnotations(), InPlaceUpdateGraceKey)
+	delete(obj.GetAnnotations(), InPlaceUpdateGraceKeyOld)
 }

--- a/pkg/controller/cloneset/cloneset_controller.go
+++ b/pkg/controller/cloneset/cloneset_controller.go
@@ -352,7 +352,8 @@ func (r *ReconcileCloneSet) syncCloneSet(
 			LastTransitionTime: metav1.Now(),
 			Message:            podsUpdateErr.Error(),
 		})
-		if err == nil {
+		// If these is a delay duration, need not to return error to outside
+		if err == nil && delayDuration <= 0 {
 			err = podsUpdateErr
 		}
 	}

--- a/pkg/controller/cloneset/scale/cloneset_scale.go
+++ b/pkg/controller/cloneset/scale/cloneset_scale.go
@@ -66,7 +66,7 @@ func (r *realControl) Manage(
 	}
 
 	updatedPods, notUpdatedPods := clonesetutils.SplitPodsByRevision(pods, updateRevision)
-	diff, currentRevDiff := calculateDiffs(updateCS, updateRevision == currentRevision, len(pods), len(notUpdatedPods))
+	diff, currentRevDiff := calculateDiffs(updateCS, len(pods), len(notUpdatedPods))
 
 	// 1. scale out
 	if diff < 0 {

--- a/pkg/controller/cloneset/scale/cloneset_scale_util_test.go
+++ b/pkg/controller/cloneset/scale/cloneset_scale_util_test.go
@@ -61,7 +61,6 @@ func TestCalculateDiffs(t *testing.T) {
 	cases := []struct {
 		name                   string
 		cs                     *appsv1alpha1.CloneSet
-		revConsistent          bool
 		totalPods              int
 		notUpdatedPods         int
 		expectedTotalDiff      int
@@ -78,7 +77,6 @@ func TestCalculateDiffs(t *testing.T) {
 					},
 				},
 			},
-			revConsistent:          true,
 			totalPods:              10,
 			notUpdatedPods:         0,
 			expectedTotalDiff:      0,
@@ -95,7 +93,6 @@ func TestCalculateDiffs(t *testing.T) {
 					},
 				},
 			},
-			revConsistent:          true,
 			totalPods:              10,
 			notUpdatedPods:         0,
 			expectedTotalDiff:      0,
@@ -112,7 +109,6 @@ func TestCalculateDiffs(t *testing.T) {
 					},
 				},
 			},
-			revConsistent:          true,
 			totalPods:              8,
 			notUpdatedPods:         0,
 			expectedTotalDiff:      -2,
@@ -129,7 +125,6 @@ func TestCalculateDiffs(t *testing.T) {
 					},
 				},
 			},
-			revConsistent:          false,
 			totalPods:              8,
 			notUpdatedPods:         0,
 			expectedTotalDiff:      -2,
@@ -146,7 +141,6 @@ func TestCalculateDiffs(t *testing.T) {
 					},
 				},
 			},
-			revConsistent:          false,
 			totalPods:              8,
 			notUpdatedPods:         1,
 			expectedTotalDiff:      -3,
@@ -163,7 +157,6 @@ func TestCalculateDiffs(t *testing.T) {
 					},
 				},
 			},
-			revConsistent:          false,
 			totalPods:              10,
 			notUpdatedPods:         1,
 			expectedTotalDiff:      0,
@@ -180,7 +173,6 @@ func TestCalculateDiffs(t *testing.T) {
 					},
 				},
 			},
-			revConsistent:          false,
 			totalPods:              11,
 			notUpdatedPods:         1,
 			expectedTotalDiff:      0,
@@ -197,7 +189,6 @@ func TestCalculateDiffs(t *testing.T) {
 					},
 				},
 			},
-			revConsistent:          false,
 			totalPods:              8,
 			notUpdatedPods:         6,
 			expectedTotalDiff:      -2,
@@ -213,7 +204,6 @@ func TestCalculateDiffs(t *testing.T) {
 					},
 				},
 			},
-			revConsistent:          false,
 			totalPods:              10,
 			notUpdatedPods:         10,
 			expectedTotalDiff:      1,
@@ -230,10 +220,9 @@ func TestCalculateDiffs(t *testing.T) {
 					},
 				},
 			},
-			revConsistent:          false,
 			totalPods:              10,
 			notUpdatedPods:         10,
-			expectedTotalDiff:      0,
+			expectedTotalDiff:      1,
 			expectedCurrentRevDiff: 1,
 		},
 		{
@@ -247,7 +236,6 @@ func TestCalculateDiffs(t *testing.T) {
 					},
 				},
 			},
-			revConsistent:          false,
 			totalPods:              1,
 			notUpdatedPods:         1,
 			expectedTotalDiff:      -1,
@@ -264,7 +252,6 @@ func TestCalculateDiffs(t *testing.T) {
 					},
 				},
 			},
-			revConsistent:          true,
 			totalPods:              11,
 			notUpdatedPods:         0,
 			expectedTotalDiff:      1,
@@ -281,7 +268,6 @@ func TestCalculateDiffs(t *testing.T) {
 					},
 				},
 			},
-			revConsistent:          true,
 			totalPods:              11,
 			notUpdatedPods:         0,
 			expectedTotalDiff:      1,
@@ -298,7 +284,6 @@ func TestCalculateDiffs(t *testing.T) {
 					},
 				},
 			},
-			revConsistent:          false,
 			totalPods:              11,
 			notUpdatedPods:         0,
 			expectedTotalDiff:      1,
@@ -315,7 +300,6 @@ func TestCalculateDiffs(t *testing.T) {
 					},
 				},
 			},
-			revConsistent:          false,
 			totalPods:              11,
 			notUpdatedPods:         0,
 			expectedTotalDiff:      1,
@@ -332,7 +316,6 @@ func TestCalculateDiffs(t *testing.T) {
 					},
 				},
 			},
-			revConsistent:          false,
 			totalPods:              11,
 			notUpdatedPods:         1,
 			expectedTotalDiff:      0,
@@ -349,7 +332,6 @@ func TestCalculateDiffs(t *testing.T) {
 					},
 				},
 			},
-			revConsistent:          false,
 			totalPods:              12,
 			notUpdatedPods:         2,
 			expectedTotalDiff:      1,
@@ -366,7 +348,6 @@ func TestCalculateDiffs(t *testing.T) {
 					},
 				},
 			},
-			revConsistent:          false,
 			totalPods:              13,
 			notUpdatedPods:         7,
 			expectedTotalDiff:      2,
@@ -376,7 +357,7 @@ func TestCalculateDiffs(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(*testing.T) {
-			totalDiff, currentRevDiff := calculateDiffs(tc.cs, tc.revConsistent, tc.totalPods, tc.notUpdatedPods)
+			totalDiff, currentRevDiff := calculateDiffs(tc.cs, tc.totalPods, tc.notUpdatedPods)
 			if totalDiff != tc.expectedTotalDiff || currentRevDiff != tc.expectedCurrentRevDiff {
 				t.Fatalf("failed calculateDiffs, expected totalDiff %d, got %d, expected currentRevDiff %d, got %d",
 					tc.expectedTotalDiff, totalDiff, tc.expectedCurrentRevDiff, currentRevDiff)

--- a/pkg/controller/cloneset/update/cloneset_update_test.go
+++ b/pkg/controller/cloneset/update/cloneset_update_test.go
@@ -239,74 +239,6 @@ func TestMange(t *testing.T) {
 			},
 		},
 		{
-			name: "inplace update preparing",
-			cs: &appsv1alpha1.CloneSet{Spec: appsv1alpha1.CloneSetSpec{
-				Replicas:       getInt32Pointer(1),
-				UpdateStrategy: appsv1alpha1.CloneSetUpdateStrategy{Type: appsv1alpha1.InPlaceIfPossibleCloneSetUpdateStrategyType},
-			}},
-			updateRevision: &apps.ControllerRevision{
-				ObjectMeta: metav1.ObjectMeta{Name: "rev-new"},
-				Data:       runtime.RawExtension{Raw: []byte(`{"spec":{"template":{"$patch":"replace","spec":{"containers":[{"name":"c1","image":"foo2"}]}}}}`)},
-			},
-			revisions: []*apps.ControllerRevision{
-				{
-					ObjectMeta: metav1.ObjectMeta{Name: "rev-old"},
-					Data:       runtime.RawExtension{Raw: []byte(`{"spec":{"template":{"$patch":"replace","spec":{"containers":[{"name":"c1","image":"foo1"}]}}}}`)},
-				},
-			},
-			pods: []*v1.Pod{
-				{
-					ObjectMeta: metav1.ObjectMeta{Name: "pod-0", Labels: map[string]string{
-						apps.ControllerRevisionHashLabelKey: "rev-old",
-						appsv1alpha1.CloneSetInstanceID:     "id-0",
-					}},
-					Spec: v1.PodSpec{
-						ReadinessGates: []v1.PodReadinessGate{{ConditionType: appspub.InPlaceUpdateReady}},
-						Containers:     []v1.Container{{Name: "c1", Image: "foo1"}},
-					},
-					Status: v1.PodStatus{
-						Phase: v1.PodRunning,
-						Conditions: []v1.PodCondition{
-							{Type: v1.PodReady, Status: v1.ConditionTrue},
-							{Type: appspub.InPlaceUpdateReady, Status: v1.ConditionTrue},
-						},
-						ContainerStatuses: []v1.ContainerStatus{{Name: "c1", ImageID: "image-id-xyz"}},
-					},
-				},
-			},
-			pvcs: []*v1.PersistentVolumeClaim{
-				{ObjectMeta: metav1.ObjectMeta{Name: "pvc-0", Labels: map[string]string{appsv1alpha1.CloneSetInstanceID: "id-0"}}},
-				{ObjectMeta: metav1.ObjectMeta{Name: "pvc-1", Labels: map[string]string{appsv1alpha1.CloneSetInstanceID: "id-1"}}},
-				{ObjectMeta: metav1.ObjectMeta{Name: "pvc-2", Labels: map[string]string{appsv1alpha1.CloneSetInstanceID: "id-0"}}},
-			},
-			expectedPods: []*v1.Pod{
-				{
-					ObjectMeta: metav1.ObjectMeta{Name: "pod-0", ResourceVersion: "1", Labels: map[string]string{
-						apps.ControllerRevisionHashLabelKey: "rev-old",
-						appsv1alpha1.CloneSetInstanceID:     "id-0",
-						appspub.LifecycleStateKey:           string(appspub.LifecycleStatePreparingUpdate),
-					}},
-					Spec: v1.PodSpec{
-						ReadinessGates: []v1.PodReadinessGate{{ConditionType: appspub.InPlaceUpdateReady}},
-						Containers:     []v1.Container{{Name: "c1", Image: "foo1"}},
-					},
-					Status: v1.PodStatus{
-						Phase: v1.PodRunning,
-						Conditions: []v1.PodCondition{
-							{Type: v1.PodReady, Status: v1.ConditionTrue},
-							{Type: appspub.InPlaceUpdateReady, Status: v1.ConditionTrue},
-						},
-						ContainerStatuses: []v1.ContainerStatus{{Name: "c1", ImageID: "image-id-xyz"}},
-					},
-				},
-			},
-			expectedPVCs: []*v1.PersistentVolumeClaim{
-				{ObjectMeta: metav1.ObjectMeta{Name: "pvc-0", Labels: map[string]string{appsv1alpha1.CloneSetInstanceID: "id-0"}}},
-				{ObjectMeta: metav1.ObjectMeta{Name: "pvc-1", Labels: map[string]string{appsv1alpha1.CloneSetInstanceID: "id-1"}}},
-				{ObjectMeta: metav1.ObjectMeta{Name: "pvc-2", Labels: map[string]string{appsv1alpha1.CloneSetInstanceID: "id-0"}}},
-			},
-		},
-		{
 			name: "inplace update",
 			cs: &appsv1alpha1.CloneSet{Spec: appsv1alpha1.CloneSetSpec{
 				Replicas:       getInt32Pointer(1),
@@ -327,7 +259,6 @@ func TestMange(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Name: "pod-0", Labels: map[string]string{
 						apps.ControllerRevisionHashLabelKey: "rev-old",
 						appsv1alpha1.CloneSetInstanceID:     "id-0",
-						appspub.LifecycleStateKey:           string(appspub.LifecycleStatePreparingUpdate),
 					}},
 					Spec: v1.PodSpec{
 						ReadinessGates: []v1.PodReadinessGate{{ConditionType: appspub.InPlaceUpdateReady}},
@@ -404,7 +335,6 @@ func TestMange(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Name: "pod-0", Labels: map[string]string{
 						apps.ControllerRevisionHashLabelKey: "rev-old",
 						appsv1alpha1.CloneSetInstanceID:     "id-0",
-						appspub.LifecycleStateKey:           string(appspub.LifecycleStatePreparingUpdate),
 					}},
 					Spec: v1.PodSpec{
 						ReadinessGates: []v1.PodReadinessGate{{ConditionType: appspub.InPlaceUpdateReady}},

--- a/pkg/controller/statefulset/stateful_set_utils.go
+++ b/pkg/controller/statefulset/stateful_set_utils.go
@@ -500,8 +500,3 @@ func filterOutCondition(conditions []apps.StatefulSetCondition, condType apps.St
 func getStatefulSetKey(o metav1.Object) string {
 	return o.GetNamespace() + "/" + o.GetName()
 }
-
-func isInPlaceOnly(set *appsv1beta1.StatefulSet) bool {
-	return set.Spec.UpdateStrategy.RollingUpdate != nil &&
-		set.Spec.UpdateStrategy.RollingUpdate.PodUpdatePolicy == appsv1beta1.InPlaceOnlyPodUpdateStrategyType
-}

--- a/pkg/util/inplaceupdate/inplace_utils_test.go
+++ b/pkg/util/inplaceupdate/inplace_utils_test.go
@@ -119,7 +119,7 @@ func TestCalculateInPlaceUpdateSpec(t *testing.T) {
 	}
 
 	for i, tc := range cases {
-		res := calculateInPlaceUpdateSpec(tc.oldRevision, tc.newRevision, nil)
+		res := defaultCalculateInPlaceUpdateSpec(tc.oldRevision, tc.newRevision, nil)
 		if !reflect.DeepEqual(res, tc.expectedSpec) {
 			t.Fatalf("case #%d failed, expected %v, got %v", i, tc.expectedSpec, res)
 		}
@@ -211,12 +211,12 @@ func TestCheckInPlaceUpdateCompleted(t *testing.T) {
 	}
 
 	for _, p := range succeedPods {
-		if err := CheckInPlaceUpdateCompleted(p); err != nil {
+		if err := defaultCheckInPlaceUpdateCompleted(p); err != nil {
 			t.Errorf("pod %s expected check success, got %v", p.Name, err)
 		}
 	}
 	for _, p := range failPods {
-		if err := CheckInPlaceUpdateCompleted(p); err == nil {
+		if err := defaultCheckInPlaceUpdateCompleted(p); err == nil {
 			t.Errorf("pod %s expected check failure, got no error", p.Name)
 		}
 	}

--- a/pkg/util/inplaceupdate/options.go
+++ b/pkg/util/inplaceupdate/options.go
@@ -1,0 +1,192 @@
+/*
+Copyright 2021 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inplaceupdate
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/appscode/jsonpatch"
+	appspub "github.com/openkruise/kruise/apis/apps/pub"
+	apps "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
+)
+
+type UpdateOptions struct {
+	GracePeriodSeconds int32
+	AdditionalFuncs    []func(*v1.Pod)
+
+	CalculateSpec        func(oldRevision, newRevision *apps.ControllerRevision, opts *UpdateOptions) *UpdateSpec
+	PatchSpecToPod       func(pod *v1.Pod, spec *UpdateSpec) (*v1.Pod, error)
+	CheckUpdateCompleted func(pod *v1.Pod) error
+	GetRevision          func(rev *apps.ControllerRevision) string
+}
+
+func SetOptionsDefaults(opts *UpdateOptions) *UpdateOptions {
+	if opts == nil {
+		opts = &UpdateOptions{}
+	}
+
+	if opts.CalculateSpec == nil {
+		opts.CalculateSpec = defaultCalculateInPlaceUpdateSpec
+	}
+
+	if opts.PatchSpecToPod == nil {
+		opts.PatchSpecToPod = defaultPatchUpdateSpecToPod
+	}
+
+	if opts.CheckUpdateCompleted == nil {
+		opts.CheckUpdateCompleted = defaultCheckInPlaceUpdateCompleted
+	}
+
+	return opts
+}
+
+// defaultPatchUpdateSpecToPod returns new pod that merges spec into old pod
+func defaultPatchUpdateSpecToPod(pod *v1.Pod, spec *UpdateSpec) (*v1.Pod, error) {
+	if spec.MetaDataPatch != nil {
+		cloneBytes, _ := json.Marshal(pod)
+		modified, err := strategicpatch.StrategicMergePatch(cloneBytes, spec.MetaDataPatch, &v1.Pod{})
+		if err != nil {
+			return nil, err
+		}
+		pod = &v1.Pod{}
+		if err = json.Unmarshal(modified, pod); err != nil {
+			return nil, err
+		}
+	}
+
+	for i := range pod.Spec.Containers {
+		if newImage, ok := spec.ContainerImages[pod.Spec.Containers[i].Name]; ok {
+			pod.Spec.Containers[i].Image = newImage
+		}
+	}
+	return pod, nil
+}
+
+// defaultCalculateInPlaceUpdateSpec calculates diff between old and update revisions.
+// If the diff just contains replace operation of spec.containers[x].image, it will returns an UpdateSpec.
+// Otherwise, it returns nil which means can not use in-place update.
+func defaultCalculateInPlaceUpdateSpec(oldRevision, newRevision *apps.ControllerRevision, opts *UpdateOptions) *UpdateSpec {
+	if oldRevision == nil || newRevision == nil {
+		return nil
+	}
+	opts = SetOptionsDefaults(opts)
+
+	patches, err := jsonpatch.CreatePatch(oldRevision.Data.Raw, newRevision.Data.Raw)
+	if err != nil {
+		return nil
+	}
+
+	oldTemp, err := GetTemplateFromRevision(oldRevision)
+	if err != nil {
+		return nil
+	}
+	newTemp, err := GetTemplateFromRevision(newRevision)
+	if err != nil {
+		return nil
+	}
+
+	updateSpec := &UpdateSpec{
+		Revision:        newRevision.Name,
+		ContainerImages: make(map[string]string),
+		GraceSeconds:    opts.GracePeriodSeconds,
+	}
+	if opts.GetRevision != nil {
+		updateSpec.Revision = opts.GetRevision(newRevision)
+	}
+
+	// all patches for podSpec can just update images
+	var metadataChanged bool
+	for _, jsonPatchOperation := range patches {
+		jsonPatchOperation.Path = strings.Replace(jsonPatchOperation.Path, "/spec/template", "", 1)
+
+		if !strings.HasPrefix(jsonPatchOperation.Path, "/spec/") {
+			metadataChanged = true
+			continue
+		}
+		if jsonPatchOperation.Operation != "replace" || !inPlaceUpdatePatchRexp.MatchString(jsonPatchOperation.Path) {
+			return nil
+		}
+		// for example: /spec/containers/0/image
+		words := strings.Split(jsonPatchOperation.Path, "/")
+		idx, _ := strconv.Atoi(words[3])
+		if len(oldTemp.Spec.Containers) <= idx {
+			return nil
+		}
+		updateSpec.ContainerImages[oldTemp.Spec.Containers[idx].Name] = jsonPatchOperation.Value.(string)
+	}
+	if metadataChanged {
+		oldBytes, _ := json.Marshal(v1.Pod{ObjectMeta: oldTemp.ObjectMeta})
+		newBytes, _ := json.Marshal(v1.Pod{ObjectMeta: newTemp.ObjectMeta})
+		patchBytes, err := strategicpatch.CreateTwoWayMergePatch(oldBytes, newBytes, &v1.Pod{})
+		if err != nil {
+			return nil
+		}
+		updateSpec.MetaDataPatch = patchBytes
+	}
+	return updateSpec
+}
+
+// defaultCheckInPlaceUpdateCompleted checks whether imageID in pod status has been changed since in-place update.
+// If the imageID in containerStatuses has not been changed, we assume that kubelet has not updated
+// containers in Pod.
+func defaultCheckInPlaceUpdateCompleted(pod *v1.Pod) error {
+	inPlaceUpdateState := appspub.InPlaceUpdateState{}
+	if stateStr, ok := appspub.GetInPlaceUpdateState(pod); !ok {
+		return nil
+	} else if err := json.Unmarshal([]byte(stateStr), &inPlaceUpdateState); err != nil {
+		return err
+	}
+
+	// this should not happen, unless someone modified pod revision label
+	if inPlaceUpdateState.Revision != pod.Labels[apps.StatefulSetRevisionLabel] {
+		return fmt.Errorf("currently revision %s not equal to in-place update revision %s",
+			pod.Labels[apps.StatefulSetRevisionLabel], inPlaceUpdateState.Revision)
+	}
+
+	containerImages := make(map[string]string, len(pod.Spec.Containers))
+	for i := range pod.Spec.Containers {
+		c := &pod.Spec.Containers[i]
+		containerImages[c.Name] = c.Image
+		if len(strings.Split(c.Image, ":")) <= 1 {
+			containerImages[c.Name] = fmt.Sprintf("%s:latest", c.Image)
+		}
+	}
+
+	_, isInGraceState := appspub.GetInPlaceUpdateGrace(pod)
+	for _, cs := range pod.Status.ContainerStatuses {
+		if oldStatus, ok := inPlaceUpdateState.LastContainerStatuses[cs.Name]; ok {
+			// TODO: we assume that users should not update workload template with new image which actually has the same imageID as the old image
+			if oldStatus.ImageID == cs.ImageID {
+				if containerImages[cs.Name] != cs.Image || isInGraceState {
+					return fmt.Errorf("container %s imageID not changed", cs.Name)
+				}
+			}
+			delete(inPlaceUpdateState.LastContainerStatuses, cs.Name)
+		}
+	}
+
+	if len(inPlaceUpdateState.LastContainerStatuses) > 0 {
+		return fmt.Errorf("not found statuses of containers %v", inPlaceUpdateState.LastContainerStatuses)
+	}
+
+	return nil
+}

--- a/test/e2e/apps/cloneset.go
+++ b/test/e2e/apps/cloneset.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2021 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apps
+
+import (
+	"time"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
+	kruiseclientset "github.com/openkruise/kruise/pkg/client/clientset/versioned"
+	"github.com/openkruise/kruise/test/e2e/framework"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	clientset "k8s.io/client-go/kubernetes"
+)
+
+var _ = SIGDescribe("CloneSet", func() {
+	f := framework.NewDefaultFramework("clonesets")
+	var ns string
+	var c clientset.Interface
+	var kc kruiseclientset.Interface
+	var tester *framework.CloneSetTester
+
+	ginkgo.BeforeEach(func() {
+		c = f.ClientSet
+		kc = f.KruiseClientSet
+		ns = f.Namespace.Name
+		tester = framework.NewCloneSetTester(c, kc, ns)
+	})
+
+	framework.KruiseDescribe("CloneSet Scaling", func() {
+		var err error
+
+		ginkgo.It("scales in normal cases", func() {
+			cs := tester.NewCloneSet("clone", 3)
+			cs, err = tester.CreateCloneSet(cs)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			gomega.Expect(cs.Spec.UpdateStrategy.Type).To(gomega.Equal(appsv1alpha1.RecreateCloneSetUpdateStrategyType))
+			gomega.Expect(cs.Spec.UpdateStrategy.MaxUnavailable).To(gomega.Equal(func() *intstr.IntOrString { i := intstr.FromString("20%"); return &i }()))
+
+			ginkgo.By("Wait for replicas satisfied")
+			gomega.Eventually(func() int32 {
+				cs, err = tester.GetCloneSet(cs.Name)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				return cs.Status.Replicas
+			}, 3*time.Second, time.Second).Should(gomega.Equal(int32(3)))
+
+			ginkgo.By("Wait for all pods ready")
+			gomega.Eventually(func() int32 {
+				cs, err = tester.GetCloneSet(cs.Name)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				return cs.Status.ReadyReplicas
+			}, 120*time.Second, 3*time.Second).Should(gomega.Equal(int32(3)))
+		})
+	})
+})

--- a/test/e2e/framework/cloneset_util.go
+++ b/test/e2e/framework/cloneset_util.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2021 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
+	kruiseclientset "github.com/openkruise/kruise/pkg/client/clientset/versioned"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+)
+
+type CloneSetTester struct {
+	c  clientset.Interface
+	kc kruiseclientset.Interface
+	ns string
+}
+
+func NewCloneSetTester(c clientset.Interface, kc kruiseclientset.Interface, ns string) *CloneSetTester {
+	return &CloneSetTester{
+		c:  c,
+		kc: kc,
+		ns: ns,
+	}
+}
+
+func (t *CloneSetTester) NewCloneSet(name string, replicas int32) *appsv1alpha1.CloneSet {
+	return &appsv1alpha1.CloneSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: t.ns,
+			Name:      name,
+		},
+		Spec: appsv1alpha1.CloneSetSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"owner": name}},
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"owner": name},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:  "nginx",
+							Image: "nginx:1.9.1",
+							Env: []v1.EnvVar{
+								{Name: "test", Value: "foo"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (t *CloneSetTester) CreateCloneSet(cs *appsv1alpha1.CloneSet) (*appsv1alpha1.CloneSet, error) {
+	return t.kc.AppsV1alpha1().CloneSets(t.ns).Create(cs)
+}
+
+func (t *CloneSetTester) GetCloneSet(name string) (*appsv1alpha1.CloneSet, error) {
+	return t.kc.AppsV1alpha1().CloneSets(t.ns).Get(name, metav1.GetOptions{})
+}


### PR DESCRIPTION
Signed-off-by: Siyu Wang <FillZpp.pub@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Optimize in-place update for CloneSet and Advanced StatefulSet:

- change annotation `inplace-update-state` to `apps.kruise.io/inplace-update-state`
- change annotation `inplace-update-grace` to `apps.kruise.io/inplace-update-grace`
- fix CloneSet scale in with partition > replicas
- do not change Pod state to PreparingUpdate before in-place update, if no lifecycle hook defined in CloneSet
- optimize in-place update options with default functions

