### PR TITLE
Remove redundant filterActiveHandlers invoke

### DIFF
--- a/pkg/webhook/server.go
+++ b/pkg/webhook/server.go
@@ -114,7 +114,6 @@ func Initialize(mgr manager.Manager, stopCh <-chan struct{}) error {
 		StatusClient: mgr.GetClient(),
 	}
 
-	filterActiveHandlers()
 	c, err := webhookcontroller.New(mgr.GetConfig(), cli, HandlerMap)
 	if err != nil {
 		return err


### PR DESCRIPTION
Signed-off-by: champly [champly@outlook.com](mailto:champly@outlook.com)

### Ⅰ. Describe what this PR does

Resolve repeat call `filterActiveHandlers` within `webhook.SetupWithManager` and `webhook.Initialize`.


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


