### PR TITLE
Add KruisePodReady readiness-gate

### DIFF
--- a/apis/apps/pub/pod_readiness_gate.go
+++ b/apis/apps/pub/pod_readiness_gate.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2021 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pub
+
+import v1 "k8s.io/api/core/v1"
+
+const (
+	KruisePodReadyConditionType v1.PodConditionType = "KruisePodReady"
+)

--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ import (
 	"time"
 
 	extclient "github.com/openkruise/kruise/pkg/client"
-	_ "github.com/openkruise/kruise/pkg/features"
+	"github.com/openkruise/kruise/pkg/features"
 	utilfeature "github.com/openkruise/kruise/pkg/util/feature"
 	"github.com/openkruise/kruise/pkg/util/fieldindex"
 	"github.com/openkruise/kruise/pkg/webhook"
@@ -87,6 +87,11 @@ func main() {
 	pflag.Parse()
 	rand.Seed(time.Now().UnixNano())
 	ctrl.SetLogger(klogr.New())
+
+	if err := features.ValidateFeatureGates(); err != nil {
+		setupLog.Error(err, "unable to setup feature-gates")
+		os.Exit(1)
+	}
 
 	if enablePprof {
 		go func() {

--- a/pkg/controller/controllers.go
+++ b/pkg/controller/controllers.go
@@ -23,6 +23,7 @@ import (
 	"github.com/openkruise/kruise/pkg/controller/daemonset"
 	"github.com/openkruise/kruise/pkg/controller/imagepulljob"
 	"github.com/openkruise/kruise/pkg/controller/nodeimage"
+	"github.com/openkruise/kruise/pkg/controller/podreadiness"
 	"github.com/openkruise/kruise/pkg/controller/sidecarset"
 	"github.com/openkruise/kruise/pkg/controller/statefulset"
 	"github.com/openkruise/kruise/pkg/controller/uniteddeployment"
@@ -40,6 +41,7 @@ func init() {
 	controllerAddFuncs = append(controllerAddFuncs, daemonset.Add)
 	controllerAddFuncs = append(controllerAddFuncs, nodeimage.Add)
 	controllerAddFuncs = append(controllerAddFuncs, imagepulljob.Add)
+	controllerAddFuncs = append(controllerAddFuncs, podreadiness.Add)
 	controllerAddFuncs = append(controllerAddFuncs, sidecarset.Add)
 	controllerAddFuncs = append(controllerAddFuncs, statefulset.Add)
 	controllerAddFuncs = append(controllerAddFuncs, uniteddeployment.Add)

--- a/pkg/controller/podreadiness/pod_readiness_controller.go
+++ b/pkg/controller/podreadiness/pod_readiness_controller.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2021 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package podreadiness
+
+import (
+	"context"
+	"time"
+
+	appspub "github.com/openkruise/kruise/apis/apps/pub"
+	"github.com/openkruise/kruise/pkg/util"
+	utilpodreadiness "github.com/openkruise/kruise/pkg/util/podreadiness"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/klog"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+var (
+	concurrentReconciles = 3
+)
+
+func Add(mgr manager.Manager) error {
+	return add(mgr, newReconciler(mgr))
+}
+
+// newReconciler returns a new reconcile.Reconciler
+func newReconciler(mgr manager.Manager) *ReconcilePodReadiness {
+	return &ReconcilePodReadiness{
+		Client: util.NewClientFromManager(mgr, "pod-readiness-controller"),
+	}
+}
+
+// add adds a new Controller to mgr with r as the reconcile.Reconciler
+func add(mgr manager.Manager, r *ReconcilePodReadiness) error {
+	// Create a new controller
+	c, err := controller.New("pod-readiness-controller", mgr, controller.Options{Reconciler: r, MaxConcurrentReconciles: concurrentReconciles})
+	if err != nil {
+		return err
+	}
+
+	err = c.Watch(&source.Kind{Type: &v1.Pod{}}, &handler.EnqueueRequestForObject{}, predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			pod := e.Object.(*v1.Pod)
+			return utilpodreadiness.ContainsReadinessGate(pod) && utilpodreadiness.GetReadinessCondition(pod) == nil
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			pod := e.ObjectNew.(*v1.Pod)
+			return utilpodreadiness.ContainsReadinessGate(pod) && utilpodreadiness.GetReadinessCondition(pod) == nil
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return false
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return false
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var _ reconcile.Reconciler = &ReconcilePodReadiness{}
+
+// ReconcilePodReadiness reconciles a Pod object
+type ReconcilePodReadiness struct {
+	client.Client
+}
+
+// +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=pods/status,verbs=get;update;patch
+
+func (r *ReconcilePodReadiness) Reconcile(request reconcile.Request) (res reconcile.Result, err error) {
+	start := time.Now()
+	klog.V(3).Infof("Starting to process Pod %v", request.NamespacedName)
+	defer func() {
+		if err != nil {
+			klog.Warningf("Failed to process Pod %v, elapsedTime %v, error: %v", request.NamespacedName, time.Since(start), err)
+		} else {
+			klog.Infof("Finish to process Pod %v, elapsedTime %v", request.NamespacedName, time.Since(start))
+		}
+	}()
+
+	err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		pod := &v1.Pod{}
+		err = r.Get(context.TODO(), request.NamespacedName, pod)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				// Object not found, return.  Created objects are automatically garbage collected.
+				// For additional cleanup logic use finalizers.
+				return nil
+			}
+			// Error reading the object - requeue the request.
+			return err
+		}
+		if pod.DeletionTimestamp != nil {
+			return nil
+		}
+		if !utilpodreadiness.ContainsReadinessGate(pod) {
+			return nil
+		}
+		if utilpodreadiness.GetReadinessCondition(pod) != nil {
+			return nil
+		}
+
+		pod.Status.Conditions = append(pod.Status.Conditions, v1.PodCondition{
+			Type:               appspub.KruisePodReadyConditionType,
+			Status:             v1.ConditionTrue,
+			LastTransitionTime: metav1.Now(),
+		})
+		return r.Status().Update(context.TODO(), pod)
+	})
+	return reconcile.Result{}, err
+}

--- a/pkg/controller/podreadiness/pod_readiness_controller_test.go
+++ b/pkg/controller/podreadiness/pod_readiness_controller_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2021 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package podreadiness
+
+import (
+	"context"
+	"testing"
+
+	appspub "github.com/openkruise/kruise/apis/apps/pub"
+	utilpodreadiness "github.com/openkruise/kruise/pkg/util/podreadiness"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestReconcile(t *testing.T) {
+	pod0 := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceDefault, Name: "pod0"},
+		Spec: v1.PodSpec{
+			ReadinessGates: []v1.PodReadinessGate{{ConditionType: appspub.KruisePodReadyConditionType}},
+		},
+	}
+	pod1 := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceDefault, Name: "pod1"},
+		Spec: v1.PodSpec{
+			ReadinessGates: []v1.PodReadinessGate{},
+		},
+	}
+	fakeClient := fake.NewFakeClientWithScheme(clientgoscheme.Scheme, pod0, pod1)
+	reconciler := &ReconcilePodReadiness{Client: fakeClient}
+
+	_, err := reconciler.Reconcile(reconcile.Request{NamespacedName: types.NamespacedName{Namespace: pod0.Namespace, Name: pod0.Name}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = reconciler.Reconcile(reconcile.Request{NamespacedName: types.NamespacedName{Namespace: pod1.Namespace, Name: pod1.Name}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	newPod0 := &v1.Pod{}
+	if err := fakeClient.Get(context.TODO(), types.NamespacedName{Namespace: pod0.Namespace, Name: pod0.Name}, newPod0); err != nil {
+		t.Fatal(err)
+	}
+	condition := utilpodreadiness.GetReadinessCondition(newPod0)
+	if condition == nil || condition.Status != v1.ConditionTrue {
+		t.Fatalf("expect pod0 ready, got %v", condition)
+	}
+
+	newPod1 := &v1.Pod{}
+	if err := fakeClient.Get(context.TODO(), types.NamespacedName{Namespace: pod1.Namespace, Name: pod1.Name}, newPod1); err != nil {
+		t.Fatal(err)
+	}
+	condition = utilpodreadiness.GetReadinessCondition(newPod1)
+	if condition != nil {
+		t.Fatalf("expect pod1 no ready, got %v", condition)
+	}
+}

--- a/pkg/util/podreadiness/pod_readiness_utils.go
+++ b/pkg/util/podreadiness/pod_readiness_utils.go
@@ -1,0 +1,186 @@
+/*
+Copyright 2021 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package podreadiness
+
+import (
+	"context"
+	"encoding/json"
+	"sort"
+
+	appspub "github.com/openkruise/kruise/apis/apps/pub"
+	"github.com/openkruise/kruise/pkg/util"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func AddNotReadyKey(c client.Client, pod *v1.Pod, msg Message) error {
+	if alreadyHasKey(pod, msg) {
+		return nil
+	}
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		newPod := &v1.Pod{}
+		if err := c.Get(context.TODO(), types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}, newPod); err != nil {
+			return err
+		}
+		if !ContainsReadinessGate(pod) {
+			return nil
+		}
+
+		condition := GetReadinessCondition(newPod)
+		if condition == nil {
+			_, messages := addMessage("", msg)
+			newPod.Status.Conditions = append(newPod.Status.Conditions, v1.PodCondition{
+				Type:               appspub.KruisePodReadyConditionType,
+				Message:            messages.dump(),
+				LastTransitionTime: metav1.Now(),
+			})
+		} else {
+			changed, messages := addMessage(condition.Message, msg)
+			if !changed {
+				return nil
+			}
+			condition.Status = v1.ConditionFalse
+			condition.Message = messages.dump()
+			condition.LastTransitionTime = metav1.Now()
+		}
+
+		return c.Status().Update(context.TODO(), newPod)
+	})
+}
+
+func RemoveNotReadyKey(c client.Client, pod *v1.Pod, msg Message) error {
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		newPod := &v1.Pod{}
+		if err := c.Get(context.TODO(), types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}, newPod); err != nil {
+			return err
+		}
+		if !ContainsReadinessGate(pod) {
+			return nil
+		}
+
+		condition := GetReadinessCondition(newPod)
+		if condition == nil {
+			return nil
+		}
+		changed, messages := removeMessage(condition.Message, msg)
+		if !changed {
+			return nil
+		}
+		if len(messages) == 0 {
+			condition.Status = v1.ConditionTrue
+		}
+		condition.Message = messages.dump()
+		condition.LastTransitionTime = metav1.Now()
+
+		return c.Status().Update(context.TODO(), newPod)
+	})
+}
+
+type Message struct {
+	UserAgent string `json:"userAgent"`
+	Key       string `json:"key"`
+}
+
+type messageList []Message
+
+func (c messageList) Len() int      { return len(c) }
+func (c messageList) Swap(i, j int) { c[i], c[j] = c[j], c[i] }
+func (c messageList) Less(i, j int) bool {
+	if c[i].UserAgent == c[j].UserAgent {
+		return c[i].Key < c[j].Key
+	}
+	return c[i].UserAgent < c[j].UserAgent
+}
+
+func (c messageList) dump() string {
+	sort.Sort(c)
+	return util.DumpJSON(c)
+}
+
+func addMessage(base string, msg Message) (bool, messageList) {
+	messages := messageList{}
+	if base != "" {
+		_ = json.Unmarshal([]byte(base), &messages)
+	}
+	for _, m := range messages {
+		if m.UserAgent == msg.UserAgent && m.Key == msg.Key {
+			return false, messages
+		}
+	}
+	messages = append(messages, msg)
+	return true, messages
+}
+
+func removeMessage(base string, msg Message) (bool, messageList) {
+	messages := messageList{}
+	if base != "" {
+		_ = json.Unmarshal([]byte(base), &messages)
+	}
+	var removed bool
+	newMessages := messageList{}
+	for _, m := range messages {
+		if m.UserAgent == msg.UserAgent && m.Key == msg.Key {
+			removed = true
+			continue
+		}
+		newMessages = append(newMessages, m)
+	}
+	return removed, newMessages
+}
+
+func GetReadinessCondition(pod *v1.Pod) *v1.PodCondition {
+	if pod == nil {
+		return nil
+	}
+	for i := range pod.Status.Conditions {
+		c := &pod.Status.Conditions[i]
+		if c.Type == appspub.KruisePodReadyConditionType {
+			return c
+		}
+	}
+	return nil
+}
+
+func ContainsReadinessGate(pod *v1.Pod) bool {
+	for _, g := range pod.Spec.ReadinessGates {
+		if g.ConditionType == appspub.KruisePodReadyConditionType {
+			return true
+		}
+	}
+	return false
+}
+
+func alreadyHasKey(pod *v1.Pod, msg Message) bool {
+	condition := GetReadinessCondition(pod)
+	if condition == nil {
+		return false
+	}
+	if condition.Status == v1.ConditionTrue || condition.Message == "" {
+		return false
+	}
+	messages := messageList{}
+	_ = json.Unmarshal([]byte(condition.Message), &messages)
+	for _, m := range messages {
+		if m.UserAgent == msg.UserAgent && m.Key == msg.Key {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/util/podreadiness/pod_readiness_utils_test.go
+++ b/pkg/util/podreadiness/pod_readiness_utils_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2021 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package podreadiness
+
+import (
+	"context"
+	"testing"
+
+	appspub "github.com/openkruise/kruise/apis/apps/pub"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestPodReadiness(t *testing.T) {
+	pod0 := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceDefault, Name: "pod0"},
+		Spec: v1.PodSpec{
+			ReadinessGates: []v1.PodReadinessGate{{ConditionType: appspub.KruisePodReadyConditionType}},
+		},
+	}
+	pod1 := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceDefault, Name: "pod1"},
+		Spec: v1.PodSpec{
+			ReadinessGates: []v1.PodReadinessGate{},
+		},
+	}
+	fakeClient := fake.NewFakeClientWithScheme(clientgoscheme.Scheme, pod0, pod1)
+
+	msg0 := Message{UserAgent: "ua1", Key: "foo"}
+	msg1 := Message{UserAgent: "ua1", Key: "bar"}
+
+	if err := AddNotReadyKey(fakeClient, pod0, msg0); err != nil {
+		t.Fatal(err)
+	}
+	if err := AddNotReadyKey(fakeClient, pod0, msg1); err != nil {
+		t.Fatal(err)
+	}
+	if err := AddNotReadyKey(fakeClient, pod1, msg0); err != nil {
+		t.Fatal(err)
+	}
+	if err := AddNotReadyKey(fakeClient, pod1, msg1); err != nil {
+		t.Fatal(err)
+	}
+
+	newPod0 := &v1.Pod{}
+	if err := fakeClient.Get(context.TODO(), types.NamespacedName{Namespace: pod0.Namespace, Name: pod0.Name}, newPod0); err != nil {
+		t.Fatal(err)
+	}
+	if !alreadyHasKey(newPod0, msg0) || !alreadyHasKey(newPod0, msg1) {
+		t.Fatalf("expect already has key, but not")
+	}
+	condition := GetReadinessCondition(newPod0)
+	if condition.Status != v1.ConditionFalse {
+		t.Fatalf("expect condition false, but not")
+	}
+
+	newPod1 := &v1.Pod{}
+	if err := fakeClient.Get(context.TODO(), types.NamespacedName{Namespace: pod1.Namespace, Name: pod1.Name}, newPod1); err != nil {
+		t.Fatal(err)
+	}
+	if alreadyHasKey(newPod1, msg0) || alreadyHasKey(newPod1, msg1) {
+		t.Fatalf("expect not have key, but it does")
+	}
+	if condition = GetReadinessCondition(newPod1); condition != nil {
+		t.Fatalf("expect condition nil, but exists: %v", condition)
+	}
+
+	if err := RemoveNotReadyKey(fakeClient, newPod0, msg0); err != nil {
+		t.Fatal(err)
+	}
+	newPod0 = &v1.Pod{}
+	if err := fakeClient.Get(context.TODO(), types.NamespacedName{Namespace: pod0.Namespace, Name: pod0.Name}, newPod0); err != nil {
+		t.Fatal(err)
+	}
+	if !alreadyHasKey(newPod0, msg1) {
+		t.Fatalf("expect already has key, but not")
+	}
+	if alreadyHasKey(newPod0, msg0) {
+		t.Fatalf("expect not have key, but it does")
+	}
+	condition = GetReadinessCondition(newPod0)
+	if condition.Status != v1.ConditionFalse {
+		t.Fatalf("expect condition false, but not")
+	}
+
+	if err := RemoveNotReadyKey(fakeClient, newPod0, msg1); err != nil {
+		t.Fatal(err)
+	}
+	newPod0 = &v1.Pod{}
+	if err := fakeClient.Get(context.TODO(), types.NamespacedName{Namespace: pod0.Namespace, Name: pod0.Name}, newPod0); err != nil {
+		t.Fatal(err)
+	}
+	if alreadyHasKey(newPod0, msg0) || alreadyHasKey(newPod0, msg1) {
+		t.Fatalf("expect not have key, but it does")
+	}
+	condition = GetReadinessCondition(newPod0)
+	if condition.Status != v1.ConditionTrue {
+		t.Fatalf("expect condition true, but not")
+	}
+}

--- a/pkg/webhook/pod/mutating/pod_create_update_handler.go
+++ b/pkg/webhook/pod/mutating/pod_create_update_handler.go
@@ -40,12 +40,6 @@ type PodCreateHandler struct {
 	Decoder *admission.Decoder
 }
 
-func (h *PodCreateHandler) mutatingPodFn(ctx context.Context, obj *corev1.Pod, oldPod *corev1.Pod) error {
-	return h.sidecarsetMutatingPod(ctx, obj, oldPod)
-}
-
-var _ admission.Handler = &PodCreateHandler{}
-
 // Handle handles admission requests.
 func (h *PodCreateHandler) Handle(ctx context.Context, req admission.Request) admission.Response {
 	obj := &corev1.Pod{}
@@ -69,7 +63,9 @@ func (h *PodCreateHandler) Handle(ctx context.Context, req admission.Request) ad
 		}
 	}
 
-	err = h.mutatingPodFn(ctx, obj, oldPod)
+	injectPodReadinessGate(req, obj)
+
+	err = h.sidecarsetMutatingPod(ctx, obj, oldPod)
 	if err != nil {
 		return admission.Errored(http.StatusInternalServerError, err)
 	}

--- a/pkg/webhook/pod/mutating/pod_readiness.go
+++ b/pkg/webhook/pod/mutating/pod_readiness.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2021 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutating
+
+import (
+	appspub "github.com/openkruise/kruise/apis/apps/pub"
+	"github.com/openkruise/kruise/pkg/features"
+	"github.com/openkruise/kruise/pkg/util"
+	utilfeature "github.com/openkruise/kruise/pkg/util/feature"
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+func injectPodReadinessGate(req admission.Request, pod *v1.Pod) {
+	if req.Operation != admissionv1beta1.Create {
+		return
+	}
+	if !util.IsPodOwnedByKruise(pod) && !utilfeature.DefaultFeatureGate.Enabled(features.KruisePodReadinessGate) {
+		return
+	}
+	util.InjectReadinessGateToPod(pod, appspub.KruisePodReadyConditionType)
+}


### PR DESCRIPTION
Signed-off-by: FillZpp <FillZpp.pub@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Add KruisePodReady readiness-gate.

Reference to proposal [ContainerRecreateRequest](https://github.com/FillZpp/kruise/blob/proposal-for-container-recreate-request/docs/proposals/20210316-containerrecreaterequest.md).

### II. Special notes for reviews

By default, the `KruisePodReady` readiness-gate will only be injected to creating Pods that owned by Kruise. And, when users open the `KruisePodReadinessGate` feature-gate, it will be injected to each Pod during creation.

After injected, `pod-readiness-controller` will update `KruisePodReady` the condition as `status=True` in Pod status.


