### PR TITLE
Fix inaccurate resourceVersion expectation for ImagePullJob

### DIFF
--- a/pkg/controller/imagepulljob/imagepulljob_event_handler.go
+++ b/pkg/controller/imagepulljob/imagepulljob_event_handler.go
@@ -47,7 +47,6 @@ func (e *nodeImageEventHandler) Create(evt event.CreateEvent, q workqueue.RateLi
 func (e *nodeImageEventHandler) Update(evt event.UpdateEvent, q workqueue.RateLimitingInterface) {
 	obj := evt.ObjectNew.(*appsv1alpha1.NodeImage)
 	oldObj := evt.ObjectOld.(*appsv1alpha1.NodeImage)
-	resourceVersionExpectations.Observe(obj)
 	if obj.DeletionTimestamp != nil {
 		e.handle(obj, q)
 	} else {

--- a/pkg/controller/nodeimage/nodeimage_controller.go
+++ b/pkg/controller/nodeimage/nodeimage_controller.go
@@ -438,7 +438,7 @@ func (r *ReconcileNodeImage) updateNodeImageStatus(nodeImage *appsv1alpha1.NodeI
 		}
 	}
 
-	if util.IsJSONEqual(newStatus.ImageStatuses, nodeImage.Status.ImageStatuses) {
+	if util.IsJSONObjectEqual(newStatus.ImageStatuses, nodeImage.Status.ImageStatuses) {
 		return nil
 	}
 

--- a/pkg/daemon/imagepuller/utils.go
+++ b/pkg/daemon/imagepuller/utils.go
@@ -97,7 +97,7 @@ func newStatusUpdater(imagePullNodeClient clientalpha1.NodeImageInterface) *stat
 }
 
 func (su *statusUpdater) updateStatus(nodeImage *appsv1alpha1.NodeImage, newStatus *appsv1alpha1.NodeImageStatus) (limited bool, err error) {
-	if util.IsJSONEqual(newStatus, su.previousStatus) {
+	if util.IsJSONObjectEqual(newStatus, su.previousStatus) {
 		// 12h + 0~60min
 		randRefresh := time.Hour*12 + time.Second*time.Duration(rand.Int63n(3600))
 		if time.Since(su.previousTimestamp) < randRefresh {

--- a/pkg/util/json.go
+++ b/pkg/util/json.go
@@ -27,14 +27,18 @@ func DumpJSON(o interface{}) string {
 	return string(j)
 }
 
-// IsJSONEqual checks if two objects are equal after encoding json
-func IsJSONEqual(o1, o2 interface{}) bool {
+// IsJSONObjectEqual checks if two objects are equal after encoding json
+func IsJSONObjectEqual(o1, o2 interface{}) bool {
+	if reflect.DeepEqual(o1, o2) {
+		return true
+	}
+
 	oj1, _ := json.Marshal(o1)
 	oj2, _ := json.Marshal(o2)
 	os1 := string(oj1)
 	os2 := string(oj2)
-	if os1 != os2 {
-
+	if os1 == os2 {
+		return true
 	}
 
 	om1 := make(map[string]interface{})

--- a/pkg/util/json_test.go
+++ b/pkg/util/json_test.go
@@ -89,10 +89,10 @@ func TestIsJSONEqual(t *testing.T) {
 		t.Fatalf("expect t1 not equal to t2")
 	}
 
-	if !IsJSONEqual(t1, t2) {
+	if !IsJSONObjectEqual(t1, t2) {
 		t.Fatalf("expect t1 json equal to t2: %v, %v", t1.TestTime.Time, t2.TestTime.Time)
 	}
-	if IsJSONEqual(t1, t3) {
+	if IsJSONObjectEqual(t1, t3) {
 		t.Fatalf("expect t1 not json equal to t3")
 	}
 }


### PR DESCRIPTION
Signed-off-by: FillZpp <FillZpp.pub@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Fix inaccurate resourceVersion expectation for ImagePullJob.

### Ⅴ. Special notes for reviews
The previous `resourceVersionExpectations` observes nodeimage in event handler, which might cause the satisfied check to be inaccurate in reconcile, and the active pulling count may be bigger than `parallelism`.


