### PR TITLE
Sort Pods by workload logic for ImagePullJob pre-downloading

### DIFF
--- a/pkg/control/sorting/pod_sorting.go
+++ b/pkg/control/sorting/pod_sorting.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2021 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sorting
+
+import (
+	"context"
+	"fmt"
+
+	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
+	appsv1beta1 "github.com/openkruise/kruise/apis/apps/v1beta1"
+	clonesetcore "github.com/openkruise/kruise/pkg/controller/cloneset/core"
+	synccontrol "github.com/openkruise/kruise/pkg/controller/cloneset/sync"
+	sidecarsetcontroller "github.com/openkruise/kruise/pkg/controller/sidecarset"
+	statefulsetcontroller "github.com/openkruise/kruise/pkg/controller/statefulset"
+	"github.com/openkruise/kruise/pkg/util/updatesort"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// SortPods sorts the given Pods according the owner workload logic.
+// Currently only for image pre-downloading.
+func SortPods(reader client.Reader, ns string, owner metav1.OwnerReference, pods []*v1.Pod) ([]*v1.Pod, error) {
+	gv, err := schema.ParseGroupVersion(owner.APIVersion)
+	if err != nil {
+		return nil, fmt.Errorf("parse apiVersion of owner reference %v error: %v", owner, err)
+	}
+
+	// ignore no Kruise owners
+	if gv.Group != appsv1alpha1.GroupVersion.Group {
+		return pods, nil
+	}
+
+	var indexes []int
+	namespacedName := types.NamespacedName{Namespace: ns, Name: owner.Name}
+	switch owner.Kind {
+	case "CloneSet":
+		set := &appsv1alpha1.CloneSet{}
+		if err := reader.Get(context.TODO(), namespacedName, set); err != nil {
+			if errors.IsNotFound(err) {
+				return pods, nil
+			}
+			return nil, fmt.Errorf("get cloneset %s error: %v", namespacedName, err)
+		}
+		indexes = sortPodsForCloneSet(set, pods)
+
+	case "StatefulSet":
+		set := &appsv1beta1.StatefulSet{}
+		if err := reader.Get(context.TODO(), namespacedName, set); err != nil {
+			if errors.IsNotFound(err) {
+				return pods, nil
+			}
+			return nil, fmt.Errorf("get statefulset %s error: %v", namespacedName, err)
+		}
+		indexes = sortPodsForStatefulSet(set, pods)
+
+	case "SidecarSet":
+		set := &appsv1alpha1.SidecarSet{}
+		if err := reader.Get(context.TODO(), namespacedName, set); err != nil {
+			if errors.IsNotFound(err) {
+				return pods, nil
+			}
+			return nil, fmt.Errorf("get sidecarset %s error: %v", namespacedName, err)
+		}
+		indexes = sortPodsForSidecarSet(set, pods)
+
+	default:
+		// unsupported sorting workload
+		return pods, nil
+	}
+
+	newPods := make([]*v1.Pod, 0, len(pods))
+	for _, i := range indexes {
+		newPods = append(newPods, pods[i])
+	}
+	return newPods, nil
+}
+
+func sortPodsForCloneSet(set *appsv1alpha1.CloneSet, pods []*v1.Pod) []int {
+	indexes := make([]int, 0, len(pods))
+	for i := 0; i < len(pods); i++ {
+		indexes = append(indexes, i)
+	}
+
+	indexes = synccontrol.SortUpdateIndexes(clonesetcore.New(set), set.Spec.UpdateStrategy, pods, indexes)
+	return indexes
+}
+
+func sortPodsForStatefulSet(set *appsv1beta1.StatefulSet, pods []*v1.Pod) []int {
+	indexes := make([]int, 0, len(pods))
+	for i := len(pods) - 1; i >= 0; i-- {
+		indexes = append(indexes, i)
+	}
+
+	statefulsetcontroller.SortPodsAscendingOrdinal(pods)
+	if set.Spec.UpdateStrategy.RollingUpdate != nil &&
+		set.Spec.UpdateStrategy.RollingUpdate.UnorderedUpdate != nil &&
+		set.Spec.UpdateStrategy.RollingUpdate.UnorderedUpdate.PriorityStrategy != nil {
+		indexes = updatesort.NewPrioritySorter(set.Spec.UpdateStrategy.RollingUpdate.UnorderedUpdate.PriorityStrategy).Sort(pods, indexes)
+	}
+	return indexes
+}
+
+func sortPodsForSidecarSet(set *appsv1alpha1.SidecarSet, pods []*v1.Pod) []int {
+	indexes := make([]int, 0, len(pods))
+	for i := 0; i < len(pods); i++ {
+		indexes = append(indexes, i)
+	}
+
+	indexes = sidecarsetcontroller.SortUpdateIndexes(set.Spec.UpdateStrategy, pods, indexes)
+	return indexes
+}

--- a/pkg/controller/cloneset/sync/cloneset_update.go
+++ b/pkg/controller/cloneset/sync/cloneset_update.go
@@ -104,7 +104,7 @@ func (c *realControl) Update(cs *appsv1alpha1.CloneSet,
 	}
 
 	// 4. sort all pods waiting to update
-	waitUpdateIndexes = sortUpdateIndexes(coreControl, cs.Spec.UpdateStrategy, pods, waitUpdateIndexes)
+	waitUpdateIndexes = SortUpdateIndexes(coreControl, cs.Spec.UpdateStrategy, pods, waitUpdateIndexes)
 
 	// 5. limit max count of pods can update
 	waitUpdateIndexes = limitUpdateIndexes(coreControl, cs.Spec.MinReadySeconds, diffRes, waitUpdateIndexes, pods)
@@ -243,7 +243,8 @@ func (c *realControl) updatePod(cs *appsv1alpha1.CloneSet, coreControl clonesetc
 	return 0, nil
 }
 
-func sortUpdateIndexes(coreControl clonesetcore.Control, strategy appsv1alpha1.CloneSetUpdateStrategy, pods []*v1.Pod, waitUpdateIndexes []int) []int {
+// SortUpdateIndexes sorts the given waitUpdateIndexes of Pods to update according to the CloneSet strategy.
+func SortUpdateIndexes(coreControl clonesetcore.Control, strategy appsv1alpha1.CloneSetUpdateStrategy, pods []*v1.Pod, waitUpdateIndexes []int) []int {
 	// Sort Pods with default sequence
 	sort.Slice(waitUpdateIndexes, coreControl.GetPodsSortFunc(pods, waitUpdateIndexes))
 

--- a/pkg/controller/cloneset/sync/cloneset_update_test.go
+++ b/pkg/controller/cloneset/sync/cloneset_update_test.go
@@ -631,7 +631,7 @@ func TestSortUpdateIndexes(t *testing.T) {
 
 	coreControl := clonesetcore.New(&appsv1alpha1.CloneSet{})
 	for i, tc := range cases {
-		got := sortUpdateIndexes(coreControl, tc.strategy, tc.pods, tc.waitUpdateIndexes)
+		got := SortUpdateIndexes(coreControl, tc.strategy, tc.pods, tc.waitUpdateIndexes)
 		if !reflect.DeepEqual(got, tc.expectedIndexes) {
 			t.Fatalf("case #%d failed, expected %v, got %v", i, tc.expectedIndexes, got)
 		}

--- a/pkg/controller/statefulset/stateful_set_utils.go
+++ b/pkg/controller/statefulset/stateful_set_utils.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"sort"
 	"strconv"
 	"time"
 
@@ -431,6 +432,11 @@ func completeRollingUpdate(set *appsv1beta1.StatefulSet, status *appsv1beta1.Sta
 		status.CurrentReplicas = status.UpdatedReplicas
 		status.CurrentRevision = status.UpdateRevision
 	}
+}
+
+// SortPodsAscendingOrdinal sorts the given Pods according to their oridinals.
+func SortPodsAscendingOrdinal(pods []*v1.Pod) {
+	sort.Sort(ascendingOrdinal(pods))
 }
 
 // ascendingOrdinal is a sort.Interface that Sorts a list of Pods based on the ordinals extracted


### PR DESCRIPTION
Signed-off-by: FillZpp <FillZpp.pub@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Sort Pods by workload logic for ImagePullJob pre-downloading

Reference to proposal [image pre-download during in-place update](https://github.com/openkruise/kruise/pull/570).
