### PR TITLE
remove diff pods for managePreparingDelete

### DIFF
--- a/pkg/controller/cloneset/sync/cloneset_scale.go
+++ b/pkg/controller/cloneset/sync/cloneset_scale.go
@@ -62,7 +62,7 @@ func (r *realControl) Scale(
 
 	// 1. manage pods to delete and in preDelete
 	podsSpecifiedToDelete, podsInPreDelete, numToDelete := getPlannedDeletedPods(updateCS, pods)
-	if modified, err := r.managePreparingDelete(updateCS, pods, util.DiffPods(podsInPreDelete, podsSpecifiedToDelete), numToDelete); err != nil || modified {
+	if modified, err := r.managePreparingDelete(updateCS, pods, podsInPreDelete, numToDelete); err != nil || modified {
 		return modified, err
 	}
 


### PR DESCRIPTION
It has checked whether the pod is isSpecifiedDelete for the range of
podsInPreDelete in managePreparingDelete func.

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Remove diff pods for managePreparingDelete since it has checked whether the pod is isSpecifiedDelete for the range of
podsInPreDelete in managePreparingDelete func.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


