### PR TITLE
remove redundant code

### DIFF
--- a/pkg/controller/podreadiness/pod_readiness_controller.go
+++ b/pkg/controller/podreadiness/pod_readiness_controller.go
@@ -120,12 +120,6 @@ func (r *ReconcilePodReadiness) Reconcile(request reconcile.Request) (res reconc
 		if pod.DeletionTimestamp != nil {
 			return nil
 		}
-		if !utilpodreadiness.ContainsReadinessGate(pod) {
-			return nil
-		}
-		if utilpodreadiness.GetReadinessCondition(pod) != nil {
-			return nil
-		}
 
 		pod.Status.Conditions = append(pod.Status.Conditions, v1.PodCondition{
 			Type:               appspub.KruisePodReadyConditionType,


### PR DESCRIPTION
Signed-off-by: hantmac <hantmac@outlook.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Remove redundant code, because the pods those can't through [predicate funcs](https://github.com/openkruise/kruise/blob/786beb4c0fd5fa6f84cf78a4255d514e0c34ed59/pkg/controller/podreadiness/pod_readiness_controller.go#L67), can not be reconciled, so in `reconcile` we have no need to check it twice. 


### Ⅴ. Special notes for reviews


