### PR TITLE
Support minStartedSeconds for ContainerRecreateRequest

### DIFF
--- a/apis/apps/v1alpha1/containerrecreaterequest_types.go
+++ b/apis/apps/v1alpha1/containerrecreaterequest_types.go
@@ -98,6 +98,10 @@ type ContainerRecreateRequestStrategy struct {
 	// UnreadyGracePeriodSeconds is the optional duration in seconds to mark Pod as not ready over this duration before
 	// executing preStop hook and stopping the container.
 	UnreadyGracePeriodSeconds *int64 `json:"unreadyGracePeriodSeconds,omitempty"`
+	// Minimum number of seconds for which a newly created container should be started and ready
+	// without any of its container crashing, for it to be considered Succeeded.
+	// Defaults to 0 (container will be considered Succeeded as soon as it is started and ready)
+	MinStartedSeconds int32 `json:"minStartedSeconds,omitempty"`
 }
 
 type ContainerRecreateRequestFailurePolicyType string

--- a/config/crd/bases/apps.kruise.io_containerrecreaterequests.yaml
+++ b/config/crd/bases/apps.kruise.io_containerrecreaterequests.yaml
@@ -125,6 +125,13 @@ spec:
                   description: FailurePolicy decides whether to continue if one container
                     fails to recreate
                   type: string
+                minStartedSeconds:
+                  description: Minimum number of seconds for which a newly created
+                    container should be started and ready without any of its container
+                    crashing, for it to be considered Succeeded. Defaults to 0 (container
+                    will be considered Succeeded as soon as it is started and ready)
+                  format: int32
+                  type: integer
                 orderedRecreate:
                   description: OrderedRecreate indicates whether to recreate the next
                     container only if the previous one has recreated completely.

--- a/test/e2e/apps/containerrecreate.go
+++ b/test/e2e/apps/containerrecreate.go
@@ -84,6 +84,7 @@ var _ = SIGDescribe("ContainerRecreateRequest", func() {
 						Containers: []appsv1alpha1.ContainerRecreateRequestContainer{
 							{Name: "app"},
 						},
+						Strategy:                &appsv1alpha1.ContainerRecreateRequestStrategy{MinStartedSeconds: 5},
 						TTLSecondsAfterFinished: utilpointer.Int32Ptr(3),
 					},
 				}
@@ -100,17 +101,18 @@ var _ = SIGDescribe("ContainerRecreateRequest", func() {
 					crr, err = tester.GetCRR(crr.Name)
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 					return crr.Status.Phase
-				}, 60*time.Second, 3*time.Second).Should(gomega.Equal(appsv1alpha1.ContainerRecreateRequestCompleted))
+				}, 70*time.Second, 3*time.Second).Should(gomega.Equal(appsv1alpha1.ContainerRecreateRequestCompleted))
 				gomega.Expect(crr.Status.CompletionTime).ShouldNot(gomega.BeNil())
 				gomega.Expect(crr.Labels[appsv1alpha1.ContainerRecreateRequestActiveKey]).Should(gomega.Equal(""))
 				gomega.Expect(crr.Status.ContainerRecreateStates).Should(gomega.Equal([]appsv1alpha1.ContainerRecreateRequestContainerRecreateState{{Name: "app", Phase: appsv1alpha1.ContainerRecreateRequestSucceeded}}))
 
-				ginkgo.By("Check Pod containers recreated")
+				ginkgo.By("Check Pod containers recreated and started for minStartedSeconds")
 				pod, err = tester.GetPod(pod.Name)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				gomega.Expect(podutil.IsPodReady(pod)).Should(gomega.Equal(true))
 				gomega.Expect(pod.Status.ContainerStatuses[0].ContainerID).ShouldNot(gomega.Equal(crr.Spec.Containers[0].StatusContext.ContainerID))
 				gomega.Expect(pod.Status.ContainerStatuses[0].RestartCount).Should(gomega.Equal(int32(1)))
+				gomega.Expect(crr.Status.CompletionTime.Sub(pod.Status.ContainerStatuses[0].State.Running.StartedAt.Time)).Should(gomega.BeNumerically(">", 4*time.Second))
 
 				ginkgo.By("Wait CRR deleted by TTL")
 				gomega.Eventually(func() bool {


### PR DESCRIPTION
Signed-off-by: FillZpp <FillZpp.pub@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Support minStartedSeconds for ContainerRecreateRequest.

`minStartedSeconds` is the minimum number of seconds for which a newly created container should be started and ready without any of its container crashing, for it to be considered Succeeded.

It defaults to 0, which means container will be considered Succeeded as soon as it is started and ready.


