### PR TITLE
support reserved ordinal large than replica

### DIFF
--- a/pkg/controller/statefulset/stateful_set_control.go
+++ b/pkg/controller/statefulset/stateful_set_control.go
@@ -314,11 +314,14 @@ func (ssc *defaultStatefulSetControl) updateStatefulSet(
 	status.CollisionCount = utilpointer.Int32Ptr(collisionCount)
 	status.LabelSelector = selector.String()
 
-	reserveOrdinals := sets.NewInt()
-	if len(set.Spec.ReserveOrdinals) > 0 {
-		reserveOrdinals.Insert(set.Spec.ReserveOrdinals...)
+	reserveOrdinals := sets.NewInt(set.Spec.ReserveOrdinals...)
+	replicaCount := 0
+	for realReplicaCount := 0; realReplicaCount < int(*set.Spec.Replicas); replicaCount++ {
+		if reserveOrdinals.Has(replicaCount) {
+			continue
+		}
+		realReplicaCount++
 	}
-	replicaCount := int(*set.Spec.Replicas) + reserveOrdinals.Len()
 	// slice that will contain all Pods such that 0 <= getOrdinal(pod) < replicaCount and not in reserveOrdinals
 	replicas := make([]*v1.Pod, replicaCount)
 	// slice that will contain all Pods such that replicaCount <= getOrdinal(pod) or in reserveOrdinals

--- a/pkg/webhook/statefulset/validating/statefulset_validation.go
+++ b/pkg/webhook/statefulset/validating/statefulset_validation.go
@@ -44,9 +44,8 @@ func validateStatefulSetSpec(spec *appsv1beta1.StatefulSetSpec, fldPath *field.P
 			allErrs = append(allErrs, field.Invalid(fldPath.Root(), spec.ReserveOrdinals, "reserveOrdinals contains duplicated items"))
 		}
 		for _, i := range spec.ReserveOrdinals {
-			if i < 0 || i >= int(*spec.Replicas)+orders.Len() {
-				allErrs = append(allErrs, field.Invalid(fldPath.Root(), spec.ReserveOrdinals, fmt.Sprintf("reserveOrdinals contains %d which must be 0 <= order < (%d+%d)",
-					i, *spec.Replicas, orders.Len())))
+			if i < 0 {
+				allErrs = append(allErrs, field.Invalid(fldPath.Root(), spec.ReserveOrdinals, fmt.Sprintf("reserveOrdinals contains %d which must be order >= 0", i)))
 			}
 		}
 	}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Support reserveOrdinals which is large than `replicas+len(reservedOrdinals)`.

Imagine, sts has five replicas with the reservedOrdinals set to be {0,5}, then all the created pod are {1,2,3,4,6}. 

Later, when I want to scale sts to 4 replicas, nothing else but the spec.replicas should be changed.

What's more, when I want to scale sts back to 5 replicas, the reservedOrdinals previously set can still take effects.

On the other hand, if `0 <= order < replicas+len(reservedOrdinals)` is a must, mutating webhook might be a better choice.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


