### PR TITLE
Optimize pod template validation for CloneSet

### DIFF
--- a/pkg/webhook/cloneset/validating/validation_test.go
+++ b/pkg/webhook/cloneset/validating/validation_test.go
@@ -30,7 +30,7 @@ func TestValidate(t *testing.T) {
 			Spec: v1.PodSpec{
 				RestartPolicy: v1.RestartPolicyAlways,
 				DNSPolicy:     v1.DNSClusterFirst,
-				Containers:    []v1.Container{{Name: "abc", Image: "image", ImagePullPolicy: "IfNotPresent"}},
+				Containers:    []v1.Container{{Name: "abc", Image: "image", ImagePullPolicy: "IfNotPresent", TerminationMessagePolicy: v1.TerminationMessageReadFile}},
 			},
 		},
 	}
@@ -42,7 +42,7 @@ func TestValidate(t *testing.T) {
 			Spec: v1.PodSpec{
 				RestartPolicy: v1.RestartPolicyAlways,
 				DNSPolicy:     v1.DNSClusterFirst,
-				Containers:    []v1.Container{{Name: "abc", Image: "image1", ImagePullPolicy: "IfNotPresent"}},
+				Containers:    []v1.Container{{Name: "abc", Image: "image1", ImagePullPolicy: "IfNotPresent", TerminationMessagePolicy: v1.TerminationMessageReadFile}},
 			},
 		},
 	}
@@ -54,7 +54,7 @@ func TestValidate(t *testing.T) {
 			Spec: v1.PodSpec{
 				RestartPolicy: v1.RestartPolicyAlways,
 				DNSPolicy:     v1.DNSClusterFirst,
-				Containers:    []v1.Container{{Name: "abc", Image: "image2", ImagePullPolicy: "Always"}},
+				Containers:    []v1.Container{{Name: "abc", Image: "image2", ImagePullPolicy: "Always", TerminationMessagePolicy: v1.TerminationMessageReadFile}},
 			},
 		},
 	}


### PR DESCRIPTION
Signed-off-by: FillZpp <FillZpp.pub@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Optimize pod template validation for CloneSet:

1. mock `volumeClaimTemplates` into `template.spec.volumes`
2. validate `template` using `ValidatePodTemplateSpec`, which could check the whole pod spec

