### PR TITLE
Optimize CloneSet diff calculation to allow updating when scaling failed

### DIFF
--- a/pkg/controller/cloneset/sync/cloneset_sync_utils.go
+++ b/pkg/controller/cloneset/sync/cloneset_sync_utils.go
@@ -181,16 +181,14 @@ func calculateDiffsWithExpectation(cs *appsv1alpha1.CloneSet, pods []*v1.Pod, cu
 		res.deleteReadyLimit = integer.IntMax(maxUnavailable+(len(pods)-replicas)-preDeletingCount-notReadyNewRevisionCount-notReadyOldRevisionCount, 0)
 	}
 
-	// Do update only if the scaling has satisfied
-	if newRevisionActiveCount+oldRevisionActiveCount == replicas+res.useSurge {
-		if util.IntAbs(updateOldDiff) <= util.IntAbs(updateNewDiff) {
-			res.updateNum = updateOldDiff
-		} else {
-			res.updateNum = 0 - updateNewDiff
-		}
+	// The consistency between scale and update will be guaranteed by syncCloneSet and expectations
+	if util.IntAbs(updateOldDiff) <= util.IntAbs(updateNewDiff) {
+		res.updateNum = updateOldDiff
+	} else {
+		res.updateNum = 0 - updateNewDiff
 	}
 	if res.updateNum != 0 {
-		res.updateMaxUnavailable = maxUnavailable + res.useSurge
+		res.updateMaxUnavailable = maxUnavailable + len(pods) - replicas
 	}
 
 	return

--- a/pkg/controller/cloneset/sync/cloneset_sync_utils_test.go
+++ b/pkg/controller/cloneset/sync/cloneset_sync_utils_test.go
@@ -333,7 +333,7 @@ func TestCalculateDiffsWithExpectation(t *testing.T) {
 				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
 				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
 			},
-			expectResult: expectationDiffs{scaleNum: 1, useSurge: 1},
+			expectResult: expectationDiffs{scaleNum: 1, useSurge: 1, updateNum: 2, updateMaxUnavailable: 1},
 		},
 		{
 			name: "update in-place partition=3 with maxSurge (step 2/4)",
@@ -384,7 +384,7 @@ func TestCalculateDiffsWithExpectation(t *testing.T) {
 				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
 				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
 			},
-			expectResult: expectationDiffs{scaleNum: 1, useSurge: 1},
+			expectResult: expectationDiffs{scaleNum: 1, useSurge: 1, updateNum: 2, updateMaxUnavailable: 1},
 		},
 		{
 			name: "update recreate partition=3 with maxSurge (step 2/7)",
@@ -422,7 +422,7 @@ func TestCalculateDiffsWithExpectation(t *testing.T) {
 				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
 				createTestPod(newRevision, appspub.LifecycleStateNormal, false, false), // new creation
 			},
-			expectResult: expectationDiffs{useSurge: 1, scaleNum: 1},
+			expectResult: expectationDiffs{useSurge: 1, scaleNum: 1, updateNum: 1, updateMaxUnavailable: 1},
 		},
 		{
 			name: "update recreate partition=3 with maxSurge (step 5/7)",
@@ -513,6 +513,32 @@ func TestCalculateDiffsWithExpectation(t *testing.T) {
 			},
 			revisionConsistent: true,
 			expectResult:       expectationDiffs{updateNum: 2, updateMaxUnavailable: 1},
+		},
+		{
+			name: "allow to update when fail to scale out normally",
+			set:  createTestCloneSet(5, intstr.FromInt(1), intstr.FromInt(2), intstr.FromInt(0)),
+			pods: []*v1.Pod{
+				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
+				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
+				createTestPod(newRevision, appspub.LifecycleStateNormal, true, false),
+				createTestPod(newRevision, appspub.LifecycleStateNormal, true, false),
+			},
+			revisionConsistent: true,
+			expectResult:       expectationDiffs{scaleNum: 1, updateNum: 1, updateMaxUnavailable: 1},
+		},
+		{
+			name: "allow to update when fail to scale in normally",
+			set:  createTestCloneSet(5, intstr.FromInt(1), intstr.FromInt(1), intstr.FromInt(0)),
+			pods: []*v1.Pod{
+				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
+				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
+				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
+				createTestPod(newRevision, appspub.LifecycleStateNormal, true, false),
+				createTestPod(newRevision, appspub.LifecycleStateNormal, true, false),
+				createTestPod(newRevision, appspub.LifecycleStateNormal, true, false),
+			},
+			revisionConsistent: true,
+			expectResult:       expectationDiffs{scaleNum: -1, scaleNumOldRevision: -2, deleteReadyLimit: 2, updateNum: 1, updateMaxUnavailable: 2},
 		},
 	}
 


### PR DESCRIPTION
Signed-off-by: FillZpp <FillZpp.pub@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Optimize CloneSet diff calculation to allow updating when scaling failed.
The consistency between scale and update will be guaranteed by syncCloneSet and expectations.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


