### PR TITLE
Promoe webhook performance

### DIFF
--- a/pkg/webhook/advancedcronjob/mutating/advancedcronjob_create_update_handler.go
+++ b/pkg/webhook/advancedcronjob/mutating/advancedcronjob_create_update_handler.go
@@ -19,7 +19,9 @@ package mutating
 import (
 	"context"
 	"encoding/json"
+	"k8s.io/apimachinery/pkg/runtime"
 	"net/http"
+	"reflect"
 
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -53,11 +55,15 @@ func (h *AdvancedCronJobCreateUpdateHandler) Handle(ctx context.Context, req adm
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
+	var copy runtime.Object = obj.DeepCopy()
 	err = h.mutatingAdvancedCronJobFn(ctx, obj)
 	if err != nil {
 		return admission.Errored(http.StatusInternalServerError, err)
 	}
 
+	if reflect.DeepEqual(obj, copy) {
+		return admission.Allowed("")
+	}
 	marshalled, err := json.Marshal(obj)
 	if err != nil {
 		return admission.Errored(http.StatusInternalServerError, err)

--- a/pkg/webhook/cloneset/mutating/cloneset_create_update_handler.go
+++ b/pkg/webhook/cloneset/mutating/cloneset_create_update_handler.go
@@ -20,6 +20,9 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"reflect"
+
+	"k8s.io/apimachinery/pkg/runtime"
 
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
 	"github.com/openkruise/kruise/pkg/util"
@@ -50,8 +53,11 @@ func (h *CloneSetCreateUpdateHandler) Handle(ctx context.Context, req admission.
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
+	var copy runtime.Object = obj.DeepCopy()
 	appsv1alpha1.SetDefaultsCloneSet(obj)
-
+	if reflect.DeepEqual(obj, copy) {
+		return admission.Allowed("")
+	}
 	marshalled, err := json.Marshal(obj)
 	if err != nil {
 		return admission.Errored(http.StatusInternalServerError, err)

--- a/pkg/webhook/containerrecreaterequest/mutating/crr_mutating_handler.go
+++ b/pkg/webhook/containerrecreaterequest/mutating/crr_mutating_handler.go
@@ -23,6 +23,8 @@ import (
 	"net/http"
 	"reflect"
 
+	"k8s.io/apimachinery/pkg/runtime"
+
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
 	"github.com/openkruise/kruise/pkg/features"
 	"github.com/openkruise/kruise/pkg/util"
@@ -59,6 +61,7 @@ func (h *ContainerRecreateRequestHandler) Handle(ctx context.Context, req admiss
 	if err != nil {
 		return admission.Errored(http.StatusBadRequest, err)
 	}
+	var copy runtime.Object = obj.DeepCopy()
 
 	if req.AdmissionRequest.Operation == admissionv1beta1.Update {
 		oldObj := &appsv1alpha1.ContainerRecreateRequest{}
@@ -136,6 +139,9 @@ func (h *ContainerRecreateRequestHandler) Handle(ctx context.Context, req admiss
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
+	if reflect.DeepEqual(obj, copy) {
+		return admission.Allowed("")
+	}
 	marshalled, err := json.Marshal(obj)
 	if err != nil {
 		return admission.Errored(http.StatusInternalServerError, err)

--- a/pkg/webhook/daemonset/mutating/daemonset_create_update_handler.go
+++ b/pkg/webhook/daemonset/mutating/daemonset_create_update_handler.go
@@ -19,7 +19,9 @@ package mutating
 import (
 	"context"
 	"encoding/json"
+	"k8s.io/apimachinery/pkg/runtime"
 	"net/http"
+	"reflect"
 
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
 	"github.com/openkruise/kruise/pkg/util"
@@ -49,9 +51,11 @@ func (h *DaemonSetCreateUpdateHandler) Handle(ctx context.Context, req admission
 	if err != nil {
 		return admission.Errored(http.StatusBadRequest, err)
 	}
-
+	var copy runtime.Object = obj.DeepCopy()
 	appsv1alpha1.SetDefaultsDaemonSet(obj)
-
+	if reflect.DeepEqual(obj, copy) {
+		return admission.Allowed("")
+	}
 	marshalled, err := json.Marshal(obj)
 	if err != nil {
 		return admission.Errored(http.StatusInternalServerError, err)

--- a/pkg/webhook/imagepulljob/mutating/imagepulljob_create_update_handler.go
+++ b/pkg/webhook/imagepulljob/mutating/imagepulljob_create_update_handler.go
@@ -20,6 +20,9 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"reflect"
+
+	"k8s.io/apimachinery/pkg/runtime"
 
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
 	"github.com/openkruise/kruise/pkg/util"
@@ -42,9 +45,11 @@ func (h *ImagePullJobCreateUpdateHandler) Handle(ctx context.Context, req admiss
 	if err != nil {
 		return admission.Errored(http.StatusBadRequest, err)
 	}
-
+	var copy runtime.Object = obj.DeepCopy()
 	appsv1alpha1.SetDefaultsImagePullJob(obj)
-
+	if reflect.DeepEqual(obj, copy) {
+		return admission.Allowed("")
+	}
 	marshalled, err := json.Marshal(obj)
 	if err != nil {
 		return admission.Errored(http.StatusInternalServerError, err)

--- a/pkg/webhook/uniteddeployment/mutating/uniteddeployment_create_update_handler.go
+++ b/pkg/webhook/uniteddeployment/mutating/uniteddeployment_create_update_handler.go
@@ -19,7 +19,9 @@ package mutating
 import (
 	"context"
 	"encoding/json"
+	"k8s.io/apimachinery/pkg/runtime"
 	"net/http"
+	"reflect"
 
 	"github.com/openkruise/kruise/pkg/util"
 	"k8s.io/klog"
@@ -50,10 +52,12 @@ func (h *UnitedDeploymentCreateUpdateHandler) Handle(ctx context.Context, req ad
 	if err != nil {
 		return admission.Errored(http.StatusBadRequest, err)
 	}
-
+	var copy runtime.Object = obj.DeepCopy()
 	appsv1alpha1.SetDefaultsUnitedDeployment(obj)
 	obj.Status = appsv1alpha1.UnitedDeploymentStatus{}
-
+	if reflect.DeepEqual(obj, copy) {
+		return admission.Allowed("")
+	}
 	marshalled, err := json.Marshal(obj)
 	if err != nil {
 		return admission.Errored(http.StatusInternalServerError, err)


### PR DESCRIPTION
Signed-off-by: JunjunLi <junjunli666@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Promoe webhook performance

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it

here is test case:

```
func LocalDeepEqual(original, current interface{}) {
	reflect.DeepEqual(original, current)
}

func PatchResponseFromRaw(original, current []byte) {
	admission.PatchResponseFromRaw(original, current)
}


func BenchmarkLocalDeepEqual(be *testing.B) {
	origin := []byte(a)
	current := []byte(b)

	for i := 0; i < be.N; i++ {
		LocalDeepEqual(origin, current)
	}
}

func BenchmarkPatchResponseFromRaw(be *testing.B) {
	origin := []byte(a)
	current := []byte(b)

	for i := 0; i < be.N; i++ {
		PatchResponseFromRaw(origin, current)
	}
}
```

here is result
```
zhoushua@B-H3KJLVDL-0114 util % go test  --bench=. --count=6
goos: darwin
goarch: amd64
pkg: github.com/openkruise/kruise/pkg/webhook/util
BenchmarkLocalDeepEqual-8                6835633               176 ns/op
BenchmarkLocalDeepEqual-8                6942193               176 ns/op
BenchmarkLocalDeepEqual-8                6939074               173 ns/op
BenchmarkLocalDeepEqual-8                7056753               174 ns/op
BenchmarkLocalDeepEqual-8                6859546               172 ns/op
BenchmarkLocalDeepEqual-8                6977091               172 ns/op
BenchmarkPatchResponseFromRaw-8              198           5983445 ns/op
BenchmarkPatchResponseFromRaw-8              200           5968557 ns/op
BenchmarkPatchResponseFromRaw-8              194           5960386 ns/op
BenchmarkPatchResponseFromRaw-8              200           5964584 ns/op
BenchmarkPatchResponseFromRaw-8              200           5959902 ns/op
BenchmarkPatchResponseFromRaw-8              200           6003306 ns/op
PASS
ok      github.com/openkruise/kruise/pkg/webhook/util   31.190s
```

### Ⅴ. Special notes for reviews


