### PR TITLE
Delete By Deletion Cost

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,8 @@ require (
 	github.com/go-bindata/go-bindata v3.1.2+incompatible // indirect
 	github.com/go-openapi/spec v0.19.2
 	github.com/gogo/googleapis v1.4.0 // indirect
+	github.com/gogo/protobuf v1.3.1
+	github.com/google/gofuzz v1.0.0
 	github.com/gorilla/mux v1.7.3
 	github.com/onsi/ginkgo v1.12.1
 	github.com/onsi/gomega v1.10.1

--- a/go.mod
+++ b/go.mod
@@ -17,8 +17,6 @@ require (
 	github.com/go-bindata/go-bindata v3.1.2+incompatible // indirect
 	github.com/go-openapi/spec v0.19.2
 	github.com/gogo/googleapis v1.4.0 // indirect
-	github.com/gogo/protobuf v1.3.1
-	github.com/google/gofuzz v1.0.0
 	github.com/gorilla/mux v1.7.3
 	github.com/onsi/ginkgo v1.12.1
 	github.com/onsi/gomega v1.10.1

--- a/pkg/controller/cloneset/sync/cloneset_sync_utils.go
+++ b/pkg/controller/cloneset/sync/cloneset_sync_utils.go
@@ -17,6 +17,7 @@ limitations under the License.
 package sync
 
 import (
+	"fmt"
 	appspub "github.com/openkruise/kruise/apis/apps/pub"
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
 	clonesetcore "github.com/openkruise/kruise/pkg/controller/cloneset/core"
@@ -26,10 +27,14 @@ import (
 	utilfeature "github.com/openkruise/kruise/pkg/util/feature"
 	"github.com/openkruise/kruise/pkg/util/lifecycle"
 	"github.com/openkruise/kruise/pkg/util/specifieddelete"
+
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	intstrutil "k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/klog"
+	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/utils/integer"
+	"strconv"
 )
 
 type expectationDiffs struct {
@@ -215,4 +220,130 @@ func isPodReady(coreControl clonesetcore.Control, pod *v1.Pod, minReadySeconds i
 		return false
 	}
 	return coreControl.IsPodUpdateReady(pod, minReadySeconds)
+}
+
+// ActivePodsWithDeletionCost type allows custom sorting of pods so a controller can pick the best ones to delete.
+type ActivePodsWithDeletionCost []*v1.Pod
+
+const (
+	// PodRunning and ready
+	ReceiveTraffic = 21
+	// PodDeletionCost can be used to set to an int32 that represent the cost of deleting
+	// a pod compared to other pods belonging to the same ReplicaSet. Pods with lower
+	// deletion cost are preferred to be deleted before pods with higher deletion cost.
+	// Note that this is honored on a best-effort basis, and so it does not offer guarantees on
+	// pod deletion order.
+	// The implicit deletion cost for pods that don't set the annotation is 0, negative values are permitted.
+	//
+	// This annotation is beta-level and is only honored when PodDeletionCost feature is enabled.
+	PodDeletionCost = "controller.kubernetes.io/pod-deletion-cost"
+)
+
+func (s ActivePodsWithDeletionCost) Len() int      { return len(s) }
+func (s ActivePodsWithDeletionCost) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+
+func (s ActivePodsWithDeletionCost) Less(i, j int) bool {
+	// 1. Unassigned < assigned
+	// If only one of the pods is unassigned, the unassigned one is smaller
+	if s[i].Spec.NodeName != s[j].Spec.NodeName && (len(s[i].Spec.NodeName) == 0 || len(s[j].Spec.NodeName) == 0) {
+		return len(s[i].Spec.NodeName) == 0
+	}
+	// 2.Score according to the rules:
+	// PodPending: 0, PodUnknown: 10, PodRunning: 20 ， Not ready: 0, ready: 1
+	m := map[v1.PodPhase]int{v1.PodPending: 0, v1.PodUnknown: 10, v1.PodRunning: 20}
+
+	iScore := m[s[i].Status.Phase] + btoi(podutil.IsPodReady(s[i]))
+	jScore := m[s[j].Status.Phase] + btoi(podutil.IsPodReady(s[j]))
+
+	// 3. not receives traffic < receives traffic  (a score of 21 means receiving traffic)
+	// If a pod receives traffic but one is not, the not receives traffic one is smaller
+	if iScore != jScore && (iScore == ReceiveTraffic || jScore == ReceiveTraffic) {
+		return iScore < jScore
+	}
+	// 4. higher pod-deletion-cost < lower pod-deletion cost
+	pi, _ := getDeletionCostFromPodAnnotations(s[i].Annotations)
+	pj, _ := getDeletionCostFromPodAnnotations(s[j].Annotations)
+	if pi != pj {
+		return pi < pj
+	}
+	// 5. Compare scores
+	if iScore != jScore {
+		return iScore < jScore
+	}
+	// 6. Been ready for empty time < less time < more time
+	// If both pods are ready, the latest ready one is smaller
+	if podutil.IsPodReady(s[i]) && podutil.IsPodReady(s[j]) && !podReadyTime(s[i]).Equal(podReadyTime(s[j])) {
+		return afterOrZero(podReadyTime(s[i]), podReadyTime(s[j]))
+	}
+	// 7. Pods with containers with higher restart counts < lower restart counts
+	if maxContainerRestarts(s[i]) != maxContainerRestarts(s[j]) {
+		return maxContainerRestarts(s[i]) > maxContainerRestarts(s[j])
+	}
+	// 8. Empty creation time pods < newer pods < older pods
+	if !s[i].CreationTimestamp.Equal(&s[j].CreationTimestamp) {
+		return afterOrZero(&s[i].CreationTimestamp, &s[j].CreationTimestamp)
+	}
+	return false
+}
+
+func btoi(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}
+
+// afterOrZero checks if time t1 is after time t2; if one of them
+// is zero, the zero time is seen as after non-zero time.
+func afterOrZero(t1, t2 *metav1.Time) bool {
+	if t1.Time.IsZero() || t2.Time.IsZero() {
+		return t1.Time.IsZero()
+	}
+	return t1.After(t2.Time)
+}
+
+func podReadyTime(pod *v1.Pod) *metav1.Time {
+	if podutil.IsPodReady(pod) {
+		for _, c := range pod.Status.Conditions {
+			// we only care about pod ready conditions
+			if c.Type == v1.PodReady && c.Status == v1.ConditionTrue {
+				return &c.LastTransitionTime
+			}
+		}
+	}
+	return &metav1.Time{}
+}
+
+func maxContainerRestarts(pod *v1.Pod) int {
+	maxRestarts := 0
+	for _, c := range pod.Status.ContainerStatuses {
+		maxRestarts = integer.IntMax(maxRestarts, int(c.RestartCount))
+	}
+	return maxRestarts
+}
+
+// getDeletionCostFromPodAnnotations returns the integer value of pod-deletion-cost. Returns 0
+// if not set or the value is invalid.
+func getDeletionCostFromPodAnnotations(annotations map[string]string) (int32, error) {
+	if value, exist := annotations[PodDeletionCost]; exist {
+		// values that start with plus sign (e.g, "+10") or leading zeros (e.g., "008") are not valid.
+		if !validFirstDigit(value) {
+			return 0, fmt.Errorf("invalid value %q", value)
+		}
+
+		i, err := strconv.ParseInt(value, 10, 32)
+		if err != nil {
+			// make sure we default to 0 on error.
+			return 0, err
+		}
+		return int32(i), nil
+	}
+	return 0, nil
+}
+
+func validFirstDigit(str string) bool {
+	if len(str) == 0 {
+		return false
+	}
+	return str[0] == '-' || (str[0] == '0' && str == "0") || (str[0] >= '1' && str[0] <= '9')
 }

--- a/pkg/controller/cloneset/sync/cloneset_sync_utils.go
+++ b/pkg/controller/cloneset/sync/cloneset_sync_utils.go
@@ -18,6 +18,7 @@ package sync
 
 import (
 	"fmt"
+
 	appspub "github.com/openkruise/kruise/apis/apps/pub"
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
 	clonesetcore "github.com/openkruise/kruise/pkg/controller/cloneset/core"
@@ -28,13 +29,14 @@ import (
 	"github.com/openkruise/kruise/pkg/util/lifecycle"
 	"github.com/openkruise/kruise/pkg/util/specifieddelete"
 
+	"strconv"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	intstrutil "k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/klog"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/utils/integer"
-	"strconv"
 )
 
 type expectationDiffs struct {
@@ -229,11 +231,6 @@ const (
 	// PodDeletionCost can be used to set to an int32 that represent the cost of deleting
 	// a pod compared to other pods belonging to the same ReplicaSet. Pods with lower
 	// deletion cost are preferred to be deleted before pods with higher deletion cost.
-	// Note that this is honored on a best-effort basis, and so it does not offer guarantees on
-	// pod deletion order.
-	// The implicit deletion cost for pods that don't set the annotation is 0, negative values are permitted.
-	//
-	// This annotation is beta-level and is only honored when PodDeletionCost feature is enabled.
 	PodDeletionCost = "controller.kubernetes.io/pod-deletion-cost"
 )
 

--- a/pkg/controller/cloneset/sync/cloneset_sync_utils_test.go
+++ b/pkg/controller/cloneset/sync/cloneset_sync_utils_test.go
@@ -604,3 +604,87 @@ func createTestPod(revisionHash string, lifecycleState appspub.LifecycleStateTyp
 	}
 	return pod
 }
+
+func TestSortingActivePodsWithDeletionCost(t *testing.T) {
+	now := metav1.Now()
+	then := metav1.Time{Time: now.AddDate(0, -1, 0)}
+	zeroTime := metav1.Time{}
+	pod := func(podName, nodeName string, phase v1.PodPhase, ready bool, restarts int32, readySince metav1.Time, created metav1.Time, annotations map[string]string) *v1.Pod {
+		var conditions []v1.PodCondition
+		var containerStatuses []v1.ContainerStatus
+		if ready {
+			conditions = []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionTrue, LastTransitionTime: readySince}}
+			containerStatuses = []v1.ContainerStatus{{RestartCount: restarts}}
+		}
+		return &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				CreationTimestamp: created,
+				Name:              podName,
+				Annotations:       annotations,
+			},
+			Spec: v1.PodSpec{NodeName: nodeName},
+			Status: v1.PodStatus{
+				Conditions:        conditions,
+				ContainerStatuses: containerStatuses,
+				Phase:             phase,
+			},
+		}
+	}
+	var (
+		unscheduledPod                      = pod("unscheduled", "", v1.PodPending, false, 0, zeroTime, zeroTime, nil)
+		scheduledPendingPod                 = pod("pending", "node", v1.PodPending, false, 0, zeroTime, zeroTime, nil)
+		unknownPhasePod                     = pod("unknown-phase", "node", v1.PodUnknown, false, 0, zeroTime, zeroTime, nil)
+		runningNotReadyPod                  = pod("not-ready", "node", v1.PodRunning, false, 0, zeroTime, zeroTime, nil)
+		runningReadyNoLastTransitionTimePod = pod("ready-no-last-transition-time", "node", v1.PodRunning, true, 0, zeroTime, zeroTime, nil)
+		runningReadyNow                     = pod("ready-now", "node", v1.PodRunning, true, 0, now, now, nil)
+		runningReadyThen                    = pod("ready-then", "node", v1.PodRunning, true, 0, then, then, nil)
+		runningReadyNowHighRestarts         = pod("ready-high-restarts", "node", v1.PodRunning, true, 9001, now, now, nil)
+		runningReadyNowCreatedThen          = pod("ready-now-created-then", "node", v1.PodRunning, true, 0, now, then, nil)
+		lowPodDeletionCost                  = pod("low-deletion-cost", "node", v1.PodRunning, true, 0, now, then, map[string]string{PodDeletionCost: "10"})
+		highPodDeletionCost                 = pod("high-deletion-cost", "node", v1.PodRunning, true, 0, now, then, map[string]string{PodDeletionCost: "100"})
+	)
+	equalityTests := []*v1.Pod{
+		unscheduledPod,
+		scheduledPendingPod,
+		unknownPhasePod,
+		runningNotReadyPod,
+		runningReadyNowCreatedThen,
+		runningReadyNow,
+		runningReadyThen,
+		runningReadyNowHighRestarts,
+		runningReadyNowCreatedThen,
+	}
+	for _, pod := range equalityTests {
+		podsWithDeletionCost := ActivePodsWithDeletionCost([]*v1.Pod{pod, pod})
+		if podsWithDeletionCost.Less(0, 1) || podsWithDeletionCost.Less(1, 0) {
+			t.Errorf("expected pod %q not to be less than than itself", pod.Name)
+		}
+	}
+	type podWithDeletionCost *v1.Pod
+	inequalityTests := []struct {
+		lesser, greater podWithDeletionCost
+	}{
+		{lesser: podWithDeletionCost(unscheduledPod), greater: podWithDeletionCost(scheduledPendingPod)},
+		{lesser: podWithDeletionCost(unscheduledPod), greater: podWithDeletionCost(scheduledPendingPod)},
+		{lesser: podWithDeletionCost(scheduledPendingPod), greater: podWithDeletionCost(unknownPhasePod)},
+		{lesser: podWithDeletionCost(unknownPhasePod), greater: podWithDeletionCost(runningNotReadyPod)},
+		{lesser: podWithDeletionCost(runningNotReadyPod), greater: podWithDeletionCost(runningReadyNoLastTransitionTimePod)},
+		{lesser: podWithDeletionCost(runningReadyNoLastTransitionTimePod), greater: podWithDeletionCost(runningReadyNow)},
+		{lesser: podWithDeletionCost(runningReadyNow), greater: podWithDeletionCost(runningReadyThen)},
+		{lesser: podWithDeletionCost(runningReadyNowHighRestarts), greater: podWithDeletionCost(runningReadyNow)},
+		{lesser: podWithDeletionCost(runningReadyNow), greater: podWithDeletionCost(runningReadyNowCreatedThen)},
+		{lesser: podWithDeletionCost(lowPodDeletionCost), greater: podWithDeletionCost(highPodDeletionCost)},
+	}
+	for i, test := range inequalityTests {
+		t.Run(fmt.Sprintf("test%d", i), func(t *testing.T) {
+
+			podsWithDeletionCost := ActivePodsWithDeletionCost([]*v1.Pod{test.lesser, test.greater})
+			if !podsWithDeletionCost.Less(0, 1) {
+				t.Errorf("expected pod %q to be less than %q", podsWithDeletionCost[0].Name, podsWithDeletionCost[1].Name)
+			}
+			if podsWithDeletionCost.Less(1, 0) {
+				t.Errorf("expected pod %q not to be less than %v", podsWithDeletionCost[1].Name, podsWithDeletionCost[0].Name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Ⅰ. Describe what this PR does
Add the function for cloneset as deleting pod based on pod-deletion-cost

Ⅱ. Does this pull request fix one issue?
fixes #518

Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.
pkg/controller/cloneset/sync/cloneset_sync_utils_test.go:608
TestSortingActivePodsWithDeletionCost

Ⅳ. Describe how to verify it
Deploy multiple pod by cloneset firstly, then set section of controller.kubernetes.io/pod-deletion-cost. In the end, scale down cloneset to verify whether the scaling-down sort of pod meet expection

Ⅴ. Special notes for reviews

