### PR TITLE
imagePullJob for advanced stateful set

### DIFF
--- a/pkg/controller/cloneset/cloneset_controller.go
+++ b/pkg/controller/cloneset/cloneset_controller.go
@@ -35,7 +35,7 @@ import (
 	utilfeature "github.com/openkruise/kruise/pkg/util/feature"
 	"github.com/openkruise/kruise/pkg/util/fieldindex"
 	historyutil "github.com/openkruise/kruise/pkg/util/history"
-	utilimagejob "github.com/openkruise/kruise/pkg/util/imagejob"
+	imagejobutilfunc "github.com/openkruise/kruise/pkg/util/imagejob/utilfunction"
 	"github.com/openkruise/kruise/pkg/util/ratelimiter"
 	"github.com/openkruise/kruise/pkg/util/refmanager"
 	apps "k8s.io/api/apps/v1"
@@ -308,7 +308,7 @@ func (r *ReconcileCloneSet) doReconcile(request reconcile.Request) (res reconcil
 			}
 		} else {
 			// delete ImagePullJobs if revisions have been consistent
-			if err := utilimagejob.DeleteJobsForWorkload(r.Client, instance); err != nil {
+			if err := imagejobutilfunc.DeleteJobsForWorkload(r.Client, instance); err != nil {
 				klog.Errorf("Failed to delete imagepulljobs for %s: %v", request, err)
 			}
 		}

--- a/pkg/controller/cloneset/cloneset_predownload_image.go
+++ b/pkg/controller/cloneset/cloneset_predownload_image.go
@@ -23,7 +23,7 @@ import (
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
 	clonesetcore "github.com/openkruise/kruise/pkg/controller/cloneset/core"
 	clonesetutils "github.com/openkruise/kruise/pkg/controller/cloneset/utils"
-	utilimagejob "github.com/openkruise/kruise/pkg/util/imagejob"
+	imagejobutilfunc "github.com/openkruise/kruise/pkg/util/imagejob/utilfunction"
 	"github.com/openkruise/kruise/pkg/util/inplaceupdate"
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -108,7 +108,7 @@ func (r *ReconcileCloneSet) createImagePullJobsForInPlaceUpdate(cs *appsv1alpha1
 	for name, image := range containerImages {
 		// job name is revision name + container name, it can not be more than 255 characters
 		jobName := fmt.Sprintf("%s-%s", updateRevision.Name, name)
-		err := utilimagejob.CreateJobForWorkload(r.Client, cs, jobName, image, labelMap, *selector, pullSecrets)
+		err := imagejobutilfunc.CreateJobForWorkload(r.Client, cs, clonesetutils.ControllerKind, jobName, image, labelMap, *selector, pullSecrets)
 		if err != nil {
 			if !errors.IsAlreadyExists(err) {
 				klog.Errorf("CloneSet %s/%s failed to create ImagePullJob %s: %v", cs.Namespace, cs.Name, jobName, err)

--- a/pkg/controller/statefulset/statefulset_controller_test.go
+++ b/pkg/controller/statefulset/statefulset_controller_test.go
@@ -49,12 +49,10 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/cache"
-	toolscache "k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog"
 	"k8s.io/kubernetes/pkg/controller"
-	kubecontroller "k8s.io/kubernetes/pkg/controller"
 	"k8s.io/kubernetes/pkg/controller/history"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -800,7 +798,7 @@ func NewStatefulSetController(
 				history.NewHistory(kubeClient, revInformer.Lister()),
 				recorder,
 			),
-			podControl: kubecontroller.RealPodControl{KubeClient: kubeClient, Recorder: recorder},
+			podControl: controller.RealPodControl{KubeClient: kubeClient, Recorder: recorder},
 			podLister:  podInformer.Lister(),
 			setLister:  setInformer.Lister(),
 		},
@@ -847,7 +845,7 @@ func (ssc *StatefulSetController) Run(workers int, stopCh <-chan struct{}) {
 	klog.Infof("Starting stateful set controller")
 	defer klog.Infof("Shutting down statefulset controller")
 
-	if !toolscache.WaitForNamedCacheSync("stateful set", stopCh, ssc.podListerSynced, ssc.setListerSynced, ssc.pvcListerSynced, ssc.revListerSynced) {
+	if !cache.WaitForNamedCacheSync("stateful set", stopCh, ssc.podListerSynced, ssc.setListerSynced, ssc.pvcListerSynced, ssc.revListerSynced) {
 		return
 	}
 

--- a/pkg/controller/statefulset/statefulset_predownload_image.go
+++ b/pkg/controller/statefulset/statefulset_predownload_image.go
@@ -1,0 +1,175 @@
+/*
+Copyright 2021 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package statefulset
+
+import (
+	"context"
+	"fmt"
+
+	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
+	appsv1beta1 "github.com/openkruise/kruise/apis/apps/v1beta1"
+	"github.com/openkruise/kruise/pkg/util/expectations"
+	imagejobutilfunc "github.com/openkruise/kruise/pkg/util/imagejob/utilfunction"
+	"github.com/openkruise/kruise/pkg/util/inplaceupdate"
+	"github.com/openkruise/kruise/pkg/util/revisionadapter"
+	apps "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	intstrutil "k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/klog"
+	"k8s.io/kubernetes/pkg/controller/history"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func (dss *defaultStatefulSetControl) createImagePullJobsForInPlaceUpdate(sts *appsv1beta1.StatefulSet, currentRevision, updateRevision *apps.ControllerRevision) error {
+	if _, ok := updateRevision.Labels[appsv1alpha1.ImagePreDownloadCreatedKey]; ok {
+		return nil
+	} else if _, ok := updateRevision.Labels[appsv1alpha1.ImagePreDownloadIgnoredKey]; ok {
+		return nil
+	}
+
+	// ignore if update type is ReCreate
+	if string(sts.Spec.UpdateStrategy.Type) == string(appsv1beta1.RecreatePodUpdateStrategyType) {
+		klog.V(4).Infof("Statefulset %s/%s skipped to create ImagePullJob for update type is %s",
+			sts.Namespace, sts.Name, sts.Spec.UpdateStrategy.Type)
+		return dss.patchControllerRevisionLabels(updateRevision, appsv1alpha1.ImagePreDownloadIgnoredKey, "true")
+	}
+
+	// ignore if replicas <= minimumReplicasToPreDownloadImage
+	if *sts.Spec.Replicas <= minimumReplicasToPreDownloadImage {
+		klog.V(4).Infof("Statefulset %s/%s skipped to create ImagePullJob for replicas %d <= %d",
+			sts.Namespace, sts.Name, *sts.Spec.Replicas, minimumReplicasToPreDownloadImage)
+		return dss.patchControllerRevisionLabels(updateRevision, appsv1alpha1.ImagePreDownloadIgnoredKey, "true")
+	}
+
+	// ignore if all Pods update in one batch
+	var partition, maxUnavailable int
+	if sts.Spec.UpdateStrategy.RollingUpdate.Partition != nil {
+		// partition, _ = intstrutil.GetValueFromIntOrPercent(sts.Spec.UpdateStrategy.Partition, int(*sts.Spec.Replicas), true)
+		partition = int(*sts.Spec.UpdateStrategy.RollingUpdate.Partition)
+	}
+	maxUnavailable, _ = intstrutil.GetValueFromIntOrPercent(
+		intstrutil.ValueOrDefault(sts.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable, intstrutil.FromString("1")), int(*sts.Spec.Replicas), false)
+	if partition == 0 && maxUnavailable >= int(*sts.Spec.Replicas) {
+		klog.V(4).Infof("Statefulset %s/%s skipped to create ImagePullJob for all Pods update in one batch, replicas=%d, partition=%d, maxUnavailable=%d",
+			sts.Namespace, sts.Name, *sts.Spec.Replicas, partition, maxUnavailable)
+		return dss.patchControllerRevisionLabels(updateRevision, appsv1alpha1.ImagePreDownloadIgnoredKey, "true")
+	}
+
+	// opt is update option, this sectoin is to get update option
+	opts := &inplaceupdate.UpdateOptions{}
+	if sts.Spec.UpdateStrategy.RollingUpdate.InPlaceUpdateStrategy != nil {
+		opts.GracePeriodSeconds = sts.Spec.UpdateStrategy.RollingUpdate.InPlaceUpdateStrategy.GracePeriodSeconds
+	}
+
+	// ignore if this revision can not update in-place
+	inplaceControl := inplaceupdate.New(sigsruntimeClient, revisionadapter.NewDefaultImpl())
+	if !inplaceControl.CanUpdateInPlace(currentRevision, updateRevision, opts) {
+		klog.V(4).Infof("Statefulset %s/%s skipped to create ImagePullJob for %s -> %s can not update in-place",
+			sts.Namespace, sts.Name, currentRevision.Name, updateRevision.Name)
+		return dss.patchControllerRevisionLabels(updateRevision, appsv1alpha1.ImagePreDownloadIgnoredKey, "true")
+	}
+
+	// start to create jobs
+	var pullSecrets []string
+	for _, s := range sts.Spec.Template.Spec.ImagePullSecrets {
+		pullSecrets = append(pullSecrets, s.Name)
+	}
+
+	selector := sts.Spec.Selector.DeepCopy()
+	selector.MatchExpressions = append(selector.MatchExpressions, metav1.LabelSelectorRequirement{
+		Key:      apps.ControllerRevisionHashLabelKey,
+		Operator: metav1.LabelSelectorOpNotIn,
+		Values:   []string{updateRevision.Name, updateRevision.Labels[history.ControllerRevisionHashLabel]},
+	})
+
+	// As statefulset is the job's owner, we have the convention that all resources owned by statefulset
+	// have to match the selector of statefulset, such as pod, pvc and controllerrevision.
+	// So we had better put the labels into jobs.
+	labelMap := make(map[string]string)
+	for k, v := range sts.Spec.Template.Labels {
+		labelMap[k] = v
+	}
+	labelMap[history.ControllerRevisionHashLabel] = updateRevision.Labels[history.ControllerRevisionHashLabel]
+
+	containerImages := diffImagesBetweenRevisions(currentRevision, updateRevision)
+	klog.V(3).Infof("Statefulset %s/%s begin to create ImagePullJobs for revision %s -> %s: %v",
+		sts.Namespace, sts.Name, currentRevision.Name, updateRevision.Name, containerImages)
+	for name, image := range containerImages {
+		// job name is revision name + container name, it can not be more than 255 characters
+		jobName := fmt.Sprintf("%s-%s", updateRevision.Name, name)
+		err := imagejobutilfunc.CreateJobForWorkload(sigsruntimeClient, sts, controllerKind, jobName, image, labelMap, *selector, pullSecrets)
+		if err != nil {
+			if !errors.IsAlreadyExists(err) {
+				klog.Errorf("Statefulset %s/%s failed to create ImagePullJob %s: %v", sts.Namespace, sts.Name, jobName, err)
+				dss.recorder.Eventf(sts, v1.EventTypeNormal, "FailedCreateImagePullJob", "failed to create ImagePullJob %s: %v", jobName, err)
+			}
+			continue
+		}
+		klog.V(3).Infof("Statefulset %s/%s created ImagePullJob %s for image: %s", sts.Namespace, sts.Name, jobName, image)
+		dss.recorder.Eventf(sts, v1.EventTypeNormal, "CreatedImagePullJob", "created ImagePullJob %s for image: %s", jobName, image)
+	}
+
+	return dss.patchControllerRevisionLabels(updateRevision, appsv1alpha1.ImagePreDownloadCreatedKey, "true")
+}
+
+func (dss *defaultStatefulSetControl) patchControllerRevisionLabels(revision *apps.ControllerRevision, key, value string) error {
+	oldRevision := revision.ResourceVersion
+	body := fmt.Sprintf(`{"metadata":{"labels":{"%s":"%s"}}}`, key, value)
+	if err := sigsruntimeClient.Patch(context.TODO(), revision, client.RawPatch(types.StrategicMergePatchType, []byte(body))); err != nil {
+		return err
+	}
+	if oldRevision != revision.ResourceVersion {
+		expectations.NewResourceVersionExpectation()
+	}
+	return nil
+}
+
+func diffImagesBetweenRevisions(oldRevision, newRevision *apps.ControllerRevision) map[string]string {
+	oldTemp, err := inplaceupdate.GetTemplateFromRevision(oldRevision)
+	if err != nil {
+		return nil
+	}
+	newTemp, err := inplaceupdate.GetTemplateFromRevision(newRevision)
+	if err != nil {
+		return nil
+	}
+
+	containerImages := make(map[string]string)
+	for i := range newTemp.Spec.Containers {
+		name := newTemp.Spec.Containers[i].Name
+		newImage := newTemp.Spec.Containers[i].Image
+
+		var found bool
+		for j := range oldTemp.Spec.Containers {
+			if oldTemp.Spec.Containers[j].Name != name {
+				continue
+			}
+			if oldTemp.Spec.Containers[j].Image != newImage {
+				containerImages[name] = newImage
+			}
+			found = true
+			break
+		}
+		if !found {
+			containerImages[name] = newImage
+		}
+	}
+	return containerImages
+}

--- a/pkg/util/imagejob/utilfunction/imagejob_util.go
+++ b/pkg/util/imagejob/utilfunction/imagejob_util.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package imagejob
+package utilfunction
 
 import (
 	"context"
@@ -22,13 +22,13 @@ import (
 
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	utilpointer "k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func CreateJobForWorkload(c client.Client, owner metav1.Object, name, image string, labels map[string]string, podSelector metav1.LabelSelector, pullSecrets []string) error {
+func CreateJobForWorkload(c client.Client, owner metav1.Object, gvk schema.GroupVersionKind, name, image string, labels map[string]string, podSelector metav1.LabelSelector, pullSecrets []string) error {
 	var pullTimeoutSeconds int32 = 300
 	if str, ok := owner.GetAnnotations()[appsv1alpha1.ImagePreDownloadTimeoutSecondsKey]; ok {
 		if i, err := strconv.Atoi(str); err == nil {
@@ -47,7 +47,7 @@ func CreateJobForWorkload(c client.Client, owner metav1.Object, name, image stri
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:       owner.GetNamespace(),
 			Name:            name,
-			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(owner, owner.(runtime.Object).GetObjectKind().GroupVersionKind())},
+			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(owner, gvk)},
 			Labels:          labels,
 		},
 		Spec: appsv1alpha1.ImagePullJobSpec{


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
This PR add imagePullJob on advanced stateful set

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #1.  in pkg/controller/statefulset/statefulset_controller.go merge apps "k8s.io/api/apps/v1", because it is duplicate import
fixes #1.  in pkg/controller/statefulset/statefulset_controller.go merge apps 'toolscache "k8s.io/client-go/tools/cache"', because it is duplicate import


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.
None
imagePullJob is an already exist functionality

### Ⅳ. Describe how to verify it
Do a imagepull request for advanced stateful set

### Ⅴ. Special notes for reviews
none

