### PR TITLE
Allows the customization of the container manager socket location

### DIFF
--- a/charts/kruise/v0.8.0/README.md
+++ b/charts/kruise/v0.8.0/README.md
@@ -59,6 +59,7 @@ The following table lists the configurable parameters of the kruise chart and th
 | `daemon.resources.requests.cpu`           | CPU resource request of kruise-daemon container              | `0`                           |
 | `daemon.resources.requests.memory`        | Memory resource request of kruise-daemon container           | `0`                           |
 | `daemon.affinity`                         | Affinity policy for kruise-daemon pod                        | `{}`                          |
+| `daemon.socketLocation`                   | Location of the container manager control socket             | `/var/run`                    |
 | `webhookConfiguration.failurePolicy.pods` | The failurePolicy for pods in mutating webhook configuration | `Ignore`                      |
 | `webhookConfiguration.timeoutSeconds`     | The timeoutSeconds for all webhook configuration             | `30`                          |
 | `crds.managed`                            | Kruise will not install CRDs with chart if this is false     | `true`                        |

--- a/charts/kruise/v0.8.0/templates/manager.yaml
+++ b/charts/kruise/v0.8.0/templates/manager.yaml
@@ -183,7 +183,7 @@ spec:
       serviceAccountName: kruise-daemon
       volumes:
       - hostPath:
-          path: /var/run
+          path: {{ .Values.daemon.socketLocation }}
           type: ""
         name: runtime-socket
 {{- end }}

--- a/charts/kruise/v0.8.0/values.yaml
+++ b/charts/kruise/v0.8.0/values.yaml
@@ -47,6 +47,8 @@ daemon:
 
   port: 10221
 
+  socketLocation: "/var/run"
+
   resources:
     limits:
       cpu: 50m


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

This PR enables the Helm chart to specify a location other than `/var/run` for the container manager socket (i.e., docker.sock, container.sock, etc.). This allows the kruise-daemon element of kruise 0.8.0 to function on systems in which this socket is not in the standard location; for example, on k3s-based Kubernetes installations, containerd.sock is located in `/var/run/k3s/containerd` rather than `/var/run/containerd`, resulting in kruise-daemon failing on startup.

### Ⅱ. Does this pull request fix one issue?

None; I opened no issue because it was an easy fix. :smiley:

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

No test case applies on standard system; this would require one of the different-location systems available to test on specifically.
