### PR TITLE
 Optimize the CloneSetShortHash feature-gate and make it compatible with the existing Pods

### DIFF
--- a/pkg/control/sidecarcontrol/util.go
+++ b/pkg/control/sidecarcontrol/util.go
@@ -54,6 +54,8 @@ var (
 	SidecarIgnoredNamespaces = []string{"kube-system", "kube-public"}
 	// SubPathExprEnvReg format: $(ODD_NAME)、$(POD_NAME)...
 	SubPathExprEnvReg, _ = regexp.Compile(`\$\(([-._a-zA-Z][-._a-zA-Z0-9]*)\)`)
+
+	RevisionAdapterImpl = &revisionAdapterImpl{}
 )
 
 type SidecarSetUpgradeSpec struct {
@@ -91,6 +93,16 @@ func IsActivePod(pod *corev1.Pod) bool {
 		return false
 	}
 	return true
+}
+
+type revisionAdapterImpl struct{}
+
+func (r *revisionAdapterImpl) EqualToRevisionHash(sidecarSetName string, obj metav1.Object, hash string) bool {
+	return GetPodSidecarSetRevision(sidecarSetName, obj) == hash
+}
+
+func (r *revisionAdapterImpl) WriteRevisionHash(obj metav1.Object, hash string) {
+	// No need to implement yet.
 }
 
 func GetSidecarSetRevision(sidecarSet *appsv1alpha1.SidecarSet) string {

--- a/pkg/controller/cloneset/cloneset_controller.go
+++ b/pkg/controller/cloneset/cloneset_controller.go
@@ -242,17 +242,17 @@ func (r *ReconcileCloneSet) doReconcile(request reconcile.Request) (res reconcil
 	history.SortControllerRevisions(revisions)
 
 	// get the current, and update revisions
-	currentRevision, updateRevision, collisionCount, err := r.getActiveRevisions(instance, revisions, clonesetutils.GetPodsRevisions(filteredPods))
+	currentRevision, updateRevision, collisionCount, err := r.getActiveRevisions(instance, revisions)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 
 	// Refresh update expectations
 	for _, pod := range filteredPods {
-		clonesetutils.UpdateExpectations.ObserveUpdated(request.String(), clonesetutils.GetRevisionLabel(updateRevision), pod)
+		clonesetutils.UpdateExpectations.ObserveUpdated(request.String(), updateRevision.Name, pod)
 	}
 	// If update expectations have not satisfied yet, just skip this reconcile.
-	if updateSatisfied, unsatisfiedDuration, updateDirtyPods := clonesetutils.UpdateExpectations.SatisfiedExpectations(request.String(), clonesetutils.GetRevisionLabel(updateRevision)); !updateSatisfied {
+	if updateSatisfied, unsatisfiedDuration, updateDirtyPods := clonesetutils.UpdateExpectations.SatisfiedExpectations(request.String(), updateRevision.Name); !updateSatisfied {
 		if unsatisfiedDuration >= expectations.ExpectationTimeout {
 			klog.Warningf("Expectation unsatisfied overtime for %v, updateDirtyPods=%v, timeout=%v", request.String(), updateDirtyPods, unsatisfiedDuration)
 			return reconcile.Result{}, nil
@@ -285,7 +285,7 @@ func (r *ReconcileCloneSet) doReconcile(request reconcile.Request) (res reconcil
 	delayDuration, syncErr := r.syncCloneSet(instance, &newStatus, currentRevision, updateRevision, revisions, filteredPods, filteredPVCs)
 
 	// update new status
-	if err = r.statusUpdater.UpdateCloneSetStatus(instance, &newStatus, updateRevision, filteredPods); err != nil {
+	if err = r.statusUpdater.UpdateCloneSetStatus(instance, &newStatus, filteredPods); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -330,9 +330,7 @@ func (r *ReconcileCloneSet) syncCloneSet(
 	var podsScaleErr error
 	var podsUpdateErr error
 
-	scaling, podsScaleErr = r.scaleControl.Manage(currentSet, updateSet,
-		clonesetutils.GetRevisionLabel(currentRevision), clonesetutils.GetRevisionLabel(updateRevision),
-		filteredPods, filteredPVCs)
+	scaling, podsScaleErr = r.scaleControl.Manage(currentSet, updateSet, currentRevision.Name, updateRevision.Name, filteredPods, filteredPVCs)
 	if podsScaleErr != nil {
 		newStatus.Conditions = append(newStatus.Conditions, appsv1alpha1.CloneSetCondition{
 			Type:               appsv1alpha1.CloneSetConditionFailedScale,
@@ -363,7 +361,7 @@ func (r *ReconcileCloneSet) syncCloneSet(
 	return delayDuration, err
 }
 
-func (r *ReconcileCloneSet) getActiveRevisions(cs *appsv1alpha1.CloneSet, revisions []*apps.ControllerRevision, podsRevisions sets.String) (
+func (r *ReconcileCloneSet) getActiveRevisions(cs *appsv1alpha1.CloneSet, revisions []*apps.ControllerRevision) (
 	*apps.ControllerRevision, *apps.ControllerRevision, int32, error,
 ) {
 	var currentRevision, updateRevision *apps.ControllerRevision
@@ -484,13 +482,20 @@ func (r *ReconcileCloneSet) truncateHistory(
 	update *apps.ControllerRevision,
 ) error {
 	noLiveRevisions := make([]*apps.ControllerRevision, 0, len(revisions))
-	live := clonesetutils.GetPodsRevisions(pods)
-	live.Insert(current.Name, update.Name)
 
 	// collect live revisions and historic revisions
 	for i := range revisions {
-		if !live.Has(revisions[i].Name) {
-			noLiveRevisions = append(noLiveRevisions, revisions[i])
+		if revisions[i].Name != current.Name && revisions[i].Name != update.Name {
+			var found bool
+			for _, pod := range pods {
+				if clonesetutils.EqualToRevisionHash("", pod, revisions[i].Name) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				noLiveRevisions = append(noLiveRevisions, revisions[i])
+			}
 		}
 	}
 	historyLen := len(noLiveRevisions)

--- a/pkg/controller/cloneset/cloneset_controller_test.go
+++ b/pkg/controller/cloneset/cloneset_controller_test.go
@@ -17,29 +17,31 @@ limitations under the License.
 package cloneset
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
 	"time"
 
-	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/kubernetes/pkg/apis/apps"
-
 	"github.com/onsi/gomega"
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
 	clonesetutils "github.com/openkruise/kruise/pkg/controller/cloneset/utils"
+	"github.com/openkruise/kruise/pkg/features"
 	"github.com/openkruise/kruise/pkg/util"
+	utilfeature "github.com/openkruise/kruise/pkg/util/feature"
 	"github.com/openkruise/kruise/pkg/util/fieldindex"
 	"golang.org/x/net/context"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/kubernetes/pkg/apis/apps"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -131,6 +133,9 @@ func TestReconcile(t *testing.T) {
 
 	// Test for pods scale
 	testScale(g, instance)
+
+	// Enable the CloneSetShortHash feature-gate
+	utilfeature.DefaultMutableFeatureGate.Set(fmt.Sprintf("%s=true", features.CloneSetShortHash))
 
 	// Get latest cloneset
 	err = c.Get(context.TODO(), expectedRequest.NamespacedName, instance)

--- a/pkg/controller/cloneset/core/cloneset_core.go
+++ b/pkg/controller/cloneset/core/cloneset_core.go
@@ -25,7 +25,6 @@ import (
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
 	clonesetutils "github.com/openkruise/kruise/pkg/controller/cloneset/utils"
 	"github.com/openkruise/kruise/pkg/util/inplaceupdate"
-	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubecontroller "k8s.io/kubernetes/pkg/controller"
@@ -90,7 +89,7 @@ func (c *commonControl) newVersionedPods(cs *appsv1alpha1.CloneSet, revision str
 		if pod.Labels == nil {
 			pod.Labels = make(map[string]string)
 		}
-		pod.Labels[apps.ControllerRevisionHashLabelKey] = revision
+		clonesetutils.WriteRevisionHash(pod, revision)
 
 		pod.Name = fmt.Sprintf("%s-%s", cs.Name, id)
 		pod.Namespace = cs.Namespace

--- a/pkg/controller/cloneset/scale/cloneset_scale.go
+++ b/pkg/controller/cloneset/scale/cloneset_scale.go
@@ -13,7 +13,6 @@ import (
 	"github.com/openkruise/kruise/pkg/util"
 	"github.com/openkruise/kruise/pkg/util/expectations"
 	"github.com/openkruise/kruise/pkg/util/lifecycle"
-	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
@@ -177,7 +176,7 @@ func (r *realControl) createPods(
 		pod := <-podsCreationChan
 
 		cs := updateCS
-		if pod.Labels[apps.ControllerRevisionHashLabelKey] == currentRevision {
+		if clonesetutils.EqualToRevisionHash("", pod, currentRevision) {
 			cs = currentCS
 		}
 		lifecycle.SetPodLifecycle(appspub.LifecycleStateNormal)(pod)

--- a/pkg/controller/cloneset/scale/cloneset_scale_test.go
+++ b/pkg/controller/cloneset/scale/cloneset_scale_test.go
@@ -34,8 +34,8 @@ func TestCreatePods(t *testing.T) {
 	currentCS := clonesettest.NewCloneSet(3)
 	updateCS := currentCS.DeepCopy()
 	updateCS.Spec.Template.Spec.Containers[0].Env = []v1.EnvVar{{Name: "e-key", Value: "e-value"}}
-	currentRevision := "revision-abc"
-	updateRevision := "revision-xyz"
+	currentRevision := "revision_abc"
+	updateRevision := "revision_xyz"
 
 	ctrl := newFakeControl()
 	created, err := ctrl.createPods(
@@ -66,7 +66,7 @@ func TestCreatePods(t *testing.T) {
 				GenerateName: "foo-",
 				Labels: map[string]string{
 					appsv1alpha1.CloneSetInstanceID:     "id1",
-					apps.ControllerRevisionHashLabelKey: "revision-abc",
+					apps.ControllerRevisionHashLabelKey: "revision_abc",
 					"foo":                               "bar",
 					appspub.LifecycleStateKey:           string(appspub.LifecycleStateNormal),
 				},
@@ -122,7 +122,7 @@ func TestCreatePods(t *testing.T) {
 				GenerateName: "foo-",
 				Labels: map[string]string{
 					appsv1alpha1.CloneSetInstanceID:     "id3",
-					apps.ControllerRevisionHashLabelKey: "revision-xyz",
+					apps.ControllerRevisionHashLabelKey: "revision_xyz",
 					"foo":                               "bar",
 					appspub.LifecycleStateKey:           string(appspub.LifecycleStateNormal),
 				},
@@ -179,7 +179,7 @@ func TestCreatePods(t *testing.T) {
 				GenerateName: "foo-",
 				Labels: map[string]string{
 					appsv1alpha1.CloneSetInstanceID:     "id4",
-					apps.ControllerRevisionHashLabelKey: "revision-xyz",
+					apps.ControllerRevisionHashLabelKey: "revision_xyz",
 					"foo":                               "bar",
 					appspub.LifecycleStateKey:           string(appspub.LifecycleStateNormal),
 				},

--- a/pkg/controller/cloneset/update/cloneset_update_test.go
+++ b/pkg/controller/cloneset/update/cloneset_update_test.go
@@ -26,6 +26,7 @@ import (
 	appspub "github.com/openkruise/kruise/apis/apps/pub"
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
 	clonesetcore "github.com/openkruise/kruise/pkg/controller/cloneset/core"
+	clonesetutils "github.com/openkruise/kruise/pkg/controller/cloneset/utils"
 	"github.com/openkruise/kruise/pkg/util"
 	"github.com/openkruise/kruise/pkg/util/inplaceupdate"
 	"github.com/openkruise/kruise/pkg/util/lifecycle"
@@ -79,10 +80,10 @@ func TestMange(t *testing.T) {
 		{
 			name:           "do nothing",
 			cs:             &appsv1alpha1.CloneSet{Spec: appsv1alpha1.CloneSetSpec{Replicas: getInt32Pointer(1)}},
-			updateRevision: &apps.ControllerRevision{ObjectMeta: metav1.ObjectMeta{Name: "rev-new"}},
+			updateRevision: &apps.ControllerRevision{ObjectMeta: metav1.ObjectMeta{Name: "rev_new"}},
 			pods: []*v1.Pod{
 				{
-					ObjectMeta: metav1.ObjectMeta{Name: "pod-0", Labels: map[string]string{apps.ControllerRevisionHashLabelKey: "rev-new"}},
+					ObjectMeta: metav1.ObjectMeta{Name: "pod-0", Labels: map[string]string{apps.ControllerRevisionHashLabelKey: "rev_new"}},
 					Spec:       v1.PodSpec{ReadinessGates: []v1.PodReadinessGate{{ConditionType: appspub.InPlaceUpdateReady}}},
 					Status: v1.PodStatus{Phase: v1.PodRunning, Conditions: []v1.PodCondition{
 						{Type: v1.PodReady, Status: v1.ConditionTrue},
@@ -92,7 +93,7 @@ func TestMange(t *testing.T) {
 			},
 			expectedPods: []*v1.Pod{
 				{
-					ObjectMeta: metav1.ObjectMeta{Name: "pod-0", Labels: map[string]string{apps.ControllerRevisionHashLabelKey: "rev-new"}},
+					ObjectMeta: metav1.ObjectMeta{Name: "pod-0", Labels: map[string]string{apps.ControllerRevisionHashLabelKey: "rev_new"}},
 					Spec:       v1.PodSpec{ReadinessGates: []v1.PodReadinessGate{{ConditionType: appspub.InPlaceUpdateReady}}},
 					Status: v1.PodStatus{Phase: v1.PodRunning, Conditions: []v1.PodCondition{
 						{Type: v1.PodReady, Status: v1.ConditionTrue},
@@ -104,10 +105,10 @@ func TestMange(t *testing.T) {
 		{
 			name:           "normal update condition",
 			cs:             &appsv1alpha1.CloneSet{Spec: appsv1alpha1.CloneSetSpec{Replicas: getInt32Pointer(1)}},
-			updateRevision: &apps.ControllerRevision{ObjectMeta: metav1.ObjectMeta{Name: "rev-new"}},
+			updateRevision: &apps.ControllerRevision{ObjectMeta: metav1.ObjectMeta{Name: "rev_new"}},
 			pods: []*v1.Pod{
 				{
-					ObjectMeta: metav1.ObjectMeta{Name: "pod-0", Labels: map[string]string{apps.ControllerRevisionHashLabelKey: "rev-new"}},
+					ObjectMeta: metav1.ObjectMeta{Name: "pod-0", Labels: map[string]string{apps.ControllerRevisionHashLabelKey: "rev_new"}},
 					Spec:       v1.PodSpec{ReadinessGates: []v1.PodReadinessGate{{ConditionType: appspub.InPlaceUpdateReady}}},
 					Status: v1.PodStatus{Phase: v1.PodRunning, Conditions: []v1.PodCondition{
 						{Type: v1.PodReady, Status: v1.ConditionTrue},
@@ -116,7 +117,7 @@ func TestMange(t *testing.T) {
 			},
 			expectedPods: []*v1.Pod{
 				{
-					ObjectMeta: metav1.ObjectMeta{Name: "pod-0", Labels: map[string]string{apps.ControllerRevisionHashLabelKey: "rev-new"}, ResourceVersion: "1"},
+					ObjectMeta: metav1.ObjectMeta{Name: "pod-0", Labels: map[string]string{apps.ControllerRevisionHashLabelKey: "rev_new"}, ResourceVersion: "1"},
 					Spec:       v1.PodSpec{ReadinessGates: []v1.PodReadinessGate{{ConditionType: appspub.InPlaceUpdateReady}}},
 					Status: v1.PodStatus{Phase: v1.PodRunning, Conditions: []v1.PodCondition{
 						{Type: v1.PodReady, Status: v1.ConditionTrue},
@@ -131,11 +132,11 @@ func TestMange(t *testing.T) {
 				Replicas:       getInt32Pointer(1),
 				UpdateStrategy: appsv1alpha1.CloneSetUpdateStrategy{Type: appsv1alpha1.RecreateCloneSetUpdateStrategyType},
 			}},
-			updateRevision: &apps.ControllerRevision{ObjectMeta: metav1.ObjectMeta{Name: "rev-new"}},
+			updateRevision: &apps.ControllerRevision{ObjectMeta: metav1.ObjectMeta{Name: "rev_new"}},
 			pods: []*v1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "pod-0", Labels: map[string]string{
-						apps.ControllerRevisionHashLabelKey: "rev-old",
+						apps.ControllerRevisionHashLabelKey: "rev_old",
 						appsv1alpha1.CloneSetInstanceID:     "id-0",
 					}},
 					Spec: v1.PodSpec{ReadinessGates: []v1.PodReadinessGate{{ConditionType: appspub.InPlaceUpdateReady}}},
@@ -153,7 +154,7 @@ func TestMange(t *testing.T) {
 			expectedPods: []*v1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "pod-0", ResourceVersion: "1", Labels: map[string]string{
-						apps.ControllerRevisionHashLabelKey: "rev-old",
+						apps.ControllerRevisionHashLabelKey: "rev_old",
 						appsv1alpha1.CloneSetInstanceID:     "id-0",
 						appsv1alpha1.SpecifiedDeleteKey:     "true",
 					}},
@@ -177,19 +178,19 @@ func TestMange(t *testing.T) {
 				UpdateStrategy: appsv1alpha1.CloneSetUpdateStrategy{Type: appsv1alpha1.InPlaceIfPossibleCloneSetUpdateStrategyType},
 			}},
 			updateRevision: &apps.ControllerRevision{
-				ObjectMeta: metav1.ObjectMeta{Name: "rev-new"},
+				ObjectMeta: metav1.ObjectMeta{Name: "rev_new"},
 				Data:       runtime.RawExtension{Raw: []byte(`{"spec":{"template":{"$patch":"replace","spec":{"containers":[{"name":"c1","image":"foo2","env":["name":"k", "value":"v"]}]}}}}`)},
 			},
 			revisions: []*apps.ControllerRevision{
 				{
-					ObjectMeta: metav1.ObjectMeta{Name: "rev-old"},
+					ObjectMeta: metav1.ObjectMeta{Name: "rev_old"},
 					Data:       runtime.RawExtension{Raw: []byte(`{"spec":{"template":{"$patch":"replace","spec":{"containers":[{"name":"c1","image":"foo1"}]}}}}`)},
 				},
 			},
 			pods: []*v1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "pod-0", Labels: map[string]string{
-						apps.ControllerRevisionHashLabelKey: "rev-old",
+						apps.ControllerRevisionHashLabelKey: "rev_old",
 						appsv1alpha1.CloneSetInstanceID:     "id-0",
 					}},
 					Spec: v1.PodSpec{
@@ -214,7 +215,7 @@ func TestMange(t *testing.T) {
 			expectedPods: []*v1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "pod-0", ResourceVersion: "1", Labels: map[string]string{
-						apps.ControllerRevisionHashLabelKey: "rev-old",
+						apps.ControllerRevisionHashLabelKey: "rev_old",
 						appsv1alpha1.CloneSetInstanceID:     "id-0",
 						appsv1alpha1.SpecifiedDeleteKey:     "true",
 					}},
@@ -245,19 +246,19 @@ func TestMange(t *testing.T) {
 				UpdateStrategy: appsv1alpha1.CloneSetUpdateStrategy{Type: appsv1alpha1.InPlaceIfPossibleCloneSetUpdateStrategyType},
 			}},
 			updateRevision: &apps.ControllerRevision{
-				ObjectMeta: metav1.ObjectMeta{Name: "rev-new"},
+				ObjectMeta: metav1.ObjectMeta{Name: "rev_new"},
 				Data:       runtime.RawExtension{Raw: []byte(`{"spec":{"template":{"$patch":"replace","spec":{"containers":[{"name":"c1","image":"foo2"}]}}}}`)},
 			},
 			revisions: []*apps.ControllerRevision{
 				{
-					ObjectMeta: metav1.ObjectMeta{Name: "rev-old"},
+					ObjectMeta: metav1.ObjectMeta{Name: "rev_old"},
 					Data:       runtime.RawExtension{Raw: []byte(`{"spec":{"template":{"$patch":"replace","spec":{"containers":[{"name":"c1","image":"foo1"}]}}}}`)},
 				},
 			},
 			pods: []*v1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "pod-0", Labels: map[string]string{
-						apps.ControllerRevisionHashLabelKey: "rev-old",
+						apps.ControllerRevisionHashLabelKey: "rev_old",
 						appsv1alpha1.CloneSetInstanceID:     "id-0",
 					}},
 					Spec: v1.PodSpec{
@@ -283,12 +284,12 @@ func TestMange(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "pod-0",
 						Labels: map[string]string{
-							apps.ControllerRevisionHashLabelKey: "rev-new",
+							apps.ControllerRevisionHashLabelKey: "rev_new",
 							appsv1alpha1.CloneSetInstanceID:     "id-0",
 							appspub.LifecycleStateKey:           string(appspub.LifecycleStateUpdating),
 						},
 						Annotations: map[string]string{appspub.InPlaceUpdateStateKey: util.DumpJSON(appspub.InPlaceUpdateState{
-							Revision:              "rev-new",
+							Revision:              "rev_new",
 							UpdateTimestamp:       now,
 							LastContainerStatuses: map[string]appspub.InPlaceUpdateContainerStatus{"c1": {ImageID: "image-id-xyz"}},
 						})},
@@ -321,19 +322,19 @@ func TestMange(t *testing.T) {
 				UpdateStrategy: appsv1alpha1.CloneSetUpdateStrategy{Type: appsv1alpha1.InPlaceIfPossibleCloneSetUpdateStrategyType, InPlaceUpdateStrategy: &appspub.InPlaceUpdateStrategy{GracePeriodSeconds: 3630}},
 			}},
 			updateRevision: &apps.ControllerRevision{
-				ObjectMeta: metav1.ObjectMeta{Name: "rev-new"},
+				ObjectMeta: metav1.ObjectMeta{Name: "rev_new"},
 				Data:       runtime.RawExtension{Raw: []byte(`{"spec":{"template":{"$patch":"replace","spec":{"containers":[{"name":"c1","image":"foo2"}]}}}}`)},
 			},
 			revisions: []*apps.ControllerRevision{
 				{
-					ObjectMeta: metav1.ObjectMeta{Name: "rev-old"},
+					ObjectMeta: metav1.ObjectMeta{Name: "rev_old"},
 					Data:       runtime.RawExtension{Raw: []byte(`{"spec":{"template":{"$patch":"replace","spec":{"containers":[{"name":"c1","image":"foo1"}]}}}}`)},
 				},
 			},
 			pods: []*v1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "pod-0", Labels: map[string]string{
-						apps.ControllerRevisionHashLabelKey: "rev-old",
+						apps.ControllerRevisionHashLabelKey: "rev_old",
 						appsv1alpha1.CloneSetInstanceID:     "id-0",
 					}},
 					Spec: v1.PodSpec{
@@ -359,17 +360,17 @@ func TestMange(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "pod-0",
 						Labels: map[string]string{
-							apps.ControllerRevisionHashLabelKey: "rev-new",
+							apps.ControllerRevisionHashLabelKey: "rev_new",
 							appsv1alpha1.CloneSetInstanceID:     "id-0",
 							appspub.LifecycleStateKey:           string(appspub.LifecycleStateUpdating),
 						},
 						Annotations: map[string]string{
 							appspub.InPlaceUpdateStateKey: util.DumpJSON(appspub.InPlaceUpdateState{
-								Revision:              "rev-new",
+								Revision:              "rev_new",
 								UpdateTimestamp:       now,
 								LastContainerStatuses: map[string]appspub.InPlaceUpdateContainerStatus{"c1": {ImageID: "image-id-xyz"}},
 							}),
-							appspub.InPlaceUpdateGraceKey: `{"revision":"rev-new","containerImages":{"c1":"foo2"},"graceSeconds":3630}`,
+							appspub.InPlaceUpdateGraceKey: `{"revision":"rev_new","containerImages":{"c1":"foo2"},"graceSeconds":3630}`,
 						},
 						ResourceVersion: "2",
 					},
@@ -400,26 +401,26 @@ func TestMange(t *testing.T) {
 				UpdateStrategy: appsv1alpha1.CloneSetUpdateStrategy{Type: appsv1alpha1.InPlaceIfPossibleCloneSetUpdateStrategyType, InPlaceUpdateStrategy: &appspub.InPlaceUpdateStrategy{GracePeriodSeconds: 3630}},
 			}},
 			updateRevision: &apps.ControllerRevision{
-				ObjectMeta: metav1.ObjectMeta{Name: "rev-new"},
+				ObjectMeta: metav1.ObjectMeta{Name: "rev_new"},
 				Data:       runtime.RawExtension{Raw: []byte(`{"spec":{"template":{"$patch":"replace","spec":{"containers":[{"name":"c1","image":"foo2"}]}}}}`)},
 			},
 			revisions: []*apps.ControllerRevision{
 				{
-					ObjectMeta: metav1.ObjectMeta{Name: "rev-old"},
+					ObjectMeta: metav1.ObjectMeta{Name: "rev_old"},
 					Data:       runtime.RawExtension{Raw: []byte(`{"spec":{"template":{"$patch":"replace","spec":{"containers":[{"name":"c1","image":"foo1"}]}}}}`)},
 				},
 			},
 			pods: []*v1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "pod-0",
-						Labels: map[string]string{apps.ControllerRevisionHashLabelKey: "rev-new", appsv1alpha1.CloneSetInstanceID: "id-0"},
+						Labels: map[string]string{apps.ControllerRevisionHashLabelKey: "rev_new", appsv1alpha1.CloneSetInstanceID: "id-0"},
 						Annotations: map[string]string{
 							appspub.InPlaceUpdateStateKey: util.DumpJSON(appspub.InPlaceUpdateState{
-								Revision:              "rev-new",
+								Revision:              "rev_new",
 								UpdateTimestamp:       metav1.NewTime(now.Add(-time.Second * 10)),
 								LastContainerStatuses: map[string]appspub.InPlaceUpdateContainerStatus{"c1": {ImageID: "image-id-xyz"}},
 							}),
-							appspub.InPlaceUpdateGraceKey: `{"revision":"rev-new","containerImages":{"c1":"foo2"},"graceSeconds":3630}`,
+							appspub.InPlaceUpdateGraceKey: `{"revision":"rev_new","containerImages":{"c1":"foo2"},"graceSeconds":3630}`,
 						},
 					},
 					Spec: v1.PodSpec{
@@ -445,16 +446,16 @@ func TestMange(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "pod-0",
 						Labels: map[string]string{
-							apps.ControllerRevisionHashLabelKey: "rev-new",
+							apps.ControllerRevisionHashLabelKey: "rev_new",
 							appsv1alpha1.CloneSetInstanceID:     "id-0",
 						},
 						Annotations: map[string]string{
 							appspub.InPlaceUpdateStateKey: util.DumpJSON(appspub.InPlaceUpdateState{
-								Revision:              "rev-new",
+								Revision:              "rev_new",
 								UpdateTimestamp:       metav1.NewTime(now.Add(-time.Second * 10)),
 								LastContainerStatuses: map[string]appspub.InPlaceUpdateContainerStatus{"c1": {ImageID: "image-id-xyz"}},
 							}),
-							appspub.InPlaceUpdateGraceKey: `{"revision":"rev-new","containerImages":{"c1":"foo2"},"graceSeconds":3630}`,
+							appspub.InPlaceUpdateGraceKey: `{"revision":"rev_new","containerImages":{"c1":"foo2"},"graceSeconds":3630}`,
 						},
 					},
 					Spec: v1.PodSpec{
@@ -484,26 +485,26 @@ func TestMange(t *testing.T) {
 				UpdateStrategy: appsv1alpha1.CloneSetUpdateStrategy{Type: appsv1alpha1.InPlaceIfPossibleCloneSetUpdateStrategyType, InPlaceUpdateStrategy: &appspub.InPlaceUpdateStrategy{GracePeriodSeconds: 3630}},
 			}},
 			updateRevision: &apps.ControllerRevision{
-				ObjectMeta: metav1.ObjectMeta{Name: "rev-new"},
+				ObjectMeta: metav1.ObjectMeta{Name: "rev_new"},
 				Data:       runtime.RawExtension{Raw: []byte(`{"spec":{"template":{"$patch":"replace","spec":{"containers":[{"name":"c1","image":"foo2"}]}}}}`)},
 			},
 			revisions: []*apps.ControllerRevision{
 				{
-					ObjectMeta: metav1.ObjectMeta{Name: "rev-old"},
+					ObjectMeta: metav1.ObjectMeta{Name: "rev_old"},
 					Data:       runtime.RawExtension{Raw: []byte(`{"spec":{"template":{"$patch":"replace","spec":{"containers":[{"name":"c1","image":"foo1"}]}}}}`)},
 				},
 			},
 			pods: []*v1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "pod-0",
-						Labels: map[string]string{apps.ControllerRevisionHashLabelKey: "rev-new", appsv1alpha1.CloneSetInstanceID: "id-0"},
+						Labels: map[string]string{apps.ControllerRevisionHashLabelKey: "rev_new", appsv1alpha1.CloneSetInstanceID: "id-0"},
 						Annotations: map[string]string{
 							appspub.InPlaceUpdateStateKey: util.DumpJSON(appspub.InPlaceUpdateState{
-								Revision:              "rev-new",
+								Revision:              "rev_new",
 								UpdateTimestamp:       metav1.NewTime(now.Add(-time.Minute)),
 								LastContainerStatuses: map[string]appspub.InPlaceUpdateContainerStatus{"c1": {ImageID: "image-id-xyz"}},
 							}),
-							appspub.InPlaceUpdateGraceKey: `{"revision":"rev-new","containerImages":{"c1":"foo2"},"graceSeconds":3630}`,
+							appspub.InPlaceUpdateGraceKey: `{"revision":"rev_new","containerImages":{"c1":"foo2"},"graceSeconds":3630}`,
 						},
 					},
 					Spec: v1.PodSpec{
@@ -529,12 +530,12 @@ func TestMange(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "pod-0",
 						Labels: map[string]string{
-							apps.ControllerRevisionHashLabelKey: "rev-new",
+							apps.ControllerRevisionHashLabelKey: "rev_new",
 							appsv1alpha1.CloneSetInstanceID:     "id-0",
 						},
 						Annotations: map[string]string{
 							appspub.InPlaceUpdateStateKey: util.DumpJSON(appspub.InPlaceUpdateState{
-								Revision:              "rev-new",
+								Revision:              "rev_new",
 								UpdateTimestamp:       metav1.NewTime(now.Add(-time.Minute)),
 								LastContainerStatuses: map[string]appspub.InPlaceUpdateContainerStatus{"c1": {ImageID: "image-id-xyz"}},
 							}),
@@ -569,7 +570,7 @@ func TestMange(t *testing.T) {
 		ctrl := &realControl{
 			fakeClient,
 			lifecycle.NewForTest(fakeClient),
-			inplaceupdate.NewForTest(fakeClient, apps.ControllerRevisionHashLabelKey, func() metav1.Time { return now }),
+			inplaceupdate.NewForTest(fakeClient, clonesetutils.RevisionAdapterImpl, func() metav1.Time { return now }),
 			record.NewFakeRecorder(10),
 		}
 		if _, err := ctrl.Manage(mc.cs, mc.updateRevision, mc.revisions, mc.pods, mc.pvcs); err != nil {

--- a/pkg/controller/daemonset/daemonset_controller.go
+++ b/pkg/controller/daemonset/daemonset_controller.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	utildiscovery "github.com/openkruise/kruise/pkg/util/discovery"
+	"github.com/openkruise/kruise/pkg/util/revisionadapter"
 	apps "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -85,7 +86,7 @@ var (
 
 	// A TTLCache of pod creates/deletes each ds expects to see
 	expectations       = kubecontroller.NewControllerExpectations()
-	updateExpectations = kruiseExpectations.NewUpdateExpectations(GetPodRevision)
+	updateExpectations = kruiseExpectations.NewUpdateExpectations(revisionadapter.NewDefaultImpl())
 )
 
 const (
@@ -172,7 +173,7 @@ func newReconciler(mgr manager.Manager) (reconcile.Reconciler, error) {
 		nodeLister:          nodeLister,
 		suspendedDaemonPods: map[string]sets.String{},
 		failedPodsBackoff:   failedPodsBackoff,
-		inplaceControl:      inplaceupdate.New(cli, apps.ControllerRevisionHashLabelKey),
+		inplaceControl:      inplaceupdate.New(cli, revisionadapter.NewDefaultImpl()),
 		updateExp:           updateExpectations,
 	}
 	dsc.podNodeIndex = podInformer.(cache.SharedIndexInformer).GetIndexer()

--- a/pkg/controller/sidecarset/sidecarset_controller.go
+++ b/pkg/controller/sidecarset/sidecarset_controller.go
@@ -63,7 +63,7 @@ func Add(mgr manager.Manager) error {
 
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager) reconcile.Reconciler {
-	expectations := expectations.NewUpdateExpectations(sidecarcontrol.GetPodSidecarSetRevision)
+	expectations := expectations.NewUpdateExpectations(sidecarcontrol.RevisionAdapterImpl)
 	recorder := mgr.GetEventRecorderFor("sidecarset-controller")
 	cli := util.NewClientFromManager(mgr, "sidecarset-controller")
 	return &ReconcileSidecarSet{

--- a/pkg/controller/sidecarset/sidecarset_controller_test.go
+++ b/pkg/controller/sidecarset/sidecarset_controller_test.go
@@ -175,10 +175,10 @@ func testUpdateWhenUseNotUpdateStrategy(t *testing.T, sidecarSetInput *appsv1alp
 	}
 
 	fakeClient := fake.NewFakeClientWithScheme(scheme, sidecarSetInput, podInput)
-	exps := expectations.NewUpdateExpectations(sidecarcontrol.GetPodSidecarSetRevision)
+	exps := expectations.NewUpdateExpectations(sidecarcontrol.RevisionAdapterImpl)
 	reconciler := ReconcileSidecarSet{
 		Client:             fakeClient,
-		updateExpectations: expectations.NewUpdateExpectations(sidecarcontrol.GetPodSidecarSetRevision),
+		updateExpectations: expectations.NewUpdateExpectations(sidecarcontrol.RevisionAdapterImpl),
 		processor:          NewSidecarSetProcessor(fakeClient, exps, record.NewFakeRecorder(10)),
 	}
 	if _, err := reconciler.Reconcile(request); err != nil {
@@ -210,7 +210,7 @@ func testUpdateWhenSidecarSetPaused(t *testing.T, sidecarSetInput *appsv1alpha1.
 	}
 
 	fakeClient := fake.NewFakeClientWithScheme(scheme, sidecarSetInput, podInput)
-	exps := expectations.NewUpdateExpectations(sidecarcontrol.GetPodSidecarSetRevision)
+	exps := expectations.NewUpdateExpectations(sidecarcontrol.RevisionAdapterImpl)
 	reconciler := ReconcileSidecarSet{
 		Client:             fakeClient,
 		updateExpectations: exps,
@@ -245,7 +245,7 @@ func testUpdateWhenMaxUnavailableNotZero(t *testing.T, sidecarSetInput *appsv1al
 	}
 
 	fakeClient := fake.NewFakeClientWithScheme(scheme, sidecarSetInput, podInput)
-	exps := expectations.NewUpdateExpectations(sidecarcontrol.GetPodSidecarSetRevision)
+	exps := expectations.NewUpdateExpectations(sidecarcontrol.RevisionAdapterImpl)
 	reconciler := ReconcileSidecarSet{
 		Client:             fakeClient,
 		updateExpectations: exps,
@@ -281,7 +281,7 @@ func testUpdateWhenPartitionFinished(t *testing.T, sidecarSetInput *appsv1alpha1
 	}
 
 	fakeClient := fake.NewFakeClientWithScheme(scheme, sidecarSetInput, podInput)
-	exps := expectations.NewUpdateExpectations(sidecarcontrol.GetPodSidecarSetRevision)
+	exps := expectations.NewUpdateExpectations(sidecarcontrol.RevisionAdapterImpl)
 	reconciler := ReconcileSidecarSet{
 		Client:             fakeClient,
 		updateExpectations: exps,
@@ -317,7 +317,7 @@ func testRemoveSidecarSet(t *testing.T, sidecarSetInput *appsv1alpha1.SidecarSet
 	}
 
 	fakeClient := fake.NewFakeClientWithScheme(scheme, sidecarSetInput, podInput)
-	exps := expectations.NewUpdateExpectations(sidecarcontrol.GetPodSidecarSetRevision)
+	exps := expectations.NewUpdateExpectations(sidecarcontrol.RevisionAdapterImpl)
 	reconciler := ReconcileSidecarSet{
 		Client:             fakeClient,
 		updateExpectations: exps,

--- a/pkg/controller/sidecarset/sidecarset_processor_test.go
+++ b/pkg/controller/sidecarset/sidecarset_processor_test.go
@@ -167,7 +167,7 @@ func testUpdateColdUpgradeSidecar(t *testing.T, podDemo *corev1.Pod, sidecarSetI
 			expectedStatus: []int32{2, 2, 2, 2},
 		},
 	}
-	exps := expectations.NewUpdateExpectations(sidecarcontrol.GetPodSidecarSetRevision)
+	exps := expectations.NewUpdateExpectations(sidecarcontrol.RevisionAdapterImpl)
 	for _, cs := range cases {
 		t.Run(cs.name, func(t *testing.T) {
 			pods := cs.getPods()
@@ -248,7 +248,7 @@ func TestScopeNamespacePods(t *testing.T) {
 		}
 		fakeClient.Create(context.TODO(), pod)
 	}
-	exps := expectations.NewUpdateExpectations(sidecarcontrol.GetPodSidecarSetRevision)
+	exps := expectations.NewUpdateExpectations(sidecarcontrol.RevisionAdapterImpl)
 	processor := NewSidecarSetProcessor(fakeClient, exps, record.NewFakeRecorder(10))
 	pods, err := processor.getMatchingPods(sidecarSet)
 	if err != nil {
@@ -270,7 +270,7 @@ func TestCanUpgradePods(t *testing.T) {
 	}
 	fakeClient := fake.NewFakeClientWithScheme(scheme, sidecarSet)
 	pods := factoryPodsCommon(100, 0, sidecarSet)
-	exps := expectations.NewUpdateExpectations(sidecarcontrol.GetPodSidecarSetRevision)
+	exps := expectations.NewUpdateExpectations(sidecarcontrol.RevisionAdapterImpl)
 	for i := range pods {
 		if i < 50 {
 			pods[i].Annotations[sidecarcontrol.SidecarSetHashWithoutImageAnnotation] = `{"test-sidecarset":{"hash":"without-aaa"}}`

--- a/pkg/controller/statefulset/stateful_set_control_test.go
+++ b/pkg/controller/statefulset/stateful_set_control_test.go
@@ -56,6 +56,7 @@ import (
 	kruiseappslisters "github.com/openkruise/kruise/pkg/client/listers/apps/v1beta1"
 	"github.com/openkruise/kruise/pkg/util/inplaceupdate"
 	"github.com/openkruise/kruise/pkg/util/lifecycle"
+	"github.com/openkruise/kruise/pkg/util/revisionadapter"
 )
 
 type invariantFunc func(set *appsv1beta1.StatefulSet, spc *fakeStatefulPodControl) error
@@ -66,7 +67,7 @@ func setupController(client clientset.Interface, kruiseClient kruiseclientset.In
 	spc := newFakeStatefulPodControl(informerFactory.Core().V1().Pods(), kruiseInformerFactory.Apps().V1beta1().StatefulSets())
 	ssu := newFakeStatefulSetStatusUpdater(kruiseInformerFactory.Apps().V1beta1().StatefulSets())
 	recorder := record.NewFakeRecorder(10)
-	inplaceControl := inplaceupdate.NewForInformer(informerFactory.Core().V1().Pods(), apps.ControllerRevisionHashLabelKey)
+	inplaceControl := inplaceupdate.NewForInformer(informerFactory.Core().V1().Pods(), revisionadapter.NewDefaultImpl())
 	lifecycleControl := lifecycle.NewForInformer(informerFactory.Core().V1().Pods())
 	ssc := NewDefaultStatefulSetControl(spc, inplaceControl, lifecycleControl, ssu, history.NewFakeHistory(informerFactory.Apps().V1().ControllerRevisions()), recorder)
 
@@ -548,7 +549,7 @@ func TestStatefulSetControl_getSetRevisions(t *testing.T) {
 		spc := newFakeStatefulPodControl(informerFactory.Core().V1().Pods(), kruiseInformerFactory.Apps().V1beta1().StatefulSets())
 		ssu := newFakeStatefulSetStatusUpdater(kruiseInformerFactory.Apps().V1beta1().StatefulSets())
 		recorder := record.NewFakeRecorder(10)
-		inplaceControl := inplaceupdate.NewForInformer(informerFactory.Core().V1().Pods(), apps.ControllerRevisionHashLabelKey)
+		inplaceControl := inplaceupdate.NewForInformer(informerFactory.Core().V1().Pods(), revisionadapter.NewDefaultImpl())
 		lifecycleControl := lifecycle.NewForInformer(informerFactory.Core().V1().Pods())
 		ssc := defaultStatefulSetControl{spc, ssu, history.NewFakeHistory(informerFactory.Apps().V1().ControllerRevisions()), recorder, inplaceControl, lifecycleControl}
 

--- a/pkg/controller/statefulset/statefulset_controller_test.go
+++ b/pkg/controller/statefulset/statefulset_controller_test.go
@@ -32,7 +32,7 @@ import (
 	kruiseappslisters "github.com/openkruise/kruise/pkg/client/listers/apps/v1beta1"
 	"github.com/openkruise/kruise/pkg/util/inplaceupdate"
 	"github.com/openkruise/kruise/pkg/util/lifecycle"
-	apps "k8s.io/api/apps/v1"
+	"github.com/openkruise/kruise/pkg/util/revisionadapter"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -634,7 +634,7 @@ func newFakeStatefulSetController(initialObjects ...runtime.Object) (*StatefulSe
 	ssc.podListerSynced = alwaysReady
 	ssc.setListerSynced = alwaysReady
 	recorder := record.NewFakeRecorder(10)
-	inplaceControl := inplaceupdate.NewForInformer(informerFactory.Core().V1().Pods(), apps.ControllerRevisionHashLabelKey)
+	inplaceControl := inplaceupdate.NewForInformer(informerFactory.Core().V1().Pods(), revisionadapter.NewDefaultImpl())
 	lifecycleControl := lifecycle.NewForInformer(informerFactory.Core().V1().Pods())
 	ssc.control = NewDefaultStatefulSetControl(fpc, inplaceControl, lifecycleControl, ssu, ssh, recorder)
 
@@ -794,7 +794,7 @@ func NewStatefulSetController(
 					podInformer.Lister(),
 					pvcInformer.Lister(),
 					recorder),
-				inplaceupdate.NewForTypedClient(kubeClient, apps.ControllerRevisionHashLabelKey),
+				inplaceupdate.NewForTypedClient(kubeClient, revisionadapter.NewDefaultImpl()),
 				lifecycle.NewForTypedClient(kubeClient),
 				NewRealStatefulSetStatusUpdater(kruiseClient, setInformer.Lister()),
 				history.NewHistory(kubeClient, revInformer.Lister()),

--- a/pkg/features/kruise_features.go
+++ b/pkg/features/kruise_features.go
@@ -33,14 +33,14 @@ const (
 	// PodWebhook enables webhook for Pods creations. This is also related to SidecarSet.
 	PodWebhook featuregate.Feature = "PodWebhook"
 
-	// CloneSetHashOnlyRevisionName enables CloneSet controller only set revision hash name to pod.
-	CloneSetHashOnlyRevisionName featuregate.Feature = "CloneSetHashOnlyRevisionName"
+	// CloneSetShortHash enables CloneSet controller only set revision hash name to pod label.
+	CloneSetShortHash featuregate.Feature = "CloneSetShortHash"
 )
 
 var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	PodWebhook:                   {Default: true, PreRelease: featuregate.Beta},
-	KruiseDaemon:                 {Default: true, PreRelease: featuregate.Beta},
-	CloneSetHashOnlyRevisionName: {Default: false, PreRelease: featuregate.Beta},
+	PodWebhook:        {Default: true, PreRelease: featuregate.Beta},
+	KruiseDaemon:      {Default: true, PreRelease: featuregate.Beta},
+	CloneSetShortHash: {Default: false, PreRelease: featuregate.Alpha},
 }
 
 func init() {

--- a/pkg/util/inplaceupdate/inplace_utils_test.go
+++ b/pkg/util/inplaceupdate/inplace_utils_test.go
@@ -25,6 +25,7 @@ import (
 
 	appspub "github.com/openkruise/kruise/apis/apps/pub"
 	"github.com/openkruise/kruise/pkg/util"
+	"github.com/openkruise/kruise/pkg/util/revisionadapter"
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -433,7 +434,7 @@ func TestRefresh(t *testing.T) {
 		testCase.expectedPod.Kind = "Pod"
 
 		cli := fake.NewFakeClient(testCase.pod)
-		ctrl := NewForTest(cli, apps.ControllerRevisionHashLabelKey, func() metav1.Time { return aHourAgo })
+		ctrl := NewForTest(cli, revisionadapter.NewDefaultImpl(), func() metav1.Time { return aHourAgo })
 		if res := ctrl.Refresh(testCase.pod, nil); res.RefreshErr != nil {
 			t.Fatalf("failed to update condition: %v", res.RefreshErr)
 		}

--- a/pkg/util/revisionadapter/revision_adapter.go
+++ b/pkg/util/revisionadapter/revision_adapter.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2021 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package revisionadapter
+
+import (
+	apps "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type Interface interface {
+	EqualToRevisionHash(controllerKey string, obj metav1.Object, hash string) bool
+	WriteRevisionHash(obj metav1.Object, hash string)
+}
+
+func NewDefaultImpl() Interface {
+	return &defaultImpl{}
+}
+
+type defaultImpl struct{}
+
+func (r *defaultImpl) EqualToRevisionHash(_ string, obj metav1.Object, hash string) bool {
+	return obj.GetLabels()[apps.ControllerRevisionHashLabelKey] == hash
+}
+
+func (r *defaultImpl) WriteRevisionHash(obj metav1.Object, hash string) {
+	if obj.GetLabels() == nil {
+		obj.SetLabels(make(map[string]string, 1))
+	}
+	obj.GetLabels()[apps.ControllerRevisionHashLabelKey] = hash
+}


### PR DESCRIPTION

Signed-off-by: FillZpp <FillZpp.pub@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
 Optimize the CloneSetShortHash feature-gate and make it compatible with the existing Pods

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #536 

### Ⅴ. Special notes for reviews

1. The existing Pods use the name of ControllerRevision as their controller-revision-hash
2. The name of ControllerRevision is spliced [here](https://github.com/openkruise/kruise/blob/master/vendor/k8s.io/kubernetes/pkg/controller/history/controller_history.go#L55) , and the real hash must be the last '-' substring of revision name.
3. So, we should compare the real hashes by the last piece of revision hash.

