### PR TITLE
Fix broadcastjob expectation observed when node assigned by scheduler

### DIFF
--- a/test/e2e/apps/broadcastjob.go
+++ b/test/e2e/apps/broadcastjob.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2021 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apps
+
+import (
+	"time"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
+	kruiseclientset "github.com/openkruise/kruise/pkg/client/clientset/versioned"
+	"github.com/openkruise/kruise/test/e2e/framework"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/rand"
+	clientset "k8s.io/client-go/kubernetes"
+)
+
+var _ = SIGDescribe("BroadcastJob", func() {
+	f := framework.NewDefaultFramework("broadcastjobs")
+	var ns string
+	var c clientset.Interface
+	var kc kruiseclientset.Interface
+	var tester *framework.BroadcastJobTester
+	var nodeTester *framework.NodeTester
+	var randStr string
+
+	ginkgo.BeforeEach(func() {
+		c = f.ClientSet
+		kc = f.KruiseClientSet
+		ns = f.Namespace.Name
+		tester = framework.NewBroadcastJobTester(c, kc, ns)
+		nodeTester = framework.NewNodeTester(c)
+		randStr = rand.String(10)
+	})
+
+	ginkgo.AfterEach(func() {
+		err := nodeTester.DeleteFakeNode(randStr)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	framework.KruiseDescribe("BroadcastJob dispatching", func() {
+
+		ginkgo.It("succeeds for parallelism < number of node", func() {
+			ginkgo.By("Create Fake Node " + randStr)
+			fakeNode, err := nodeTester.CreateFakeNode(randStr)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			nodes, err := nodeTester.ListRealNodesWithFake(randStr)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("Create BroadcastJob job-" + randStr)
+			parallelism := intstr.FromInt(1)
+			job := &appsv1alpha1.BroadcastJob{
+				ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "job-" + randStr},
+				Spec: appsv1alpha1.BroadcastJobSpec{
+					Parallelism: &parallelism,
+					Template: v1.PodTemplateSpec{
+						Spec: v1.PodSpec{
+							Tolerations: []v1.Toleration{{Key: framework.E2eFakeKey, Operator: v1.TolerationOpEqual, Value: randStr, Effect: v1.TaintEffectNoSchedule}},
+							Containers: []v1.Container{{
+								Name:    "pi",
+								Image:   "perl",
+								Command: []string{"perl", "-Mbignum=bpi", "-wle", "print bpi(1000)"},
+							}},
+							RestartPolicy: v1.RestartPolicyNever,
+						},
+					},
+					CompletionPolicy: appsv1alpha1.CompletionPolicy{Type: appsv1alpha1.Always},
+				},
+			}
+
+			job, err = tester.CreateBroadcastJob(job)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("Check the status of job")
+			gomega.Eventually(func() int32 {
+				job, err = tester.GetBroadcastJob(job.Name)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				return job.Status.Desired
+			}, 3*time.Second, time.Second).Should(gomega.Equal(int32(len(nodes))))
+
+			gomega.Eventually(func() int {
+				pods, err := tester.GetPodsOfJob(job)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				var fakePod *v1.Pod
+				for _, p := range pods {
+					if p.Spec.NodeName == fakeNode.Name {
+						fakePod = p
+						break
+					}
+				}
+				if fakePod != nil && fakePod.Status.Phase != v1.PodSucceeded {
+					ginkgo.By("Try to update Pod " + fakePod.Name + " to Succeeded")
+					fakePod.Status.Phase = v1.PodSucceeded
+					_, err = c.CoreV1().Pods(ns).UpdateStatus(fakePod)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				}
+
+				return len(pods)
+			}, 120*time.Second, 3*time.Second).Should(gomega.Equal(len(nodes)))
+
+			gomega.Eventually(func() int32 {
+				job, err = tester.GetBroadcastJob(job.Name)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				return job.Status.Succeeded
+			}, 3*time.Second, time.Second).Should(gomega.Equal(int32(len(nodes))))
+		})
+	})
+})

--- a/test/e2e/framework/broadcastjob_util.go
+++ b/test/e2e/framework/broadcastjob_util.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2021 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
+	kruiseclientset "github.com/openkruise/kruise/pkg/client/clientset/versioned"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+)
+
+type BroadcastJobTester struct {
+	c  clientset.Interface
+	kc kruiseclientset.Interface
+	ns string
+}
+
+func NewBroadcastJobTester(c clientset.Interface, kc kruiseclientset.Interface, ns string) *BroadcastJobTester {
+	return &BroadcastJobTester{
+		c:  c,
+		kc: kc,
+		ns: ns,
+	}
+}
+
+func (t *BroadcastJobTester) CreateBroadcastJob(job *appsv1alpha1.BroadcastJob) (*appsv1alpha1.BroadcastJob, error) {
+	return t.kc.AppsV1alpha1().BroadcastJobs(t.ns).Create(job)
+}
+
+func (t *BroadcastJobTester) GetBroadcastJob(name string) (*appsv1alpha1.BroadcastJob, error) {
+	return t.kc.AppsV1alpha1().BroadcastJobs(t.ns).Get(name, metav1.GetOptions{})
+}
+
+func (t *BroadcastJobTester) GetPodsOfJob(job *appsv1alpha1.BroadcastJob) (pods []*v1.Pod, err error) {
+	podList, err := t.c.CoreV1().Pods(t.ns).List(metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	for i := range podList.Items {
+		pod := &podList.Items[i]
+		controllerRef := metav1.GetControllerOf(pod)
+		if controllerRef != nil && controllerRef.UID == job.UID {
+			pods = append(pods, pod)
+		}
+	}
+	return pods, nil
+}

--- a/test/e2e/framework/node_util.go
+++ b/test/e2e/framework/node_util.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2021 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/klog"
+	utilpointer "k8s.io/utils/pointer"
+)
+
+const (
+	E2eFakeKey         = "kruise-e2e-fake"
+	fakeNodeNamePrefix = "fake-node-"
+)
+
+type NodeTester struct {
+	c clientset.Interface
+}
+
+func NewNodeTester(c clientset.Interface) *NodeTester {
+	return &NodeTester{
+		c: c,
+	}
+}
+
+func (t *NodeTester) CreateFakeNode(randStr string) (node *v1.Node, err error) {
+	name := fakeNodeNamePrefix + randStr
+	node = &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: map[string]string{v1.LabelHostname: name, E2eFakeKey: "true"},
+		},
+		Spec: v1.NodeSpec{
+			Taints: []v1.Taint{{Key: E2eFakeKey, Value: randStr, Effect: v1.TaintEffectNoSchedule}},
+		},
+	}
+
+	node, err = t.c.CoreV1().Nodes().Create(node)
+	if err != nil {
+		return nil, err
+	}
+
+	resources := v1.ResourceList{
+		v1.ResourceCPU:              resource.MustParse("4"),
+		v1.ResourceMemory:           resource.MustParse("8Gi"),
+		v1.ResourceEphemeralStorage: resource.MustParse("20Gi"),
+		v1.ResourcePods:             resource.MustParse("16"),
+	}
+
+	fn := func() error {
+		return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+			node, err = t.c.CoreV1().Nodes().Get(name, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			node.Status = v1.NodeStatus{
+				Phase:       v1.NodeRunning,
+				Capacity:    resources,
+				Allocatable: resources,
+				Conditions: []v1.NodeCondition{
+					{
+						Type:               v1.NodeReady,
+						Status:             v1.ConditionTrue,
+						Reason:             "FakeReady",
+						LastTransitionTime: metav1.Now(),
+						LastHeartbeatTime:  metav1.Now(),
+					},
+				},
+			}
+			node, err = t.c.CoreV1().Nodes().UpdateStatus(node)
+			return err
+		})
+	}
+
+	err = fn()
+	if err != nil {
+		return nil, err
+	}
+
+	// start a goroutine to keep updating ready condition
+	go func() {
+		var noNode bool
+		for {
+			time.Sleep(time.Second * 3)
+			if !noNode {
+				err = fn()
+				if err != nil {
+					if !errors.IsNotFound(err) {
+						klog.Errorf("Failed to update status of fake Node %s: %v", name, err)
+					}
+					noNode = true
+				}
+			}
+			podList, err := t.c.CoreV1().Pods(v1.NamespaceAll).List(metav1.ListOptions{FieldSelector: "spec.nodeName=" + name})
+			if err != nil {
+				klog.Errorf("Failed to get Pods of fake Node %s: %v", name, err)
+				return
+			}
+			for i := range podList.Items {
+				pod := &podList.Items[i]
+				if pod.DeletionTimestamp != nil && pod.DeletionGracePeriodSeconds != nil {
+					t.c.CoreV1().Pods(pod.Namespace).Delete(pod.Name, &metav1.DeleteOptions{GracePeriodSeconds: utilpointer.Int64Ptr(0)})
+				}
+			}
+			if len(podList.Items) == 0 && noNode {
+				return
+			}
+		}
+	}()
+
+	return node, nil
+}
+
+func (t *NodeTester) DeleteFakeNode(randStr string) error {
+	name := "fake-node-" + randStr
+	err := t.c.CoreV1().Nodes().Delete(name, &metav1.DeleteOptions{})
+	if err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+	return nil
+}
+
+func (t *NodeTester) ListRealNodesWithFake(randStr string) ([]*v1.Node, error) {
+	nodeList, err := t.c.CoreV1().Nodes().List(metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	var nodes []*v1.Node
+	for i := range nodeList.Items {
+		node := &nodeList.Items[i]
+		if len(node.Spec.Taints) > 1 {
+			continue
+		} else if len(node.Spec.Taints) == 1 && (node.Spec.Taints[0].Key != E2eFakeKey || node.Spec.Taints[0].Value != randStr) {
+			continue
+		}
+		nodes = append(nodes, node)
+	}
+	return nodes, nil
+}


### PR DESCRIPTION
Signed-off-by: FillZpp <FillZpp.pub@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Fix broadcastjob expectation observed when node assigned by scheduler

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #580 
fixes #582 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
The problem is caused by #498 . When Pod is assigned by scheduler, the event handler could not get the right node name from `pod.Spec.NodeName` field.

