### PR TITLE
change cloneset scale expectation structure

### DIFF
--- a/pkg/controller/cloneset/cloneset_controller.go
+++ b/pkg/controller/cloneset/cloneset_controller.go
@@ -192,7 +192,6 @@ func (r *ReconcileCloneSet) doReconcile(request reconcile.Request) (res reconcil
 			// Object not found, return.  Created objects are automatically garbage collected.
 			// For additional cleanup logic use finalizers.
 			klog.V(3).Infof("CloneSet %s has been deleted.", request)
-			clonesetutils.ScaleExpectations.DeleteExpectations(request.String())
 			clonesetutils.UpdateExpectations.DeleteExpectations(request.String())
 			return reconcile.Result{}, nil
 		}
@@ -213,7 +212,7 @@ func (r *ReconcileCloneSet) doReconcile(request reconcile.Request) (res reconcil
 	}
 
 	// If scaling expectations have not satisfied yet, just skip this reconcile.
-	if scaleSatisfied, unsatisfiedDuration, scaleDirtyPods := clonesetutils.ScaleExpectations.SatisfiedExpectations(request.String()); !scaleSatisfied {
+	if scaleSatisfied, unsatisfiedDuration, scaleDirtyPods := clonesetutils.ScaleExpectations.SatisfiedExpectations(request.Namespace); !scaleSatisfied {
 		if unsatisfiedDuration >= expectations.ExpectationTimeout {
 			klog.Warningf("Expectation unsatisfied overtime for %v, scaleDirtyPods=%v, overtime=%v", request.String(), scaleDirtyPods, unsatisfiedDuration)
 			return reconcile.Result{}, nil

--- a/pkg/controller/cloneset/scale/cloneset_scale.go
+++ b/pkg/controller/cloneset/scale/cloneset_scale.go
@@ -167,7 +167,7 @@ func (r *realControl) createPods(
 
 	podsCreationChan := make(chan *v1.Pod, len(newPods))
 	for _, p := range newPods {
-		clonesetutils.ScaleExpectations.ExpectScale(clonesetutils.GetControllerKey(updateCS), expectations.Create, p.Name)
+		clonesetutils.ScaleExpectations.ExpectScale(p.Namespace, expectations.Create, p.Name)
 		podsCreationChan <- p
 	}
 
@@ -196,7 +196,7 @@ func (r *realControl) createPods(
 	// rollback to ignore failure pods because the informer won't observe these pods
 	for _, pod := range newPods {
 		if _, ok := successPodNames.Load(pod.Name); !ok {
-			clonesetutils.ScaleExpectations.ObserveScale(clonesetutils.GetControllerKey(updateCS), expectations.Create, pod.Name)
+			clonesetutils.ScaleExpectations.ObserveScale(pod.Namespace, expectations.Create, pod.Name)
 		}
 	}
 
@@ -212,9 +212,9 @@ func (r *realControl) createOnePod(cs *appsv1alpha1.CloneSet, pod *v1.Pod, exist
 		if existingPVCNames.Has(c.Name) {
 			continue
 		}
-		clonesetutils.ScaleExpectations.ExpectScale(clonesetutils.GetControllerKey(cs), expectations.Create, c.Name)
+		clonesetutils.ScaleExpectations.ExpectScale(c.Namespace, expectations.Create, c.Name)
 		if err := r.Create(context.TODO(), &c); err != nil {
-			clonesetutils.ScaleExpectations.ObserveScale(clonesetutils.GetControllerKey(cs), expectations.Create, c.Name)
+			clonesetutils.ScaleExpectations.ObserveScale(c.Namespace, expectations.Create, c.Name)
 			r.recorder.Eventf(cs, v1.EventTypeWarning, "FailedCreate", "failed to create pvc: %v, pvc: %v", err, util.DumpJSON(c))
 			return err
 		}
@@ -244,9 +244,9 @@ func (r *realControl) deletePods(cs *appsv1alpha1.CloneSet, podsToDelete []*v1.P
 			continue
 		}
 
-		clonesetutils.ScaleExpectations.ExpectScale(clonesetutils.GetControllerKey(cs), expectations.Delete, pod.Name)
+		clonesetutils.ScaleExpectations.ExpectScale(pod.Namespace, expectations.Delete, pod.Name)
 		if err := r.Delete(context.TODO(), pod); err != nil {
-			clonesetutils.ScaleExpectations.ObserveScale(clonesetutils.GetControllerKey(cs), expectations.Delete, pod.Name)
+			clonesetutils.ScaleExpectations.ObserveScale(pod.Namespace, expectations.Delete, pod.Name)
 			r.recorder.Eventf(cs, v1.EventTypeWarning, "FailedDelete", "failed to delete pod %s: %v", pod.Name, err)
 			return modified, err
 		}
@@ -259,9 +259,9 @@ func (r *realControl) deletePods(cs *appsv1alpha1.CloneSet, podsToDelete []*v1.P
 				continue
 			}
 
-			clonesetutils.ScaleExpectations.ExpectScale(clonesetutils.GetControllerKey(cs), expectations.Delete, pvc.Name)
+			clonesetutils.ScaleExpectations.ExpectScale(pvc.Namespace, expectations.Delete, pvc.Name)
 			if err := r.Delete(context.TODO(), pvc); err != nil {
-				clonesetutils.ScaleExpectations.ObserveScale(clonesetutils.GetControllerKey(cs), expectations.Delete, pvc.Name)
+				clonesetutils.ScaleExpectations.ObserveScale(pvc.Namespace, expectations.Delete, pvc.Name)
 				r.recorder.Eventf(cs, v1.EventTypeWarning, "FailedDelete", "failed to delete pvc %s: %v", pvc.Name, err)
 				return modified, err
 			}

--- a/pkg/controller/cloneset/scale/cloneset_scale_test.go
+++ b/pkg/controller/cloneset/scale/cloneset_scale_test.go
@@ -320,7 +320,7 @@ func TestCreatePods(t *testing.T) {
 		t.Fatalf("expected pvcs \n%s\ngot pvcs\n%s", util.DumpJSON(expectedPVCs), util.DumpJSON(pvcs.Items))
 	}
 
-	exp := clonesetutils.ScaleExpectations.GetExpectations("default/foo")
+	exp := clonesetutils.ScaleExpectations.GetExpectations("default")
 	expectedExp := map[expectations.ScaleAction]sets.String{
 		expectations.Create: sets.NewString("foo-id1", "foo-id3", "foo-id4", "datadir-foo-id1", "datadir-foo-id4"),
 	}

--- a/pkg/util/expectations/scale_expectations_test.go
+++ b/pkg/util/expectations/scale_expectations_test.go
@@ -6,31 +6,26 @@ import (
 
 func TestScale(t *testing.T) {
 	e := NewScaleExpectations()
-	controllerKey01 := "default/cs01"
-	controllerKey02 := "default/cs02"
-	pod01 := "pod01"
-	pod02 := "pod02"
-
-	e.ExpectScale(controllerKey01, Create, pod01)
-	e.ExpectScale(controllerKey01, Create, pod02)
-	e.ExpectScale(controllerKey01, Delete, pod01)
-	if ok, _, _ := e.SatisfiedExpectations(controllerKey01); ok {
+	controllerCreateKey := "default"
+	podCreate := "podCreate"
+	e.ExpectScale(controllerCreateKey, Create, podCreate)
+	if ok, _, _ := e.SatisfiedExpectations(controllerCreateKey); ok {
+		t.Fatalf("expected not satisfied")
+	}
+	e.ObserveScale(controllerCreateKey, Create, podCreate)
+	if ok, _, _ := e.SatisfiedExpectations(controllerCreateKey); !ok {
 		t.Fatalf("expected not satisfied")
 	}
 
-	e.ObserveScale(controllerKey01, Create, pod02)
-	e.ObserveScale(controllerKey01, Create, pod01)
-	if ok, _, _ := e.SatisfiedExpectations(controllerKey01); ok {
+	controllerDeleteKey := "default-delete"
+	podDelete := "podDelete"
+
+	e.ExpectScale(controllerDeleteKey, Delete, podDelete)
+	if ok, _, _ := e.SatisfiedExpectations(controllerDeleteKey); ok {
 		t.Fatalf("expected not satisfied")
 	}
-
-	e.ObserveScale(controllerKey02, Delete, pod01)
-	if ok, _, _ := e.SatisfiedExpectations(controllerKey01); ok {
+	e.ObserveScale(controllerDeleteKey, Delete, podDelete)
+	if ok, _, _ := e.SatisfiedExpectations(controllerDeleteKey); !ok {
 		t.Fatalf("expected not satisfied")
-	}
-
-	e.ObserveScale(controllerKey01, Delete, pod01)
-	if ok, _, _ := e.SatisfiedExpectations(controllerKey01); !ok {
-		t.Fatalf("expected satisfied")
 	}
 }


### PR DESCRIPTION
Signed-off-by: JunjunLi <junjunli666@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

change cloneset scale expectation structure 

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

cloneset scale expectation map structure depends on cloneset's name and namespaces.

but in some cases, pod's `ownReference` will be set empty by other's task. in that case,  pod's owner, that is cloneset,  scale expectation will not be observed, that result it dirty pod in workload.



### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

https://github.com/hellolijj/kruise/blob/fixup/cloneset-expectation-key-structure/pkg/controller/cloneset/cloneset_event_handler_test.go#L737-L788

### Ⅳ. Describe how to verify it

### Ⅴ. Special notes for reviews
