### PR TITLE
Fix nodeimage createAt timestamp for multiple imagepulljob pulling a same image

### DIFF
--- a/.muse.toml
+++ b/.muse.toml
@@ -1,0 +1,5 @@
+# Ignore results from test and vendor directories
+ignoreFiles = """
+vendor/
+test/
+"""

--- a/pkg/controller/imagepulljob/imagepulljob_controller.go
+++ b/pkg/controller/imagepulljob/imagepulljob_controller.go
@@ -266,6 +266,7 @@ func (r *ReconcileImagePullJob) syncNodeImages(job *appsv1alpha1.ImagePullJob, n
 		pullPolicy.ActiveDeadlineSeconds = job.Spec.CompletionPolicy.ActiveDeadlineSeconds
 	}
 
+	now := metav1.NewTime(r.clock.Now())
 	imageName, imageTag, _ := daemonutil.NormalizeImageRefToNameTag(job.Spec.Image)
 	for i := 0; i < parallelism; i++ {
 		var skip bool
@@ -299,6 +300,7 @@ func (r *ReconcileImagePullJob) syncNodeImages(job *appsv1alpha1.ImagePullJob, n
 				tagSpec.Version++
 				// merge owner reference
 				tagSpec.OwnerReferences = append(tagSpec.OwnerReferences, *ownerRef)
+				tagSpec.CreatedAt = &now
 				found = true
 				break
 			}
@@ -318,6 +320,7 @@ func (r *ReconcileImagePullJob) syncNodeImages(job *appsv1alpha1.ImagePullJob, n
 					Version:         foundVersion + 1,
 					PullPolicy:      &pullPolicy,
 					OwnerReferences: []v1.ObjectReference{*ownerRef},
+					CreatedAt:       &now,
 				})
 			}
 			utilimagejob.SortSpecImageTags(&imageSpec)


### PR DESCRIPTION
…same image

Signed-off-by: FillZpp <FillZpp.pub@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Fix nodeimage createAt timestamp for multiple imagepulljob pulling a same image

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


