### PR TITLE
Implement resources-deletion-protection including Always and Cascading

### DIFF
--- a/apis/policy/v1alpha1/doc.go
+++ b/apis/policy/v1alpha1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Kruise Authors.
+Copyright 2021 The Kruise Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,17 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package validating
-
-import (
-	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
-)
-
-// +kubebuilder:webhook:path=/validate-apps-kruise-io-v1alpha1-cloneset,mutating=false,failurePolicy=fail,groups=apps.kruise.io,resources=clonesets,verbs=create;update;delete,versions=v1alpha1,name=vcloneset.kb.io
-
-var (
-	// HandlerMap contains admission webhook handlers
-	HandlerMap = map[string]admission.Handler{
-		"validate-apps-kruise-io-v1alpha1-cloneset": &CloneSetCreateUpdateHandler{},
-	}
-)
+// +k8s:openapi-gen=true
+// +groupName=policy.kruise.io
+package v1alpha1

--- a/apis/policy/v1alpha1/groupversion_info.go
+++ b/apis/policy/v1alpha1/groupversion_info.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2021 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package v1alpha1 contains API Schema definitions for the policy v1alpha1 API group
+// +kubebuilder:object:generate=true
+// +groupName=policy.kruise.io
+package v1alpha1
+
+import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/scheme"
+)
+
+var (
+	// GroupVersion is group version used to register these objects
+	GroupVersion = schema.GroupVersion{Group: "policy.kruise.io", Version: "v1alpha1"}
+
+	SchemeGroupVersion = GroupVersion
+
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
+	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
+
+	// AddToScheme adds the types in this group-version to the given scheme.
+	AddToScheme = SchemeBuilder.AddToScheme
+)
+
+// Resource is required by pkg/client/listers/...
+func Resource(resource string) schema.GroupResource {
+	return SchemeGroupVersion.WithResource(resource).GroupResource()
+}

--- a/apis/policy/v1alpha1/resources_deletion_protection.go
+++ b/apis/policy/v1alpha1/resources_deletion_protection.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2021 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+const (
+	// DeletionProtectionKey is a key in object labels and its value can be Always and Cascading.
+	// Currently supports Namespace, CustomResourcesDefinition, Deployment, StatefulSet, ReplicaSet, CloneSet, Advanced StatefulSet, UnitedDeployment.
+	DeletionProtectionKey = "policy.kruise.io/delete-protection"
+
+	// DeletionProtectionTypeAlways indicates this object will always be forbidden to be deleted, unless the label is removed.
+	DeletionProtectionTypeAlways = "Always"
+	// DeletionProtectionTypeCascading indicates this object will be forbidden to be deleted, if it has active resources owned.
+	DeletionProtectionTypeCascading = "Cascading"
+)

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,12 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - list
+- apiGroups:
   - admissionregistration.k8s.io
   resources:
   - mutatingwebhookconfigurations

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -253,6 +253,57 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /validate-apps-deployment
+  failurePolicy: Fail
+  name: vbuiltindeployment.kb.io
+  rules:
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - DELETE
+    resources:
+    - deployments
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-apps-replicaset
+  failurePolicy: Fail
+  name: vbuiltinreplicaset.kb.io
+  rules:
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - DELETE
+    resources:
+    - replicasets
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-apps-statefulset
+  failurePolicy: Fail
+  name: vbuiltinstatefulset.kb.io
+  rules:
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - DELETE
+    resources:
+    - statefulsets
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: webhook-service
+      namespace: system
       path: /validate-apps-kruise-io-v1alpha1-cloneset
   failurePolicy: Fail
   name: vcloneset.kb.io
@@ -264,8 +315,27 @@ webhooks:
     operations:
     - CREATE
     - UPDATE
+    - DELETE
     resources:
     - clonesets
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-customresourcedefinition
+  failurePolicy: Fail
+  name: vcustomresourcedefinition.kb.io
+  rules:
+  - apiGroups:
+    - apiextensions.k8s.io
+    apiVersions:
+    - v1
+    - v1beta1
+    operations:
+    - DELETE
+    resources:
+    - customresourcedefinitions
 - clientConfig:
     caBundle: Cg==
     service:
@@ -302,6 +372,23 @@ webhooks:
     - UPDATE
     resources:
     - imagepulljobs
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-namespace
+  failurePolicy: Fail
+  name: vnamespace.kb.io
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - DELETE
+    resources:
+    - namespaces
 - clientConfig:
     caBundle: Cg==
     service:
@@ -355,6 +442,7 @@ webhooks:
     operations:
     - CREATE
     - UPDATE
+    - DELETE
     resources:
     - statefulsets
 - clientConfig:
@@ -373,5 +461,6 @@ webhooks:
     operations:
     - CREATE
     - UPDATE
+    - DELETE
     resources:
     - uniteddeployments

--- a/main.go
+++ b/main.go
@@ -24,11 +24,6 @@ import (
 	"os"
 	"time"
 
-	extclient "github.com/openkruise/kruise/pkg/client"
-	"github.com/openkruise/kruise/pkg/features"
-	utilfeature "github.com/openkruise/kruise/pkg/util/feature"
-	"github.com/openkruise/kruise/pkg/util/fieldindex"
-	"github.com/openkruise/kruise/pkg/webhook"
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -39,8 +34,15 @@ import (
 	"k8s.io/kubernetes/pkg/capabilities"
 	ctrl "sigs.k8s.io/controller-runtime"
 
+	extclient "github.com/openkruise/kruise/pkg/client"
+	"github.com/openkruise/kruise/pkg/features"
+	utilfeature "github.com/openkruise/kruise/pkg/util/feature"
+	"github.com/openkruise/kruise/pkg/util/fieldindex"
+	"github.com/openkruise/kruise/pkg/webhook"
+
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
 	appsv1beta1 "github.com/openkruise/kruise/apis/apps/v1beta1"
+	policyv1alpha1 "github.com/openkruise/kruise/apis/policy/v1alpha1"
 	"github.com/openkruise/kruise/pkg/controller"
 	// +kubebuilder:scaffold:imports
 )
@@ -60,6 +62,7 @@ func init() {
 
 	_ = appsv1alpha1.AddToScheme(scheme)
 	_ = appsv1beta1.AddToScheme(scheme)
+	_ = policyv1alpha1.AddToScheme(scheme)
 	// +kubebuilder:scaffold:scheme
 }
 

--- a/pkg/features/kruise_features.go
+++ b/pkg/features/kruise_features.go
@@ -49,6 +49,14 @@ const (
 	// CloneSetPartitionRollback enables CloneSet controller to rollback Pods to currentRevision
 	// when number of updateRevision pods is bigger than (replicas - partition).
 	CloneSetPartitionRollback featuregate.Feature = "CloneSetPartitionRollback"
+
+	// ResourcesDeletionProtection enables protection for resources deletion, currently supports
+	// Namespace, CustomResourcesDefinition, Deployment, StatefulSet, ReplicaSet, CloneSet, Advanced StatefulSet, UnitedDeployment.
+	// It is only supported for Kubernetes version >= 1.16
+	// Note that if it is enabled during Kruise installation or upgrade, Kruise will require more authorities:
+	// 1. Webhook for deletion operation of namespace, crd, deployment, statefulset, replicaset and workloads in Kruise.
+	// 2. ClusterRole for reading all resource types, because CRD validation needs to list the CRs of this CRD.
+	ResourcesDeletionProtection featuregate.Feature = "ResourcesDeletionProtection"
 )
 
 var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
@@ -58,6 +66,7 @@ var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	KruisePodReadinessGate:           {Default: false, PreRelease: featuregate.Alpha},
 	PreDownloadImageForInPlaceUpdate: {Default: false, PreRelease: featuregate.Alpha},
 	CloneSetPartitionRollback:        {Default: false, PreRelease: featuregate.Alpha},
+	ResourcesDeletionProtection:      {Default: false, PreRelease: featuregate.Alpha},
 }
 
 func init() {

--- a/pkg/webhook/add_builtinworkloads.go
+++ b/pkg/webhook/add_builtinworkloads.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Kruise Authors.
+Copyright 2021 The Kruise Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,17 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package validating
+package webhook
 
 import (
-	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	"github.com/openkruise/kruise/pkg/webhook/builtinworkloads/validating"
 )
 
-// +kubebuilder:webhook:path=/validate-apps-kruise-io-v1alpha1-cloneset,mutating=false,failurePolicy=fail,groups=apps.kruise.io,resources=clonesets,verbs=create;update;delete,versions=v1alpha1,name=vcloneset.kb.io
-
-var (
-	// HandlerMap contains admission webhook handlers
-	HandlerMap = map[string]admission.Handler{
-		"validate-apps-kruise-io-v1alpha1-cloneset": &CloneSetCreateUpdateHandler{},
-	}
-)
+func init() {
+	addHandlers(validating.HandlerMap)
+}

--- a/pkg/webhook/add_customresourcedefinition.go
+++ b/pkg/webhook/add_customresourcedefinition.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Kruise Authors.
+Copyright 2021 The Kruise Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,17 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package validating
+package webhook
 
 import (
-	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	"github.com/openkruise/kruise/pkg/webhook/customresourcedefinition/validating"
 )
 
-// +kubebuilder:webhook:path=/validate-apps-kruise-io-v1alpha1-cloneset,mutating=false,failurePolicy=fail,groups=apps.kruise.io,resources=clonesets,verbs=create;update;delete,versions=v1alpha1,name=vcloneset.kb.io
-
-var (
-	// HandlerMap contains admission webhook handlers
-	HandlerMap = map[string]admission.Handler{
-		"validate-apps-kruise-io-v1alpha1-cloneset": &CloneSetCreateUpdateHandler{},
-	}
-)
+func init() {
+	addHandlers(validating.HandlerMap)
+}

--- a/pkg/webhook/add_namespace.go
+++ b/pkg/webhook/add_namespace.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Kruise Authors.
+Copyright 2021 The Kruise Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,17 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package validating
+package webhook
 
 import (
-	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	"github.com/openkruise/kruise/pkg/webhook/namespace/validating"
 )
 
-// +kubebuilder:webhook:path=/validate-apps-kruise-io-v1alpha1-cloneset,mutating=false,failurePolicy=fail,groups=apps.kruise.io,resources=clonesets,verbs=create;update;delete,versions=v1alpha1,name=vcloneset.kb.io
-
-var (
-	// HandlerMap contains admission webhook handlers
-	HandlerMap = map[string]admission.Handler{
-		"validate-apps-kruise-io-v1alpha1-cloneset": &CloneSetCreateUpdateHandler{},
-	}
-)
+func init() {
+	addHandlers(validating.HandlerMap)
+}

--- a/pkg/webhook/builtinworkloads/validating/builtin_handlers.go
+++ b/pkg/webhook/builtinworkloads/validating/builtin_handlers.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2021 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validating
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/openkruise/kruise/pkg/webhook/util/deletionprotection"
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	apps "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// WorkloadHandler handles built-in workloads, e.g. Deployment, ReplicaSet, StatefulSet
+type WorkloadHandler struct {
+	// Decoder decodes objects
+	Decoder *admission.Decoder
+}
+
+func (h *WorkloadHandler) InjectDecoder(d *admission.Decoder) error {
+	h.Decoder = d
+	return nil
+}
+
+// Handle handles admission requests.
+func (h *WorkloadHandler) Handle(ctx context.Context, req admission.Request) admission.Response {
+	if req.Operation != admissionv1beta1.Delete || req.SubResource != "" {
+		return admission.ValidationResponse(true, "")
+	}
+	if len(req.OldObject.Raw) == 0 {
+		klog.Warningf("Skip to validate %s %s/%s for no old object, maybe because of Kubernetes version < 1.16", req.Kind.Kind, req.Namespace, req.Name)
+		return admission.ValidationResponse(true, "")
+	}
+
+	var metaObj metav1.Object
+	var replicas *int32
+	switch req.Kind.Kind {
+	case "Deployment":
+		obj := &apps.Deployment{}
+		if err := h.Decoder.DecodeRaw(req.AdmissionRequest.OldObject, obj); err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+		metaObj = obj
+		replicas = obj.Spec.Replicas
+	case "ReplicaSet":
+		obj := &apps.ReplicaSet{}
+		if err := h.Decoder.DecodeRaw(req.AdmissionRequest.OldObject, obj); err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+		metaObj = obj
+		replicas = obj.Spec.Replicas
+	case "StatefulSet":
+		obj := &apps.StatefulSet{}
+		if err := h.Decoder.DecodeRaw(req.AdmissionRequest.OldObject, obj); err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+		metaObj = obj
+		replicas = obj.Spec.Replicas
+	default:
+		klog.Warningf("Skip to validate %s %s/%s for unsupported resource", req.Kind.Kind, req.Namespace, req.Name)
+		return admission.ValidationResponse(true, "")
+	}
+
+	if err := deletionprotection.ValidateWorkloadDeletion(metaObj, replicas); err != nil {
+		return admission.Errored(http.StatusForbidden, err)
+	}
+	return admission.ValidationResponse(true, "")
+}

--- a/pkg/webhook/builtinworkloads/validating/webhooks.go
+++ b/pkg/webhook/builtinworkloads/validating/webhooks.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2021 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validating
+
+import "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+// +kubebuilder:webhook:path=/validate-apps-deployment,mutating=false,failurePolicy=fail,groups=apps,resources=deployments,verbs=delete,versions=v1,name=vbuiltindeployment.kb.io
+
+// +kubebuilder:webhook:path=/validate-apps-replicaset,mutating=false,failurePolicy=fail,groups=apps,resources=replicasets,verbs=delete,versions=v1,name=vbuiltinreplicaset.kb.io
+
+// +kubebuilder:webhook:path=/validate-apps-statefulset,mutating=false,failurePolicy=fail,groups=apps,resources=statefulsets,verbs=delete,versions=v1,name=vbuiltinstatefulset.kb.io
+
+var (
+	// HandlerMap contains admission webhook handlers
+	HandlerMap = map[string]admission.Handler{
+		"validate-apps-deployment":  &WorkloadHandler{},
+		"validate-apps-replicaset":  &WorkloadHandler{},
+		"validate-apps-statefulset": &WorkloadHandler{},
+	}
+)

--- a/pkg/webhook/customresourcedefinition/validating/webhooks.go
+++ b/pkg/webhook/customresourcedefinition/validating/webhooks.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Kruise Authors.
+Copyright 2021 The Kruise Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -16,15 +16,15 @@ limitations under the License.
 
 package validating
 
-import (
-	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
-)
+import "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-// +kubebuilder:webhook:path=/validate-apps-kruise-io-v1alpha1-uniteddeployment,mutating=false,failurePolicy=fail,groups=apps.kruise.io,resources=uniteddeployments,verbs=create;update;delete,versions=v1alpha1,name=vuniteddeployment.kb.io
+// +kubebuilder:webhook:path=/validate-customresourcedefinition,mutating=false,failurePolicy=fail,groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=delete,versions=v1;v1beta1,name=vcustomresourcedefinition.kb.io
+
+// +kubebuilder:rbac:groups="*",resources="*",verbs=list
 
 var (
 	// HandlerMap contains admission webhook handlers
 	HandlerMap = map[string]admission.Handler{
-		"validate-apps-kruise-io-v1alpha1-uniteddeployment": &UnitedDeploymentCreateUpdateHandler{},
+		"validate-customresourcedefinition": &CRDHandler{},
 	}
 )

--- a/pkg/webhook/namespace/validating/namespace_handler.go
+++ b/pkg/webhook/namespace/validating/namespace_handler.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2021 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validating
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/openkruise/kruise/pkg/webhook/util/deletionprotection"
+
+	"k8s.io/klog"
+
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+type NamespaceHandler struct {
+	Client client.Client
+
+	// Decoder decodes objects
+	Decoder *admission.Decoder
+}
+
+var _ admission.Handler = &NamespaceHandler{}
+
+// Handle handles admission requests.
+func (h *NamespaceHandler) Handle(ctx context.Context, req admission.Request) admission.Response {
+	if req.AdmissionRequest.Operation != admissionv1beta1.Delete || req.AdmissionRequest.SubResource != "" {
+		return admission.ValidationResponse(true, "")
+	}
+	if len(req.OldObject.Raw) == 0 {
+		klog.Warningf("Skip to validate namespace %s deletion for no old object, maybe because of Kubernetes version < 1.16", req.Name)
+		return admission.ValidationResponse(true, "")
+	}
+
+	obj := &v1.Namespace{}
+	if err := h.Decoder.DecodeRaw(req.AdmissionRequest.OldObject, obj); err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	if err := deletionprotection.ValidateNamespaceDeletion(h.Client, obj); err != nil {
+		return admission.Errored(http.StatusForbidden, err)
+	}
+	return admission.ValidationResponse(true, "")
+}
+
+var _ inject.Client = &NamespaceHandler{}
+
+func (h *NamespaceHandler) InjectClient(c client.Client) error {
+	h.Client = c
+	return nil
+}
+
+var _ admission.DecoderInjector = &NamespaceHandler{}
+
+func (h *NamespaceHandler) InjectDecoder(d *admission.Decoder) error {
+	h.Decoder = d
+	return nil
+}

--- a/pkg/webhook/namespace/validating/webhooks.go
+++ b/pkg/webhook/namespace/validating/webhooks.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Kruise Authors.
+Copyright 2021 The Kruise Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -16,15 +16,13 @@ limitations under the License.
 
 package validating
 
-import (
-	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
-)
+import "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-// +kubebuilder:webhook:path=/validate-apps-kruise-io-v1alpha1-uniteddeployment,mutating=false,failurePolicy=fail,groups=apps.kruise.io,resources=uniteddeployments,verbs=create;update;delete,versions=v1alpha1,name=vuniteddeployment.kb.io
+// +kubebuilder:webhook:path=/validate-namespace,mutating=false,failurePolicy=fail,groups="",resources=namespaces,verbs=delete,versions=v1,name=vnamespace.kb.io
 
 var (
 	// HandlerMap contains admission webhook handlers
 	HandlerMap = map[string]admission.Handler{
-		"validate-apps-kruise-io-v1alpha1-uniteddeployment": &UnitedDeploymentCreateUpdateHandler{},
+		"validate-namespace": &NamespaceHandler{},
 	}
 )

--- a/pkg/webhook/statefulset/validating/statefulset_create_update_handler.go
+++ b/pkg/webhook/statefulset/validating/statefulset_create_update_handler.go
@@ -23,7 +23,9 @@ import (
 
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
 	appsv1beta1 "github.com/openkruise/kruise/apis/apps/v1beta1"
+	"github.com/openkruise/kruise/pkg/webhook/util/deletionprotection"
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	"k8s.io/klog"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -44,43 +46,22 @@ var _ admission.Handler = &StatefulSetCreateUpdateHandler{}
 // Handle handles admission requests.
 func (h *StatefulSetCreateUpdateHandler) Handle(ctx context.Context, req admission.Request) admission.Response {
 	obj := &appsv1beta1.StatefulSet{}
-
-	switch req.AdmissionRequest.Resource.Version {
-	case appsv1beta1.GroupVersion.Version:
-		if err := h.Decoder.Decode(req, obj); err != nil {
-			return admission.Errored(http.StatusBadRequest, err)
-		}
-	case appsv1alpha1.GroupVersion.Version:
-		objv1alpha1 := &appsv1alpha1.StatefulSet{}
-		if err := h.Decoder.Decode(req, objv1alpha1); err != nil {
-			return admission.Errored(http.StatusBadRequest, err)
-		}
-		if err := objv1alpha1.ConvertTo(obj); err != nil {
-			return admission.Errored(http.StatusBadRequest, fmt.Errorf("failed to convert v1alpha1->v1beta1: %v", err))
-		}
-	}
+	oldObj := &appsv1beta1.StatefulSet{}
 
 	switch req.AdmissionRequest.Operation {
 	case admissionv1beta1.Create:
+		if err := h.decodeObject(req, obj); err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
+		}
 		if allErrs := validateStatefulSet(obj); len(allErrs) > 0 {
 			return admission.Errored(http.StatusUnprocessableEntity, allErrs.ToAggregate())
 		}
 	case admissionv1beta1.Update:
-		oldObj := &appsv1beta1.StatefulSet{}
-
-		switch req.AdmissionRequest.Resource.Version {
-		case appsv1beta1.GroupVersion.Version:
-			if err := h.Decoder.DecodeRaw(req.AdmissionRequest.OldObject, oldObj); err != nil {
-				return admission.Errored(http.StatusBadRequest, err)
-			}
-		case appsv1alpha1.GroupVersion.Version:
-			objv1alpha1 := &appsv1alpha1.StatefulSet{}
-			if err := h.Decoder.DecodeRaw(req.AdmissionRequest.OldObject, objv1alpha1); err != nil {
-				return admission.Errored(http.StatusBadRequest, err)
-			}
-			if err := objv1alpha1.ConvertTo(oldObj); err != nil {
-				return admission.Errored(http.StatusBadRequest, fmt.Errorf("failed to convert v1alpha1->v1beta1: %v", err))
-			}
+		if err := h.decodeObject(req, obj); err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+		if err := h.decodeOldObject(req, oldObj); err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
 		}
 
 		validationErrorList := validateStatefulSet(obj)
@@ -96,9 +77,56 @@ func (h *StatefulSetCreateUpdateHandler) Handle(ctx context.Context, req admissi
 					fmt.Errorf("invalid template modified with InPlaceOnly strategy: %v, currently only image update is allowed for InPlaceOnly", err))
 			}
 		}
+	case admissionv1beta1.Delete:
+		if len(req.OldObject.Raw) == 0 {
+			klog.Warningf("Skip to validate StatefulSet %s/%s deletion for no old object, maybe because of Kubernetes version < 1.16", req.Namespace, req.Name)
+			return admission.ValidationResponse(true, "")
+		}
+		if err := h.decodeOldObject(req, oldObj); err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+		if err := deletionprotection.ValidateWorkloadDeletion(oldObj, oldObj.Spec.Replicas); err != nil {
+			return admission.Errored(http.StatusForbidden, err)
+		}
 	}
 
 	return admission.ValidationResponse(true, "")
+}
+
+func (h *StatefulSetCreateUpdateHandler) decodeObject(req admission.Request, obj *appsv1beta1.StatefulSet) error {
+	switch req.AdmissionRequest.Resource.Version {
+	case appsv1beta1.GroupVersion.Version:
+		if err := h.Decoder.Decode(req, obj); err != nil {
+			return err
+		}
+	case appsv1alpha1.GroupVersion.Version:
+		objv1alpha1 := &appsv1alpha1.StatefulSet{}
+		if err := h.Decoder.Decode(req, objv1alpha1); err != nil {
+			return err
+		}
+		if err := objv1alpha1.ConvertTo(obj); err != nil {
+			return fmt.Errorf("failed to convert v1alpha1->v1beta1: %v", err)
+		}
+	}
+	return nil
+}
+
+func (h *StatefulSetCreateUpdateHandler) decodeOldObject(req admission.Request, oldObj *appsv1beta1.StatefulSet) error {
+	switch req.AdmissionRequest.Resource.Version {
+	case appsv1beta1.GroupVersion.Version:
+		if err := h.Decoder.DecodeRaw(req.AdmissionRequest.OldObject, oldObj); err != nil {
+			return err
+		}
+	case appsv1alpha1.GroupVersion.Version:
+		objv1alpha1 := &appsv1alpha1.StatefulSet{}
+		if err := h.Decoder.DecodeRaw(req.AdmissionRequest.OldObject, objv1alpha1); err != nil {
+			return err
+		}
+		if err := objv1alpha1.ConvertTo(oldObj); err != nil {
+			return fmt.Errorf("failed to convert v1alpha1->v1beta1: %v", err)
+		}
+	}
+	return nil
 }
 
 //var _ inject.Client = &StatefulSetCreateUpdateHandler{}

--- a/pkg/webhook/statefulset/validating/webhooks.go
+++ b/pkg/webhook/statefulset/validating/webhooks.go
@@ -20,7 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
-// +kubebuilder:webhook:path=/validate-apps-kruise-io-statefulset,mutating=false,failurePolicy=fail,groups=apps.kruise.io,resources=statefulsets,verbs=create;update,versions=v1alpha1;v1beta1,name=vstatefulset.kb.io
+// +kubebuilder:webhook:path=/validate-apps-kruise-io-statefulset,mutating=false,failurePolicy=fail,groups=apps.kruise.io,resources=statefulsets,verbs=create;update;delete,versions=v1alpha1;v1beta1,name=vstatefulset.kb.io
 
 var (
 	// HandlerMap contains admission webhook handlers

--- a/pkg/webhook/util/deletionprotection/deletion_protection.go
+++ b/pkg/webhook/util/deletionprotection/deletion_protection.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2021 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deletionprotection
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	v1 "k8s.io/api/core/v1"
+	kubecontroller "k8s.io/kubernetes/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	policyv1alpha1 "github.com/openkruise/kruise/apis/policy/v1alpha1"
+	"github.com/openkruise/kruise/pkg/features"
+	utilfeature "github.com/openkruise/kruise/pkg/util/feature"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func ValidateWorkloadDeletion(obj metav1.Object, replicas *int32) error {
+	if !utilfeature.DefaultFeatureGate.Enabled(features.ResourcesDeletionProtection) || obj == nil || obj.GetDeletionTimestamp() != nil {
+		return nil
+	}
+	switch val := obj.GetLabels()[policyv1alpha1.DeletionProtectionKey]; val {
+	case policyv1alpha1.DeletionProtectionTypeAlways:
+		return fmt.Errorf("forbidden by ResourcesProtectionDeletion for %s=%s", policyv1alpha1.DeletionProtectionKey, val)
+	case policyv1alpha1.DeletionProtectionTypeCascading:
+		if replicas != nil && *replicas > 0 {
+			return fmt.Errorf("forbidden by ResourcesProtectionDeletion for %s=%s and replicas %d>0", policyv1alpha1.DeletionProtectionKey, val, *replicas)
+		}
+	default:
+	}
+	return nil
+}
+
+func ValidateNamespaceDeletion(c client.Client, namespace *v1.Namespace) error {
+	if !utilfeature.DefaultFeatureGate.Enabled(features.ResourcesDeletionProtection) || namespace.DeletionTimestamp != nil {
+		return nil
+	}
+	switch val := namespace.Labels[policyv1alpha1.DeletionProtectionKey]; val {
+	case policyv1alpha1.DeletionProtectionTypeAlways:
+		return fmt.Errorf("forbidden by ResourcesProtectionDeletion for %s=%s", policyv1alpha1.DeletionProtectionKey, val)
+	case policyv1alpha1.DeletionProtectionTypeCascading:
+		pods := v1.PodList{}
+		if err := c.List(context.TODO(), &pods, client.InNamespace(namespace.Name)); err != nil {
+			return fmt.Errorf("forbidden by ResourcesProtectionDeletion for list pods error: %v", err)
+		}
+		var activeCount int
+		for i := range pods.Items {
+			pod := &pods.Items[i]
+			if kubecontroller.IsPodActive(pod) {
+				activeCount++
+			}
+		}
+		if activeCount > 0 {
+			return fmt.Errorf("forbidden by ResourcesProtectionDeletion for %s=%s and active pods %d>0", policyv1alpha1.DeletionProtectionKey, val, activeCount)
+		}
+	default:
+	}
+	return nil
+}
+
+func ValidateCRDDeletion(c client.Client, obj metav1.Object, gvk schema.GroupVersionKind) error {
+	if !utilfeature.DefaultFeatureGate.Enabled(features.ResourcesDeletionProtection) || obj.GetDeletionTimestamp() != nil {
+		return nil
+	}
+	switch val := obj.GetLabels()[policyv1alpha1.DeletionProtectionKey]; val {
+	case policyv1alpha1.DeletionProtectionTypeAlways:
+		return fmt.Errorf("forbidden by ResourcesProtectionDeletion for %s=%s", policyv1alpha1.DeletionProtectionKey, val)
+	case policyv1alpha1.DeletionProtectionTypeCascading:
+		objList := &unstructured.UnstructuredList{}
+		objList.SetAPIVersion(gvk.GroupVersion().String())
+		objList.SetKind(gvk.Kind)
+		if err := c.List(context.TODO(), objList, client.InNamespace(v1.NamespaceAll)); err != nil {
+			return fmt.Errorf("failed to list CRs of %v: %v", gvk, err)
+		}
+
+		var activeCount int
+		for i := range objList.Items {
+			if objList.Items[i].GetDeletionTimestamp() == nil {
+				activeCount++
+			}
+		}
+		if activeCount > 0 {
+			return fmt.Errorf("forbidden by ResourcesProtectionDeletion for %s=%s and active CRs %d>0", policyv1alpha1.DeletionProtectionKey, val, activeCount)
+		}
+	default:
+	}
+	return nil
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -39,6 +39,7 @@ import (
 
 	// test sources
 	_ "github.com/openkruise/kruise/test/e2e/apps"
+	_ "github.com/openkruise/kruise/test/e2e/policy"
 )
 
 // handleFlags sets up all flags and parses the command line.

--- a/test/e2e/framework/cloneset_util.go
+++ b/test/e2e/framework/cloneset_util.go
@@ -103,3 +103,7 @@ func (t *CloneSetTester) ListImagePullJobsForCloneSet(name string) (jobs []*apps
 	}
 	return jobs, nil
 }
+
+func (t *CloneSetTester) DeleteCloneSet(name string) error {
+	return t.kc.AppsV1alpha1().CloneSets(t.ns).Delete(name, &metav1.DeleteOptions{})
+}

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -25,6 +25,7 @@ import (
 
 	kruiseclientset "github.com/openkruise/kruise/pkg/client/clientset/versioned"
 	v1 "k8s.io/api/core/v1"
+	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
@@ -60,6 +61,8 @@ type Framework struct {
 
 	KruiseClientSet kruiseclientset.Interface
 	ClientSet       clientset.Interface
+
+	ApiExtensionsClientSet apiextensionsclientset.Interface
 
 	DynamicClient dynamic.Interface
 
@@ -153,6 +156,8 @@ func (f *Framework) BeforeEach() {
 		f.KruiseClientSet, err = kruiseclientset.NewForConfig(config)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		f.ClientSet, err = clientset.NewForConfig(config)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		f.ApiExtensionsClientSet, err = apiextensionsclientset.NewForConfig(config)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		f.DynamicClient, err = dynamic.NewForConfig(config)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/test/e2e/policy/deletionprotection.go
+++ b/test/e2e/policy/deletionprotection.go
@@ -1,0 +1,302 @@
+/*
+Copyright 2021 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package policy
+
+import (
+	"fmt"
+	"time"
+
+	apps "k8s.io/api/apps/v1"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
+	policyv1alpha1 "github.com/openkruise/kruise/apis/policy/v1alpha1"
+	kruiseclientset "github.com/openkruise/kruise/pkg/client/clientset/versioned"
+	"github.com/openkruise/kruise/test/e2e/framework"
+	v1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/rand"
+	clientset "k8s.io/client-go/kubernetes"
+	utilpointer "k8s.io/utils/pointer"
+)
+
+const (
+	deleteForbiddenMessage = "forbidden by ResourcesProtectionDeletion"
+)
+
+var _ = SIGDescribe("DeletionProtection", func() {
+	f := framework.NewDefaultFramework("deletionprotection")
+	var ns string
+	var c clientset.Interface
+	var kc kruiseclientset.Interface
+	var ec apiextensionsclientset.Interface
+	var dc dynamic.Interface
+	var randStr string
+
+	ginkgo.BeforeEach(func() {
+		c = f.ClientSet
+		kc = f.KruiseClientSet
+		ec = f.ApiExtensionsClientSet
+		dc = f.DynamicClient
+		ns = f.Namespace.Name
+		randStr = rand.String(10)
+		_ = ns
+	})
+
+	framework.KruiseDescribe("namespace deletion", func() {
+		ginkgo.It("should be protected", func() {
+			ns := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{
+				Name:   "kruise-e2e-deletion-protection-" + randStr,
+				Labels: map[string]string{policyv1alpha1.DeletionProtectionKey: policyv1alpha1.DeletionProtectionTypeAlways},
+			}}
+			ginkgo.By("Create test namespace " + ns.Name + " with Always")
+			_, err := c.CoreV1().Namespaces().Create(ns)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("Delete the namespace should be rejected")
+			err = c.CoreV1().Namespaces().Delete(ns.Name, &metav1.DeleteOptions{})
+			gomega.Expect(err).To(gomega.HaveOccurred())
+			gomega.Expect(err.Error()).Should(gomega.ContainSubstring(deleteForbiddenMessage))
+
+			ginkgo.By("Create a CloneSet in this namespace and wait for pod created")
+			tester := framework.NewCloneSetTester(c, kc, ns.Name)
+			cs := tester.NewCloneSet("clone-"+randStr, 1, appsv1alpha1.CloneSetUpdateStrategy{})
+			cs, err = tester.CreateCloneSet(cs)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Eventually(func() int32 {
+				cs, err = tester.GetCloneSet(cs.Name)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				return cs.Status.Replicas
+			}, 5*time.Second, time.Second).Should(gomega.Equal(int32(1)))
+
+			ginkgo.By("Patch the namespace deletion to Cascading")
+			_, err = c.CoreV1().Namespaces().Patch(ns.Name, types.StrategicMergePatchType,
+				[]byte(fmt.Sprintf(`{"metadata":{"labels":{"%s":"%s"}}}`, policyv1alpha1.DeletionProtectionKey, policyv1alpha1.DeletionProtectionTypeCascading)))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("Delete the namespace should be rejected")
+			err = c.CoreV1().Namespaces().Delete(ns.Name, &metav1.DeleteOptions{})
+			gomega.Expect(err).To(gomega.HaveOccurred())
+			gomega.Expect(err.Error()).Should(gomega.ContainSubstring(deleteForbiddenMessage))
+
+			ginkgo.By("Scale CloneSet replicas to 0")
+			err = tester.UpdateCloneSet(cs.Name, func(cs *appsv1alpha1.CloneSet) {
+				cs.Spec.Replicas = utilpointer.Int32Ptr(0)
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Eventually(func() int32 {
+				cs, err = tester.GetCloneSet(cs.Name)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				return cs.Status.Replicas
+			}, 5*time.Second, time.Second).Should(gomega.Equal(int32(0)))
+
+			time.Sleep(time.Second)
+			ginkgo.By("Delete the namespace successfully")
+			err = c.CoreV1().Namespaces().Delete(ns.Name, &metav1.DeleteOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+	})
+
+	framework.KruiseDescribe("CRD deletion", func() {
+		ginkgo.It("should be protected", func() {
+			crd := &apiextensionsv1.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "testdeletioncases.e2e.kruise.io",
+					Labels: map[string]string{policyv1alpha1.DeletionProtectionKey: policyv1alpha1.DeletionProtectionTypeAlways},
+				},
+				Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+					Group: "e2e.kruise.io",
+					Scope: apiextensionsv1.NamespaceScoped,
+					Names: apiextensionsv1.CustomResourceDefinitionNames{Plural: "testdeletioncases", Singular: "testdeletioncase", Kind: "TestDeletionCase"},
+					Versions: []apiextensionsv1.CustomResourceDefinitionVersion{{
+						Name: "v1beta1",
+						Schema: &apiextensionsv1.CustomResourceValidation{OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+							Type: "object",
+							Properties: apiextensionsv1.JSONSchemaDefinitions{
+								"apiVersion": apiextensionsv1.JSONSchemaProps{Type: "string"},
+								"kind":       apiextensionsv1.JSONSchemaProps{Type: "string"},
+								"metadata":   apiextensionsv1.JSONSchemaProps{Type: "object"},
+							},
+						}},
+						Storage: true,
+						Served:  true,
+					}},
+				},
+			}
+			ginkgo.By("Create test CRD " + crd.Name + " with Always")
+			_, err := ec.ApiextensionsV1().CustomResourceDefinitions().Create(crd)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("Delete the CRD should be rejected")
+			err = ec.ApiextensionsV1().CustomResourceDefinitions().Delete(crd.Name, &metav1.DeleteOptions{})
+			gomega.Expect(err).To(gomega.HaveOccurred())
+			gomega.Expect(err.Error()).Should(gomega.ContainSubstring(deleteForbiddenMessage))
+
+			ginkgo.By("Create a test CR")
+			time.Sleep(time.Second)
+			obj := &unstructured.Unstructured{}
+			obj.SetAPIVersion("e2e.kruise.io/v1beta1")
+			obj.SetKind("TestDeletionCase")
+			obj.SetNamespace(ns)
+			obj.SetName("test-cr-" + randStr)
+			obj, err = dc.Resource(schema.GroupVersionResource{Group: "e2e.kruise.io", Version: "v1beta1", Resource: "testdeletioncases"}).Namespace(ns).Create(obj, metav1.CreateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("Patch the CRD deletion to Cascading")
+			_, err = ec.ApiextensionsV1().CustomResourceDefinitions().Patch(crd.Name, types.StrategicMergePatchType,
+				[]byte(fmt.Sprintf(`{"metadata":{"labels":{"%s":"%s"}}}`, policyv1alpha1.DeletionProtectionKey, policyv1alpha1.DeletionProtectionTypeCascading)))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("Delete the CRD should be rejected")
+			err = ec.ApiextensionsV1().CustomResourceDefinitions().Delete(crd.Name, &metav1.DeleteOptions{})
+			gomega.Expect(err).To(gomega.HaveOccurred())
+			gomega.Expect(err.Error()).Should(gomega.ContainSubstring(deleteForbiddenMessage))
+
+			ginkgo.By("Delete the test CR")
+			err = dc.Resource(schema.GroupVersionResource{Group: "e2e.kruise.io", Version: "v1beta1", Resource: "testdeletioncases"}).Namespace(ns).Delete(obj.GetName(), &metav1.DeleteOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("Delete the CRD should be successful")
+			err = ec.ApiextensionsV1().CustomResourceDefinitions().Delete(crd.Name, &metav1.DeleteOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+	})
+
+	framework.KruiseDescribe("Workload deletion", func() {
+		var err error
+		ginkgo.It("CloneSet should be protected", func() {
+			ginkgo.By("Create a CloneSet with Always")
+			tester := framework.NewCloneSetTester(c, kc, ns)
+			cs := tester.NewCloneSet("clone-"+randStr, 0, appsv1alpha1.CloneSetUpdateStrategy{})
+			cs.Labels = map[string]string{policyv1alpha1.DeletionProtectionKey: policyv1alpha1.DeletionProtectionTypeAlways}
+			cs, err = tester.CreateCloneSet(cs)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("Delete the CloneSet should be rejected")
+			err = tester.DeleteCloneSet(cs.Name)
+			gomega.Expect(err).To(gomega.HaveOccurred())
+			gomega.Expect(err.Error()).Should(gomega.ContainSubstring(deleteForbiddenMessage))
+
+			ginkgo.By("Scale CloneSet replicas to 2 and protection to Cascading")
+			err = tester.UpdateCloneSet(cs.Name, func(cs *appsv1alpha1.CloneSet) {
+				cs.Spec.Replicas = utilpointer.Int32Ptr(2)
+				cs.Labels[policyv1alpha1.DeletionProtectionKey] = policyv1alpha1.DeletionProtectionTypeCascading
+			})
+			gomega.Eventually(func() int32 {
+				cs, err = tester.GetCloneSet(cs.Name)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				return cs.Status.Replicas
+			}, 5*time.Second, time.Second).Should(gomega.Equal(int32(2)))
+
+			ginkgo.By("Delete the CloneSet should be rejected")
+			err = tester.DeleteCloneSet(cs.Name)
+			gomega.Expect(err).To(gomega.HaveOccurred())
+			gomega.Expect(err.Error()).Should(gomega.ContainSubstring(deleteForbiddenMessage))
+
+			ginkgo.By("Scale CloneSet replicas to 0")
+			err = tester.UpdateCloneSet(cs.Name, func(cs *appsv1alpha1.CloneSet) {
+				cs.Spec.Replicas = utilpointer.Int32Ptr(0)
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Eventually(func() int32 {
+				cs, err = tester.GetCloneSet(cs.Name)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				return cs.Status.Replicas
+			}, 5*time.Second, time.Second).Should(gomega.Equal(int32(0)))
+
+			ginkgo.By("Delete the CloneSet should be successful")
+			err = tester.DeleteCloneSet(cs.Name)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("Deployment should be protected", func() {
+			ginkgo.By("Create a Deployment with Always")
+			name := "deploy-" + randStr
+			deploy := &apps.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: ns,
+					Name:      name,
+					Labels:    map[string]string{policyv1alpha1.DeletionProtectionKey: policyv1alpha1.DeletionProtectionTypeAlways},
+				},
+				Spec: apps.DeploymentSpec{
+					Replicas: utilpointer.Int32Ptr(0),
+					Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"owner": name}},
+					Template: v1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{"owner": name},
+						},
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{
+								{
+									Name:  "nginx",
+									Image: "nginx:1.9.1",
+									Env: []v1.EnvVar{
+										{Name: "test", Value: "foo"},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			deploy, err = c.AppsV1().Deployments(ns).Create(deploy)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("Delete the Deployment should be rejected")
+			err = c.AppsV1().Deployments(ns).Delete(deploy.Name, &metav1.DeleteOptions{})
+			gomega.Expect(err).To(gomega.HaveOccurred())
+			gomega.Expect(err.Error()).Should(gomega.ContainSubstring(deleteForbiddenMessage))
+
+			ginkgo.By("Scale Deployment replicas to 2 and protection to Cascading")
+			deploy, err = c.AppsV1().Deployments(ns).Patch(deploy.Name, types.StrategicMergePatchType,
+				[]byte(fmt.Sprintf(`{"metadata":{"labels":{"%s":"%s"}},"spec":{"replicas":%d}}`, policyv1alpha1.DeletionProtectionKey, policyv1alpha1.DeletionProtectionTypeCascading, 2)))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Eventually(func() int32 {
+				deploy, err = c.AppsV1().Deployments(ns).Get(deploy.Name, metav1.GetOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				return deploy.Status.Replicas
+			}, 5*time.Second, time.Second).Should(gomega.Equal(int32(2)))
+
+			ginkgo.By("Delete the Deployment should be rejected")
+			err = c.AppsV1().Deployments(ns).Delete(deploy.Name, &metav1.DeleteOptions{})
+			gomega.Expect(err).To(gomega.HaveOccurred())
+			gomega.Expect(err.Error()).Should(gomega.ContainSubstring(deleteForbiddenMessage))
+
+			ginkgo.By("Scale Deployment replicas to 0")
+			deploy, err = c.AppsV1().Deployments(ns).Patch(deploy.Name, types.StrategicMergePatchType,
+				[]byte(fmt.Sprintf(`{"spec":{"replicas":%d}}`, 0)))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Eventually(func() int32 {
+				deploy, err = c.AppsV1().Deployments(ns).Get(deploy.Name, metav1.GetOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				return deploy.Status.Replicas
+			}, 5*time.Second, time.Second).Should(gomega.Equal(int32(0)))
+
+			ginkgo.By("Delete the Deployment should successful")
+			err = c.AppsV1().Deployments(ns).Delete(deploy.Name, &metav1.DeleteOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+	})
+})

--- a/test/e2e/policy/framework.go
+++ b/test/e2e/policy/framework.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2019 The Kruise Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,17 +15,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package validating
+package policy
 
-import (
-	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
-)
+import "github.com/onsi/ginkgo"
 
-// +kubebuilder:webhook:path=/validate-apps-kruise-io-v1alpha1-uniteddeployment,mutating=false,failurePolicy=fail,groups=apps.kruise.io,resources=uniteddeployments,verbs=create;update;delete,versions=v1alpha1,name=vuniteddeployment.kb.io
-
-var (
-	// HandlerMap contains admission webhook handlers
-	HandlerMap = map[string]admission.Handler{
-		"validate-apps-kruise-io-v1alpha1-uniteddeployment": &UnitedDeploymentCreateUpdateHandler{},
-	}
-)
+// SIGDescribe describes SIG information
+func SIGDescribe(text string, body func()) bool {
+	return ginkgo.Describe("[policy] "+text, body)
+}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Implement resources-deletion-protection including Always and Cascading.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
Proposal #577 

### Ⅴ. Special notes for reviews
API definition:

- a new feature-gate named `ResourcesDeletionProtection`
- a label named `policy.kruise.io/delete-protection`, the values can be:
  - `Always`: this object will always be forbidden to be deleted, unless the label is removed
  - `Cascading`: this object will be forbidden to be deleted, if it has active resources owned

If the feature-gate has enabled, the resources below with this label will be validated for deletion operation:

| Kind                        | Group                  | Version            | Cascading judgement                                |
| --------------------------- | ---------------------- | ------------------ | ----------------------------------------------------
| `Namespace`                 | core                   | v1                 | whether there is active Pods in this namespace     |
| `CustomResourceDefinition`  | apiextensions.k8s.io   | v1beta1, v1        | whether there is existing CRs of this CRD          |
| `Deployment`                | apps                   | v1                 | whether the replicas is 0                          |
| `StatefulSet`               | apps                   | v1                 | whether the replicas is 0                          |
| `ReplicaSet`                | apps                   | v1                 | whether the replicas is 0                          |
| `CloneSet`                  | apps.kruise.io         | v1alpha1           | whether the replicas is 0                          |
| `StatefulSet`               | apps.kruise.io         | v1alpha1, v1beta1  | whether the replicas is 0                          |
| `UnitedDeployment`          | apps.kruise.io         | v1alpha1           | whether the replicas is 0                          |


