### PR TITLE
Optimize manage phase of daemonset controller

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -224,6 +224,63 @@ jobs:
           ./scripts/generate_bindata.sh
           ginkgo -timeout 60m -v --focus='\[apps\] (PullImage|ContainerRecreateRequest)' test/e2e
 
+  e2e-tests-for-advanced-daemonset:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Setup Kind Cluster
+        uses: engineerd/setup-kind@v0.5.0
+        with:
+          version: ${{ env.KIND_VERSION }}
+      - name: Setup Kustomize
+        uses: imranismail/setup-kustomize@v1
+        with:
+          kustomize-version: ${{ env.KUSTOMIZE_VERSION }}
+      - name: Build image
+        run: |
+          export IMAGE="openkruise/kruise-manager:e2e-${GITHUB_RUN_ID}"
+          docker build --pull --no-cache . -t $IMAGE
+          kind load docker-image $IMAGE || { echo >&2 "kind not installed or error loading image: $IMAGE"; exit 1; }
+      - name: Install Kruise
+        run: |
+          set -ex
+          kubectl cluster-info
+          IMG=openkruise/kruise-manager:e2e-${GITHUB_RUN_ID} ./scripts/deploy_kind.sh
+          for ((i=1;i<10;i++));
+          do
+            set +e
+            PODS=$(kubectl get pod -n kruise-system | grep '1/1' | wc -l)
+            set -e
+            if [ "$PODS" -eq 2 ]; then
+              break
+            fi
+            sleep 3
+          done
+          set +e
+          PODS=$(kubectl get pod -n kruise-system | grep '1/1' | wc -l)
+          kubectl get all -n kruise-system -o yaml
+          kubectl get pod -n kruise-system --no-headers | grep daemon | awk '{print $1}' | xargs kubectl logs -n kruise-system
+          kubectl get pod -n kruise-system --no-headers | grep daemon | awk '{print $1}' | xargs kubectl logs -n kruise-system --previous=true
+          set -e
+          if [ "$PODS" -eq 2 ]; then
+            echo "Wait for kruise-manager and kruise-daemon ready successfully"
+          else
+            echo "Timeout to wait for kruise-manager and kruise-daemon ready"
+            exit 1
+          fi
+      - name: Run E2E Tests
+        run: |
+          export KUBECONFIG=/home/runner/.kube/config
+          go install github.com/onsi/ginkgo/ginkgo
+          ./scripts/generate_bindata.sh
+          ginkgo -timeout 60m -v --focus='\[apps\] DaemonSet' test/e2e
+
   e2e-tests-for-other:
     runs-on: ubuntu-18.04
     steps:
@@ -280,7 +337,7 @@ jobs:
           go install github.com/onsi/ginkgo/ginkgo
           ./scripts/generate_bindata.sh
           set +e
-          ginkgo -timeout 60m -v --skip='\[apps\] (StatefulSet|PullImage|ContainerRecreateRequest)' test/e2e
+          ginkgo -timeout 60m -v --skip='\[apps\] (StatefulSet|PullImage|ContainerRecreateRequest|DaemonSet)' test/e2e
 #          retVal=$?
 #          if [ $retVal -ne 0 ]; then
 #            kubectl get pod -n kruise-system -o wide

--- a/test/e2e/apps/daemonset.go
+++ b/test/e2e/apps/daemonset.go
@@ -1,0 +1,158 @@
+package apps
+
+import (
+	"fmt"
+
+	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
+	kruiseclientset "github.com/openkruise/kruise/pkg/client/clientset/versioned"
+	"github.com/openkruise/kruise/test/e2e/framework"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientset "k8s.io/client-go/kubernetes"
+)
+
+var _ = SIGDescribe("DaemonSet", func() {
+	f := framework.NewDefaultFramework("daemonset")
+	var ns string
+	var c clientset.Interface
+	var kc kruiseclientset.Interface
+	var tester *framework.DaemonSetTester
+
+	ginkgo.BeforeEach(func() {
+		c = f.ClientSet
+		kc = f.KruiseClientSet
+		ns = f.Namespace.Name
+		tester = framework.NewDaemonSetTester(c, kc, ns)
+	})
+
+	framework.KruiseDescribe("Basic DaemonSet functionality [DaemonSetBasic]", func() {
+		dsName := "e2e-ds"
+
+		ginkgo.AfterEach(func() {
+			if ginkgo.CurrentGinkgoTestDescription().Failed {
+				framework.DumpDebugInfo(c, ns)
+			}
+			framework.Logf("Deleting DaemonSet %s.%s in cluster", ns, dsName)
+			tester.DeleteDaemonSet(ns, dsName)
+		})
+
+		/*
+		  Testname: DaemonSet-Creation
+		  Description: A conformant Kubernetes distribution MUST support the creation of DaemonSets. When a DaemonSet
+		  Pod is deleted, the DaemonSet controller MUST create a replacement Pod.
+		*/
+		framework.ConformanceIt("should run and stop simple daemon", func() {
+			label := map[string]string{framework.DaemonSetNameLabel: dsName}
+
+			ginkgo.By(fmt.Sprintf("Creating simple DaemonSet %q", dsName))
+			ds, err := tester.CreateDaemonSet(tester.NewDaemonSet(dsName, label, framework.OldImage, appsv1alpha1.DaemonSetUpdateStrategy{}))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("Check that daemon pods launch on every node of the cluster.")
+			err = wait.PollImmediate(framework.DaemonSetRetryPeriod, framework.DaemonSetRetryTimeout, tester.CheckRunningOnAllNodes(ds))
+
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "error waiting for daemon pod to start")
+			err = tester.CheckDaemonStatus(dsName)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("Stop a daemon pod, check that the daemon pod is revived.")
+			podList, err := tester.ListDaemonPods(label)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(len(podList.Items)).To(gomega.BeNumerically(">", 0))
+			pod := podList.Items[0]
+
+			err = c.CoreV1().Pods(ns).Delete(pod.Name, nil)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			err = wait.PollImmediate(framework.DaemonSetRetryPeriod, framework.DaemonSetRetryTimeout, tester.CheckRunningOnAllNodes(ds))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "error waiting for daemon pod to revive")
+		})
+
+		/*
+		  Testname: DaemonSet-NodeSelection
+		  Description: A conformant Kubernetes distribution MUST support DaemonSet Pod node selection via label
+		  selectors.
+		*/
+		framework.ConformanceIt("should run and stop complex daemon", func() {
+			complexLabel := map[string]string{framework.DaemonSetNameLabel: dsName}
+			nodeSelector := map[string]string{framework.DaemonSetColorLabel: "blue"}
+			framework.Logf("Creating daemon %q with a node selector", dsName)
+			ds := tester.NewDaemonSet(dsName, complexLabel, framework.OldImage, appsv1alpha1.DaemonSetUpdateStrategy{})
+			ds.Spec.Template.Spec.NodeSelector = nodeSelector
+			ds, err := tester.CreateDaemonSet(ds)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("Initially, daemon pods should not be running on any nodes.")
+			err = wait.PollImmediate(framework.DaemonSetRetryPeriod, framework.DaemonSetRetryTimeout, tester.CheckRunningOnNoNodes(ds))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "error waiting for daemon pods to be running on no nodes")
+
+			ginkgo.By("Change node label to blue, check that daemon pod is launched.")
+			nodeList := framework.GetReadySchedulableNodesOrDie(f.ClientSet)
+			gomega.Expect(len(nodeList.Items)).To(gomega.BeNumerically(">", 0))
+			newNode, err := tester.SetDaemonSetNodeLabels(nodeList.Items[0].Name, nodeSelector)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "error setting labels on node")
+			daemonSetLabels, _ := tester.SeparateDaemonSetNodeLabels(newNode.Labels)
+			gomega.Expect(len(daemonSetLabels)).To(gomega.Equal(1))
+			err = wait.PollImmediate(framework.DaemonSetRetryPeriod, framework.DaemonSetRetryTimeout, tester.CheckDaemonPodOnNodes(ds, []string{newNode.Name}))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "error waiting for daemon pods to be running on new nodes")
+			err = tester.CheckDaemonStatus(dsName)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("Update the node label to green, and wait for daemons to be unscheduled")
+			nodeSelector[framework.DaemonSetColorLabel] = "green"
+			greenNode, err := tester.SetDaemonSetNodeLabels(nodeList.Items[0].Name, nodeSelector)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "error removing labels on node")
+			gomega.Expect(wait.PollImmediate(framework.DaemonSetRetryPeriod, framework.DaemonSetRetryTimeout, tester.CheckRunningOnNoNodes(ds))).
+				NotTo(gomega.HaveOccurred(), "error waiting for daemon pod to not be running on nodes")
+
+			ginkgo.By("Update DaemonSet node selector to green, and change its update strategy to RollingUpdate")
+			patch := fmt.Sprintf(`{"spec":{"template":{"spec":{"nodeSelector":{"%s":"%s"}}},"updateStrategy":{"type":"RollingUpdate"}}}`,
+				framework.DaemonSetColorLabel, greenNode.Labels[framework.DaemonSetColorLabel])
+			ds, err = tester.PatchDaemonSet(dsName, types.MergePatchType, []byte(patch))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "error patching daemon set")
+			daemonSetLabels, _ = tester.SeparateDaemonSetNodeLabels(greenNode.Labels)
+			gomega.Expect(len(daemonSetLabels)).To(gomega.Equal(1))
+			err = wait.PollImmediate(framework.DaemonSetRetryPeriod, framework.DaemonSetRetryTimeout, tester.CheckDaemonPodOnNodes(ds, []string{greenNode.Name}))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "error waiting for daemon pods to be running on new nodes")
+			err = tester.CheckDaemonStatus(dsName)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		/*
+		  Testname: DaemonSet-FailedPodCreation
+		  Description: A conformant Kubernetes distribution MUST create new DaemonSet Pods when they fail.
+		*/
+		framework.ConformanceIt("should retry creating failed daemon pods", func() {
+			label := map[string]string{framework.DaemonSetNameLabel: dsName}
+
+			ginkgo.By(fmt.Sprintf("Creating a simple DaemonSet %q", dsName))
+			ds, err := tester.CreateDaemonSet(tester.NewDaemonSet(dsName, label, framework.OldImage, appsv1alpha1.DaemonSetUpdateStrategy{}))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("Check that daemon pods launch on every node of the cluster.")
+			err = wait.PollImmediate(framework.DaemonSetRetryPeriod, framework.DaemonSetRetryTimeout, tester.CheckRunningOnAllNodes(ds))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "error waiting for daemon pod to start")
+			err = tester.CheckDaemonStatus(dsName)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("Set a daemon pod's phase to 'Failed', check that the daemon pod is revived.")
+			podList, err := tester.ListDaemonPods(label)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			pod := podList.Items[0]
+			pod.ResourceVersion = ""
+			pod.Status.Phase = v1.PodFailed
+			_, err = c.CoreV1().Pods(ns).UpdateStatus(&pod)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "error failing a daemon pod")
+			err = wait.PollImmediate(framework.DaemonSetRetryPeriod, framework.DaemonSetRetryTimeout, tester.CheckRunningOnAllNodes(ds))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "error waiting for daemon pod to revive")
+
+			ginkgo.By("Wait for the failed daemon pod to be completely deleted.")
+			err = wait.PollImmediate(framework.DaemonSetRetryPeriod, framework.DaemonSetRetryTimeout, tester.WaitFailedDaemonPodDeleted(&pod))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "error waiting for the failed daemon pod to be completely deleted")
+		})
+	})
+})

--- a/test/e2e/framework/daemonset_util.go
+++ b/test/e2e/framework/daemonset_util.go
@@ -1,0 +1,300 @@
+package framework
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+
+	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
+	kruiseclientset "github.com/openkruise/kruise/pkg/client/clientset/versioned"
+	"github.com/openkruise/kruise/pkg/controller/daemonset"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
+	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
+	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
+)
+
+const (
+	// DaemonSetRetryPeriod indicates poll interval for DaemonSet tests
+	DaemonSetRetryPeriod = 1 * time.Second
+	// DaemonSetRetryTimeout indicates timeout interval for DaemonSet operations
+	DaemonSetRetryTimeout = 5 * time.Minute
+
+	DaemonSetLabelPrefix = "daemonset-"
+	DaemonSetNameLabel   = DaemonSetLabelPrefix + "name"
+	DaemonSetColorLabel  = DaemonSetLabelPrefix + "color"
+
+	OldImage = "busybox:1.29"
+	NewImage = "busybox:1.30"
+)
+
+type DaemonSetTester struct {
+	c  clientset.Interface
+	kc kruiseclientset.Interface
+	ns string
+}
+
+func NewDaemonSetTester(c clientset.Interface, kc kruiseclientset.Interface, ns string) *DaemonSetTester {
+	return &DaemonSetTester{
+		c:  c,
+		kc: kc,
+		ns: ns,
+	}
+}
+
+func (t *DaemonSetTester) NewDaemonSet(name string, label map[string]string, image string, updateStrategy appsv1alpha1.DaemonSetUpdateStrategy) *appsv1alpha1.DaemonSet {
+	return &appsv1alpha1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: t.ns,
+			Name:      name,
+		},
+		Spec: appsv1alpha1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: label,
+			},
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: label,
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:    "busybox",
+							Image:   image,
+							Command: []string{"/bin/sh", "-c", "sleep 10000000"},
+						},
+					},
+					HostNetwork: true,
+				},
+			},
+			UpdateStrategy: updateStrategy,
+		},
+	}
+}
+
+func (t *DaemonSetTester) CreateDaemonSet(ds *appsv1alpha1.DaemonSet) (*appsv1alpha1.DaemonSet, error) {
+	return t.kc.AppsV1alpha1().DaemonSets(t.ns).Create(ds)
+}
+
+func (t *DaemonSetTester) GetDaemonSet(name string) (*appsv1alpha1.DaemonSet, error) {
+	return t.kc.AppsV1alpha1().DaemonSets(t.ns).Get(name, metav1.GetOptions{})
+}
+
+func (t *DaemonSetTester) UpdateDaemonSet(name string, fn func(ds *appsv1alpha1.DaemonSet)) error {
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		ds, err := t.GetDaemonSet(name)
+		if err != nil {
+			return err
+		}
+
+		fn(ds)
+		_, err = t.kc.AppsV1alpha1().DaemonSets(t.ns).Update(ds)
+		return err
+	})
+}
+
+func (t *DaemonSetTester) DeleteDaemonSet(namespace, name string) {
+	err := t.kc.AppsV1alpha1().DaemonSets(namespace).Delete(name, &metav1.DeleteOptions{})
+	if err != nil {
+		Logf("delete daemonset(%s.%s) failed: %s", t.ns, name, err.Error())
+		return
+	}
+}
+
+func (t *DaemonSetTester) PatchDaemonSet(name string, patchType types.PatchType, patch []byte) (*appsv1alpha1.DaemonSet, error) {
+	return t.kc.AppsV1alpha1().DaemonSets(t.ns).Patch(name, patchType, patch)
+}
+
+func (t *DaemonSetTester) WaitForDaemonSetDeleted(namespace, name string) {
+	pollErr := wait.PollImmediate(time.Second, time.Minute,
+		func() (bool, error) {
+			_, err := t.kc.AppsV1alpha1().DaemonSets(namespace).Get(name, metav1.GetOptions{})
+			if err != nil {
+				if apierrors.IsNotFound(err) {
+					return true, nil
+				}
+				return false, err
+			}
+			return false, nil
+		})
+	if pollErr != nil {
+		Failf("Failed waiting for daemonset to enter Deleted: %v", pollErr)
+	}
+}
+
+func (t *DaemonSetTester) CheckDaemonStatus(dsName string) error {
+	ds, err := t.GetDaemonSet(dsName)
+	if err != nil {
+		return fmt.Errorf("Could not get daemon set from v1.")
+	}
+	desired, scheduled, ready := ds.Status.DesiredNumberScheduled, ds.Status.CurrentNumberScheduled, ds.Status.NumberReady
+	if desired != scheduled && desired != ready {
+		return fmt.Errorf("Error in daemon status. DesiredScheduled: %d, CurrentScheduled: %d, Ready: %d", desired, scheduled, ready)
+	}
+	return nil
+}
+
+func (t *DaemonSetTester) SeparateDaemonSetNodeLabels(labels map[string]string) (map[string]string, map[string]string) {
+	daemonSetLabels := map[string]string{}
+	otherLabels := map[string]string{}
+	for k, v := range labels {
+		if strings.HasPrefix(k, DaemonSetLabelPrefix) {
+			daemonSetLabels[k] = v
+		} else {
+			otherLabels[k] = v
+		}
+	}
+	return daemonSetLabels, otherLabels
+}
+
+func (t *DaemonSetTester) ClearDaemonSetNodeLabels(c clientset.Interface) error {
+	nodeList := GetReadySchedulableNodesOrDie(c)
+	for _, node := range nodeList.Items {
+		_, err := t.SetDaemonSetNodeLabels(node.Name, map[string]string{})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (t *DaemonSetTester) SetDaemonSetNodeLabels(nodeName string, labels map[string]string) (*v1.Node, error) {
+	nodeClient := t.c.CoreV1().Nodes()
+	var newNode *v1.Node
+	var newLabels map[string]string
+	err := wait.PollImmediate(DaemonSetRetryPeriod, DaemonSetRetryTimeout, func() (bool, error) {
+		node, err := nodeClient.Get(nodeName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		// remove all labels this test is creating
+		daemonSetLabels, otherLabels := t.SeparateDaemonSetNodeLabels(node.Labels)
+		if reflect.DeepEqual(daemonSetLabels, labels) {
+			newNode = node
+			return true, nil
+		}
+		node.Labels = otherLabels
+		for k, v := range labels {
+			node.Labels[k] = v
+		}
+		newNode, err = nodeClient.Update(node)
+		if err == nil {
+			newLabels, _ = t.SeparateDaemonSetNodeLabels(newNode.Labels)
+			return true, err
+		}
+		if se, ok := err.(*apierrors.StatusError); ok && se.ErrStatus.Reason == metav1.StatusReasonConflict {
+			Logf("failed to update node due to resource version conflict")
+			return false, nil
+		}
+		return false, err
+	})
+	if err != nil {
+		return nil, err
+	} else if len(newLabels) != len(labels) {
+		return nil, fmt.Errorf("Could not set daemon set test labels as expected.")
+	}
+
+	return newNode, nil
+}
+
+func (t *DaemonSetTester) CheckRunningOnAllNodes(ds *appsv1alpha1.DaemonSet) func() (bool, error) {
+	return func() (bool, error) {
+		nodeNames := t.SchedulableNodes(ds)
+		return t.CheckDaemonPodOnNodes(ds, nodeNames)()
+	}
+}
+
+func (t *DaemonSetTester) CheckRunningOnNoNodes(ds *appsv1alpha1.DaemonSet) func() (bool, error) {
+	return t.CheckDaemonPodOnNodes(ds, make([]string, 0))
+}
+
+func (t *DaemonSetTester) SchedulableNodes(ds *appsv1alpha1.DaemonSet) []string {
+	nodeList, err := t.c.CoreV1().Nodes().List(metav1.ListOptions{})
+	ExpectNoError(err)
+	nodeNames := make([]string, 0)
+	for _, node := range nodeList.Items {
+		if !t.CanScheduleOnNode(node, ds) {
+			Logf("DaemonSet pods can't tolerate node %s with taints %+v, skip checking this node", node.Name, node.Spec.Taints)
+			continue
+		}
+		nodeNames = append(nodeNames, node.Name)
+	}
+	return nodeNames
+}
+
+func (t *DaemonSetTester) CheckDaemonPodOnNodes(ds *appsv1alpha1.DaemonSet, nodeNames []string) func() (bool, error) {
+	return func() (bool, error) {
+		podList, err := t.c.CoreV1().Pods(t.ns).List(metav1.ListOptions{})
+		if err != nil {
+			Logf("could not get the pod list: %v", err)
+			return false, nil
+		}
+		pods := podList.Items
+
+		nodesToPodCount := make(map[string]int)
+		for _, pod := range pods {
+			if !metav1.IsControlledBy(&pod, ds) {
+				continue
+			}
+			if pod.DeletionTimestamp != nil {
+				continue
+			}
+			if podutil.IsPodAvailable(&pod, ds.Spec.MinReadySeconds, metav1.Now()) {
+				nodesToPodCount[pod.Spec.NodeName] += 1
+			}
+		}
+		Logf("Number of nodes with available pods: %d", len(nodesToPodCount))
+
+		// Ensure that exactly 1 pod is running on all nodes in nodeNames.
+		for _, nodeName := range nodeNames {
+			if nodesToPodCount[nodeName] > 1 {
+				Logf("Node %s is running more than one daemon pod", nodeName)
+				return false, nil
+			}
+		}
+
+		Logf("Number of running nodes: %d, number of available pods: %d", len(nodeNames), len(nodesToPodCount))
+		// Ensure that sizes of the lists are the same. We've verified that every element of nodeNames is in
+		// nodesToPodCount, so verifying the lengths are equal ensures that there aren't pods running on any
+		// other nodes.
+		return len(nodesToPodCount) == len(nodeNames), nil
+	}
+}
+
+func (t *DaemonSetTester) WaitFailedDaemonPodDeleted(pod *v1.Pod) func() (bool, error) {
+	return func() (bool, error) {
+		if _, err := t.c.CoreV1().Pods(pod.Namespace).Get(pod.Name, metav1.GetOptions{}); err != nil {
+			if apierrors.IsNotFound(err) {
+				return true, nil
+			}
+			return false, fmt.Errorf("failed to get failed daemon pod %q: %v", pod.Name, err)
+		}
+		return false, nil
+	}
+}
+
+func (t *DaemonSetTester) CanScheduleOnNode(node v1.Node, ds *appsv1alpha1.DaemonSet) bool {
+	newPod := daemonset.NewPod(ds, node.Name)
+	nodeInfo := schedulernodeinfo.NewNodeInfo()
+	nodeInfo.SetNode(&node)
+	fit, _, err := daemonset.Predicates(newPod, nodeInfo)
+	if err != nil {
+		Failf("Can't test DaemonSet predicates for node %s: %v", node.Name, err)
+		return false
+	}
+	return fit
+}
+
+func (t *DaemonSetTester) ListDaemonPods(label map[string]string) (*v1.PodList, error) {
+	selector := labels.Set(label).AsSelector()
+	options := metav1.ListOptions{LabelSelector: selector.String()}
+	return t.c.CoreV1().Pods(t.ns).List(options)
+}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

Optimize manage function when synchronize daemonsets.  In manage phase, daemonset controller figures out which nodes should run daemonset pods but not yet running and  which should not run but current running one. And then upgrades limited number of replicas according to partition number configured in RollingUpdate field.

However, current implementation does not work when is-first-deploy label is added to the daemonset. We found that when the label `is-first-deploy` is set to true, daemonset controller creates all new replicas in a batch no matter what the partition is; And if this label is set to false, daemonset controller deletes all old replicas once we change the node affinity or toleration in pod template spec.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

Some conformance tests for daemonset controller has been added in this PR.

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


