### PR TITLE
Add proposal of WorkloadSpread, a bypass scheme for elasticity and multi-domain management 

### DIFF
--- a/docs/proposals/20210628-workloadspread.md
+++ b/docs/proposals/20210628-workloadspread.md
@@ -7,7 +7,7 @@ reviewers:
   - "@furykerry"
   - "@FillZpp"
 creation-date: 2021-06-28
-last-updated: 2021-07-05
+last-updated: 2021-07-06
 status: implementable
 ---
 
@@ -53,14 +53,14 @@ spec:
         operator: In
         values:
         - zone-a
-    preferredNodeSelectorTerms:
-    - weight: 50
-      preference:
-      matchExpressions:
-      - key: topology.kubernetes.io/zone
-        operator: In
-        values:
-        - zone-c
+#   preferredNodeSelectorTerms:
+#   - weight: 50
+#     preference:
+#     matchExpressions:
+#     - key: topology.kubernetes.io/zone
+#       operator: In
+#       values:
+#       - zone-a
     maxReplicas: 3
     tolertions: []
     patch:

--- a/docs/proposals/20210628-workloadspread.md
+++ b/docs/proposals/20210628-workloadspread.md
@@ -1,0 +1,237 @@
+---
+title: WorkloadSpread
+authors:
+  - "@BoltsLei"
+
+reviewers:
+  - "@Fei-Guo"
+  - "@furykerry"
+  - "@FillZpp"
+
+creation-date: 2021-06-28 
+last-updated: 2021-06-28 
+status: implementable
+---
+
+# WorkloadSpread
+
+## Table of Contents
+
+A table of contents is helpful for quickly jumping to sections of a proposal and for highlighting
+any additional information provided beyond the standard proposal template.
+[Tools for generating](https://github.com/ekalinin/github-markdown-toc) a table of contents from markdown are available.
+
+
+## Motivation
+
+Define a CRD named WorkloadSpread, which can support configuration and management for elastic and multi-domain applications,
+even more powerful and flexible than [UnitedDeployment](https://openkruise.io/en-us/docs/uniteddeployment.html) in some ways.
+
+Not like the workload type, WorkloadSpread can be used with those stateless workloads, such as CloneSet, Deployment and ReplicaSet.
+
+So users needn't learn the usage of a new workload and how to deploy and update their application by it.
+They only have to create WorkloadSpread CRs related to their existing workloads. Everything is just great!
+
+## Proposal
+
+WorkloadSpread definition looks like this:
+
+```yaml
+apiVersion: apps.kruise.io/v1alpha1
+kind: WorkloadSpread
+metadata:
+  namespace: ...
+  name: ...
+  # ...
+spec:
+  targetRef:
+    apiVersion: apps/v1 | apps.kruise.io/v1alpha1
+    kind: Deployment | CloneSet
+    name: workload-xxx
+  subsets:
+  - name: subset-a
+    requiredNodeSelectorTerm:
+      matchExpressions:
+      - key: topology.kubernetes.io/zone
+        operator: In
+        values:
+        - zone-a
+    preferredNodeSelectorTerms:
+    - weight: 50
+      preference:
+      matchExpressions:
+      - key: topology.kubernetes.io/zone
+        operator: In
+        values:
+        - zone-b
+    maxReplicas: 3
+    tolertions: []
+    patch:
+      metadata:
+        labels:
+          xxx-specific-label: xxx
+  - name: subset-b
+    requiredNodeSelectorTerm:
+      matchExpressions:
+      - key: topology.kubernetes.io/zone
+        operator: In
+        values:
+        - zone-b
+  scheduleStrategy:
+    type: Adaptive | Fixed
+    adaptive:
+      disableSimulationSchedule: false
+      rescheduleCriticalSeconds: 30
+status:
+  observedGeneration: 12
+  subsetStatuses:
+  - name: subset-a
+    missingReplicas: 2
+    creatingPods:
+      pod-xxx: "2021-04-27T08:34:11Z"
+    deletingPods:
+      pod-yyy: "2021-04-27T08:34:11Z"
+    subsetUnscheduledStatus:
+      unschedulable: true
+      unscheduledTime: 2021-04-27T08:34:11Z
+      failedCount: 1
+  - name: subset-b
+    missingReplicas: -1
+```
+
+**spec**:
+- `targetRef`: reference to a specific workload, it supports `Deployment` in `apps` group and `CloneSet` in `apps.kruise.io` group
+- `subsets`: list of subsets which defines different topologies
+  - `name`: name of this subset
+  - `requiredNodeSelectorTerm`: the additional node selector of this subset, it will be injected into each term of `pod.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms`
+  - `preferredNodeSelectorTerms`: the additional node selector of this subset, it will be injected into each term of `pod.spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution`
+  - `tolerations`: the additional tolerations of this subset, it will be injected into `pod.spec.tolerations`
+  - `patch`: the specified strategic patch body of this subset, it will be patched to Pods that belong to this subset
+  - `maxReplicas`: the maximum number of Pods in this subset, it can be an absolute number or a percentage string. maxReplicas 
+     can be null that represents there is no replicas limits in this subset.
+- `scheduleStrategy`: strategies for schedule
+  - `type`: can be `Fixed` or `Adaptive`
+    - `Fixed` means always choose the former subset for Pods unless the subset's maxReplicas has been satisfied
+    - `Adaptive` means choose the right subset by sequence of subsets and also enough resources
+  - `adaptive`:
+    - `disableSimulationSchedule`: whether to disable the simulation schedule in webhook
+      > webhook can take a simple general predicates to check whether Pod can be scheduled into this subset, \
+        but it just considers the Node resource and cannot replace scheduler to do richer predicates practically.
+    - `rescheduleCriticalSeconds`: the critical duration that controller will trigger a Pod to reschedule to another subset.
+      > rescheduleCriticalSeconds indicates how long controller will reschedule a schedule failed Pod to the subset that has
+        redundant capacity after the subset where the Pod lives. \
+        If a Pod was scheduled failed and still in a pending status over RescheduleCriticalSeconds duration, the controller will reschedule it to the suitable subset.
+
+**status**:
+- `subsetStatuses`: statuses of subsets defined in spec
+  - `missingReplicas`: the missing number of this subset, most of the time it is (maxReplicas - the number of active Pods)
+    > missingReplicas > 0 indicates the subset is still missing MissingReplicas pods to create \
+    missingReplicas = 0 indicates the subset already has enough pods, there is no need to create \
+    missingReplicas = -1 indicates the subset's MaxReplicas not set, then there is no limit for pods number
+  - `creatingPods`: the map of Pods that just allocated to this subset by webhook
+    > creatingPods contains information about pods whose creation was processed by
+      the webhook handler but not yet been observed by the WorkloadSpread controller.
+      A pod will be in this map from the time when the webhook handler processed the
+      creation request to the time when the pod is seen by controller. \
+      The key in the map is the name of the pod and the value is the time when the webhook
+      handler process the creation request. If the real creation didn't happen and a pod is
+      still in this map, it will be removed from the list automatically by WorkloadSpread controller
+      after some time.\
+      If everything goes smooth this map should be empty for the most of the time.
+      Large number of entries in the map may indicate problems with pod creations.
+  - `deletingPods`: the map of Pods been deleted or evicted that just noticed by webhook
+    > deletingPods is similar with creatingPods and it contains information about pod deletion.
+  - `subsetUnscheduledStatus`: contains the details for the unscheduled subset.
+     - `unschedulable`: unschedulable is true indicates this Subset cannot be scheduled. The default is false.
+     - `unscheduledTime`: last time for unscheduled.
+     - `failedCount`: the number of subset was marked with unschedulable.
+
+### Requirements
+
+WorkloadSpread requires Pod webhook to inject rules into Pods and notice the deletion and eviction of Pods.
+
+So if the `PodWebhook` feature-gate is set to `false`, WorkloadSpread will also be disabled.
+
+### Implementation Details/Notes/Constraints
+
+WorkloadSpread have both webhook and controller. Controller should collaborate with webhook to maintain WorkloadSpread 
+status together. The controller is responsible for calculating the real status, and the webhook mainly counts missingReplicas 
+and records the creation or deletion entry of Pod into map.
+
+#### Replicas control
+
+##### Pod creation 
+When a Pod is creating and its workload has a related WorkloadSpread,
+webhook will check the subsetStatuses in the WorkloadSpread one by one:
+
+1. if `missingReplicas` > 0 or `missingReplicas` = -1 and this subset is not unschedulable, choose this subset temporarily \
+   (1). update `missingReplicas` -= 1 and put this pod into `creatingPods` map and try to update subsetStatus. \
+   (2). if it conflicts, get the WorkloadSpread again and go back to step (1). \
+   (3). if it succeeds, inject the rules of this subset into the Pod. 
+2. if `missingReplicas` = 0, go to the next subset
+3. if there is no available subset left, just let the Pod go
+
+##### Pod deletion 
+Also, when a Pod that belongs to a subset is deleting or evicting, webhook will put it into the `deletingPods` map in subsetStatus and update `missingReplicas` += 1.
+
+##### Update Pod Status
+When a Pod that belongs to a subset changes status phase to 'succeed' or 'failed', which means Pod has been terminated lifecycle, 
+webhook will clean it from `creatingPods` map and update `missingReplicas` -= 1.
+
+#### Reschedule strategy
+rescheduleSubset will delete some unscheduled Pods that still in pending status. Some subsets have no
+sufficient resource can lead to some Pods scheduled failed.
+
+WorkloadSpread has multiple subset, so some Pods scheduled failed should be rescheduled to other subsets.
+controller will mark the subset contains Pods scheduled failed to unscheduable status and Webhook cannot inject
+Pod into this subset by check subset's status. Controller cleans up Pods scheduled failed to trigger workload create new replicas, 
+webhook will skip unscheduable subset and chose suitable subset to inject. 
+
+The unscheduled subset can be kept for 10 minutes and then should be recovered schedulable status to schedule Pod again by controller.
+
+
+#### Deletion priority
+
+We have three types for subset's Pod deletion-cost
+1. the number of active Pods in this subset <= maxReplicas, deletion-cost = 100. indicating the priority of Pods
+   in this subset is more higher than other Pods in workload.
+2. subset's maxReplicas is nil, deletion-cost = 0. indicating the priority of Pods in this subset is more lower than
+   other subsets that have a not nil maxReplicas.
+3. the number of active Pods in this subset > maxReplicas, two class: (a) deletion-cost = -100, (b) deletion-cost = +100.
+   indicating we prefer deleting the Pod have -100 deletion-cost in this subset in order to control the instance of subset
+   meeting up the desired maxReplicas number.
+
+CloneSet has supported deletion-cost feature in the recent versions.
+
+Since Kubernetes 1.21, there is a new annotation definition on Pod:
+
+```yaml
+    controller.kubernetes.io/pod-deletion-cost: -100 / 100 / 0
+```
+
+(In 1.21, users need to enable `PodDeletionCost` feature-gate, and since 1.22 it will be enabled by default)
+
+
+### Comparison with PodTopologySpread 
+
+#### PodTopologySpread
+
+You can use topology spread constraints to control how Pods are spread across your cluster among failure-domains 
+such as regions, zones, nodes, and other user-defined topology domains. 
+This can help to achieve high availability as well as efficient resource utilization.
+  
+#### For WorkloadSpread
+1. WorkloadSpread's subset maxReplicas can be a percentage string, which defines the percentage spread in multiple topology, but PodTopologySpread
+   doesn't support this feature.
+   
+2. Only if the Pods number is equal with maxReplicas of this subset, WorkloadSpread inject Pod into the next available 
+   subset. Therefore, workload spread has an order attribution, and the order of subset influence creation and deletion order
+   
+3. For PodTopologySpread, there's no guarantee that the constraints remain satisfied when Pods are removed. 
+   For example, scaling down a Deployment may result in imbalanced Pods distribution.
+   For WorkloadSpread, controller will guarantee the workload replicas meeting up maxReplicas by deletion-cost feature. 
+   
+4. WorkloadSpread support subset change desired Pod numbers by configuring maxReplicas for elastic.
+
+### Known Limitations
+- The maxReplicas of the last subset must is null because some Pods could be scheduled failed, the last subset can be scheduled forever.

--- a/docs/proposals/20210628-workloadspread.md
+++ b/docs/proposals/20210628-workloadspread.md
@@ -253,7 +253,7 @@ To change scheduleStrategy of WorkloadSpread will keep the deletion-cost annotat
 
 Webhook selects a suitable subset to inject pod by checking whether missingReplicas of the subset > 0. However, it may have two dangerous condition to lead the new created replicas of workload can't be scheduled into the suitable subset.
 
-1.The workload scales up before the WorkloadSpread controller updates the latest CR status. It can lead the subset's missingReplicas is not newest and cause the failure spread. \
+1.The workload scales up before the WorkloadSpread controller updates the latest CR status. It can lead the subset's missingReplicas is not newest and cause the failure spread.
 
 For example:
    ```yaml
@@ -288,7 +288,7 @@ For example:
        - name: subset-b
          maxReplicas: 100 # 100 + 0
      status:
-       observedGeneration: 2
+       observedGeneration: 1 # should equal 2
        subsetsStatuses:
        - name: subset-a
          missingReplicas: 0 # should equal 100
@@ -299,7 +299,7 @@ For example:
      replicas: 300 # 200 + 100
    ```
 
-The workload scales up from 200 to 300, but the WorkloadSpread controller has not completed updating the CR status.
+The workload scales up from 200 to 300, but the WorkloadSpread controller has not completed updating the CR status by comparing observedGeneration with generation.
 #### solution:
 Before the workload controller scales up, which should check whether the missingReplicas is true.
 

--- a/docs/proposals/20210628-workloadspread.md
+++ b/docs/proposals/20210628-workloadspread.md
@@ -60,7 +60,7 @@ spec:
       - key: topology.kubernetes.io/zone
         operator: In
         values:
-        - zone-b
+        - zone-c
     maxReplicas: 3
     tolertions: []
     patch:
@@ -89,7 +89,7 @@ status:
     deletingPods:
       pod-yyy: "2021-04-27T08:34:11Z"
     subsetUnscheduledStatus:
-      unschedulable: true
+      unschedulable: false
       unscheduledTime: 2021-04-27T08:34:11Z
       failedCount: 1
   - name: subset-b
@@ -100,12 +100,11 @@ status:
 - `targetRef`: reference to a specific workload, it supports `Deployment` in `apps` group and `CloneSet` in `apps.kruise.io` group
 - `subsets`: list of subsets which defines different topologies
   - `name`: name of this subset
-  - `requiredNodeSelectorTerm`: the additional node selector of this subset, it will be injected into each term of `pod.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms`
-  - `preferredNodeSelectorTerms`: the additional node selector of this subset, it will be injected into each term of `pod.spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution`
+  - `requiredNodeSelectorTerm`: the additional node selector of this subset, it will be appended into the `pod.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms`
+  - `preferredNodeSelectorTerms`: the additional node selector of this subset, it will be appended into the `pod.spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution`
   - `tolerations`: the additional tolerations of this subset, it will be injected into `pod.spec.tolerations`
   - `patch`: the specified strategic patch body of this subset, it will be patched to Pods that belong to this subset
      > use [runtime.RawExtension](https://github.com/kubernetes/apimachinery/blob/03ac7a9ade429d715a1a46ceaa3724c18ebae54f/pkg/runtime/types.go#L94) type
-       
     ```yaml
     # patch metadata:
     patch:
@@ -118,23 +117,22 @@ status:
     patch:
       spec:
         containers:
-        - name: main                                                                                                                                                       
-          resources:                                                                                                                                                       
-            limits:                                                                                                                                                        
-              cpu: "2"                                                                                                                                                     
-              memory: 800Mi  
+        - name: main
+          resources:
+            limit:
+              cpu: "2"
+              memory: 800Mi
     ```
     ```yaml
     # patch container environments:
     patch:
       spec:
         containers:
-        - name: main                                                                                                                                                       
-          env:                                                                                                                                                             
-          - name: K8S_CONTAINER_NAME                                                                                                                                           
-            value: main  
+        - name: main
+          env:
+          - name: K8S_CONTAINER_NAME
+            value: main
     ```
-       
   - `maxReplicas`: the maximum number of Pods in this subset, it can be an absolute number or percentage string. maxReplicas can be null represents that there is no replicas limits in this subset.
 - `scheduleStrategy`: strategies for schedule
   - `type`: can be `Fixed` or `Adaptive`
@@ -147,14 +145,14 @@ status:
     - `rescheduleCriticalSeconds`: the critical duration that controller will trigger a Pod to reschedule to another subset.
       > rescheduleCriticalSeconds indicates how long controller will reschedule a schedule failed Pod to the subset that has
         redundant capacity after the subset where the Pod lives. \
-        If a Pod was scheduled failed and still in a pending status over RescheduleCriticalSeconds duration, the controller will reschedule it to the suitable subset.
+        If a Pod was scheduled failed and still in a pending status over rescheduleCriticalSeconds duration, the controller will reschedule it to the suitable subset.
 
 **status**:
 - `subsetStatuses`: statuses of subsets defined in spec
   - `missingReplicas`: the missing number of this subset, most of the time it is (maxReplicas - the number of active Pods)
-    > missingReplicas > 0 indicates the subset is still missing MissingReplicas pods to create \
-    missingReplicas = 0 indicates the subset already has enough pods, there is no need to create \
-    missingReplicas = -1 indicates the subset's MaxReplicas not set, then there is no limit for pods number
+    > missingReplicas > 0 indicates the subset is still missing `missingReplicas` pods to create. \
+    missingReplicas = 0 indicates the subset already has enough pods, and there is no need to create. \
+    missingReplicas = -1 indicates the subset's maxReplicas not set, then there is no limit for pods number.
   - `creatingPods`: the map of Pods that just allocated to this subset by webhook
     > creatingPods contains information about pods whose creation was processed by
       the webhook handler but not yet been observed by the WorkloadSpread controller.
@@ -177,13 +175,27 @@ status:
        > failedCount just records the number of failures. Every failure can lead subset unschedulable for 10 minutes.
 ### Requirements
 
+#### Pod Webhook
+
 WorkloadSpread requires Pod webhook to inject rules into Pods and notice the deletion and eviction of Pods.
 
 So if the `PodWebhook` feature-gate is set to `false`, WorkloadSpread will also be disabled.
 
+#### deletion-cost feature
+
+CloneSet has supported deletion-cost feature in the latest versions.
+
+Since Kubernetes 1.21, there is a new annotation definition on Pod:
+
+```yaml
+    controller.kubernetes.io/pod-deletion-cost: -100 / 100 / 0
+```
+
+(In 1.21, users need to enable `PodDeletionCost` feature-gate, and since 1.22 it will be enabled by default)
+
 ### Implementation Details/Notes/Constraints
 
-WorkloadSpread has both webhook and controller. Controller should collaborate with webhook to maintain WorkloadSpread's status together. 
+WorkloadSpread has both webhook and controller. Controller should collaborate with webhook to maintain WorkloadSpread's status together.
 
 The webhook is responsible for injecting rules into pod, updating `missingReplicas` and recording the creation or deletion entry of Pod into map.
 
@@ -192,30 +204,30 @@ The controller is responsible for updating the missingReplicas along with other 
 #### Replicas control
 
 ##### Pod creation
-When a Pod is creating and its workload has a related WorkloadSpread, webhook will check the subsetStatuses in the WorkloadSpread one by one:
 
-1. if `missingReplicas` > 0 or `missingReplicas` = -1 and this subset is not unschedulable, choose this subset temporarily 
-   
+When a Pod is creating and its workload has a related WorkloadSpread, webhook will check the subsetStatuses in the WorkloadSpread one by one:
+1. if `missingReplicas` > 0 or `missingReplicas` = -1 and this subset is not unschedulable, choose this subset temporarily. \
    (1). update `missingReplicas` -= 1 and put this pod into `creatingPods` map and try to update subsetStatus. \
    (2). If update to WorkloadSpread conflicts with other updates, get the WorkloadSpread again and go back to step (1). \
    (3). if update to WorkloadSpread successfully, inject the rules of this subset into the Pod.
-   
-2. if `missingReplicas` = 0, go to the next subset
-   
-3. if there is no available subset left, just let the Pod go
+2. if `missingReplicas` = 0, go to the next subset.
+3. if there is no available subset left, just let the Pod go.
 
-##### Pod deletion 
+##### Pod deletion
+
 Also, when a Pod that belongs to a subset is being deleted or evicted, webhook will put it into the `deletingPods` map in subsetStatus and update `missingReplicas` += 1.
 
 ##### Update Pod Status
-When a Pod that belongs to a subset changes status phase to 'succeed' or 'failed', which means Pod has been terminated lifecycle, webhook will clean it from `creatingPods` map and update `missingReplicas` += 1.
+
+When a Pod that belongs to a subset changes status phase to 'succeed' or 'failed', which means Pod has been terminated lifecycle, webhook will update `missingReplicas` += 1.
 
 #### Reschedule strategy
+
 Reschedule strategy will delete unscheduled Pods that still in pending status. Some subsets have no sufficient resource can lead to some Pods unscheduable.
 WorkloadSpread has multiple subset, so the unschedulable pods should be rescheduled to other subsets.
 
 Controller will mark the subset containing unscheduable pods to unscheduable status and Webhook cannot inject Pod into this subset by check subset's status.
-And then controller cleans up all unscheduable Pods to trigger workload creating new replicas, and webhook will skip unscheduable subset and chose suitable subset to inject. 
+And then controller cleans up all unscheduable Pods to trigger workload creating new replicas, and webhook will skip unscheduable subset and chose suitable subset to inject.
 
 The unscheduled subset can be kept for 10 minutes and then should be recovered schedulable to schedule Pod again by controller.
 
@@ -229,28 +241,19 @@ We have three types for subset's Pod deletion-cost
 3. the number of active Pods in this subset > maxReplicas, two class: (a) deletion-cost = -100, (b) deletion-cost = +100. \
    indicating we prefer deleting the Pod have -100 deletion-cost in this subset in order to control the instance of subset \
    meeting up the desired maxReplicas number.
-
-CloneSet has supported deletion-cost feature in the recent versions.
-
-Since Kubernetes 1.21, there is a new annotation definition on Pod:
-
-```yaml
-    controller.kubernetes.io/pod-deletion-cost: -100 / 100 / 0
-```
-
-(In 1.21, users need to enable `PodDeletionCost` feature-gate, and since 1.22 it will be enabled by default)
-
+   
 ### Alternative Considered
 
 #### UnitedDeployment
 
-Both UnitedDeployment and WorkloadSpread allow the workload to be distributed in different subsets. 
-The topology distribution of UnitedDeployment is defined in advance by the user, but the topology distribution of WorkloadSpread has a sequential attribute. 
-Only if the number of Pods of the current Subset is equal to maxReplicas, the remaining replicas will be scheduled to the next Subset. 
-The order attribution of subset makes WorkloadSpread better meeting up the elastic demand of workload. 
+Both UnitedDeployment and WorkloadSpread allow the workload to be distributed in different subsets.
 
-For example, WorkloadSpread has two subsets: subset-a and subset-b, maxReplicas are 50 and null(no limit). 
-The number of replicas of workload will change with the actual business load. 
+The topology distribution of UnitedDeployment is defined in advance by the user, but the topology distribution of WorkloadSpread has a sequential attribute.
+Only if the number of Pods of the current Subset is equal to maxReplicas, the remaining replicas will be scheduled to the next Subset.
+The order attribution of subset makes WorkloadSpread better meeting up the elastic demand of workload.
+
+For example, WorkloadSpread has two subsets: subset-a and subset-b, maxReplicas are 50 and null(no limit).
+The number of replicas of workload will change with the actual business load.
 
 workload replicas changes: 40 -> 100 -> 30
 
@@ -263,25 +266,25 @@ subset replicas distribution:
 | 30  | 0  |
 
 The subset-b will only be allocated Pods when the application load is higher (100 replicas), and not provide resources during the rest of the time.
-This will reduce a lot of resources belongs to subset-b for us, and the application can get better elastic support.
+This will reduce a lot of resources belongs to subset-b for us, and the application can get a better elastic support.
+
+The UnitedDeployment can also be improved to support the subset preferences, **but the WorkloadSpread requires no workload api changes**.
+One can use vanilla CloneSet even Deployment while attaching extra topology constraints.
 
 #### NodeAffinity
 
 Add nodeAffinity to the workload template, such as preferredDuringSchedulingIgnoredDuringExecution, which can be scheduled in multiple regions.
-However, It cannot specify the replica numbers of the subset, and it is only valid when the Pod is scheduled.
+However, it cannot limit the replica numbers of a subset, and it is only effective when scaling out the workload, not effective when scaling in.
 
 The internal implementation of WorkloadSpread is also based on nodeAffinity, but it will provide richer control for multiple subset.
 
 #### PodTopologySpread
 
-You can use topology spread constraints to control how Pods are spread across your cluster among failure-domains such as regions, zones, nodes, and other user-defined topology domains. 
+You can use topology spread constraints to control how Pods are spread across your cluster among failure-domains such as regions, zones, nodes, and other user-defined topology domains.
 This can help to achieve high availability as well as efficient resource utilization.
 
 1. WorkloadSpread's subset maxReplicas can be a percentage string, which defines the percentage spread in multiple topology, but PodTopologySpread doesn't support this feature.
-   
 2. WorkloadSpread has an order attribution, and the order of subset influence creation and deletion order
-   
 3. For PodTopologySpread, there's no guarantee that the constraints remain satisfied when Pods are removed.
    For example, scaling down a Deployment may result in imbalanced Pods distribution.
    For WorkloadSpread, controller will guarantee the workload replicas meeting up maxReplicas by deletion-cost feature.
-   

--- a/docs/proposals/20210628-workloadspread.md
+++ b/docs/proposals/20210628-workloadspread.md
@@ -100,7 +100,7 @@ status:
 - `targetRef`: reference to a specific workload, it supports `Deployment` in `apps` group and `CloneSet` in `apps.kruise.io` group
 - `subsets`: list of subsets which defines different topologies
   - `name`: name of this subset
-  - `requiredNodeSelectorTerm`: the additional node selector of this subset, it will be appended into the `pod.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms`
+  - `requiredNodeSelectorTerm`: the additional node selector of this subset, it will be injected into each term of the `pod.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms`
   - `preferredNodeSelectorTerms`: the additional node selector of this subset, it will be appended into the `pod.spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution`
   - `tolerations`: the additional tolerations of this subset, it will be injected into `pod.spec.tolerations`
   - `patch`: the specified strategic patch body of this subset, it will be patched to Pods that belong to this subset

--- a/docs/proposals/20210628-workloadspread.md
+++ b/docs/proposals/20210628-workloadspread.md
@@ -199,7 +199,7 @@ WorkloadSpread has both webhook and controller. Controller should collaborate wi
 
 The webhook is responsible for injecting rules into pod, updating `missingReplicas` and recording the creation or deletion entry of Pod into map.
 
-The controller is responsible for updating the missingReplicas along with other statics, and clean `creatingPods` and `deletingPods` map.
+The controller is responsible for updating the missingReplicas along with other statics, and cleaning `creatingPods` and `deletingPods` map.
 
 ### Replicas control
 
@@ -244,9 +244,11 @@ We have three types for subset's Pod deletion-cost
    meeting up the desired maxReplicas number.
 
 If WorkloadSpread changes its subset maxReplicas, Pods will not be recreated, but WorkloadSpread will adjust deletion-cost annotation through the above algorithm.
-**We shouldn't change maxReplicas frequently because this operation may increase the pressure of api-server.**
 
 To change scheduleStrategy of WorkloadSpread will keep the deletion-cost annotation of Pod.
+
+## Caution
+When you adjust the subset's maxReplicas, you need to trigger the workload's rollout to make the existing Pods meeting the new topology spread.
 
 ## Alternative Considered
 
@@ -285,7 +287,7 @@ ECS should hold on 30 replicas, and the extra Pods should be scheduled to virtua
 Add nodeAffinity to the workload template, such as preferredDuringSchedulingIgnoredDuringExecution, which can be scheduled in multiple regions.
 However, it cannot limit the replica numbers of a subset, and it is only effective when scaling out the workload, not effective when scaling in.
 
-The internal implementation of WorkloadSpread is also based on nodeAffinity, but it will provide richer control for multiple subset.
+The internal implementation of WorkloadSpread is also based on nodeAffinity, but it will provide richer control for multiple subsets.
 
 ### PodTopologySpread
 

--- a/docs/proposals/20210628-workloadspread.md
+++ b/docs/proposals/20210628-workloadspread.md
@@ -7,7 +7,7 @@ reviewers:
   - "@furykerry"
   - "@FillZpp"
 creation-date: 2021-06-28
-last-updated: 2021-07-06
+last-updated: 2021-07-09
 status: implementable
 ---
 

--- a/docs/proposals/20210628-workloadspread.md
+++ b/docs/proposals/20210628-workloadspread.md
@@ -7,7 +7,7 @@ reviewers:
   - "@furykerry"
   - "@FillZpp"
 creation-date: 2021-06-28
-last-updated: 2021-07-09
+last-updated: 2021-07-13
 status: implementable
 ---
 
@@ -81,6 +81,7 @@ spec:
       rescheduleCriticalSeconds: 30
 status:
   observedGeneration: 12
+  observedWorkloadGeneration: 3
   subsetStatuses:
   - name: subset-a
     missingReplicas: 2
@@ -246,6 +247,15 @@ We have three types for subset's Pod deletion-cost
 If WorkloadSpread changes its subset maxReplicas, Pods will not be recreated, but WorkloadSpread will adjust deletion-cost annotation through the above algorithm.
 
 To change scheduleStrategy of WorkloadSpread will keep the deletion-cost annotation of Pod.
+
+### MissingReplicas consistency
+
+Webhook will select suitable subset to inject pod by checking whether missingReplicas of the subset > 0. Therefore, the consistency of missingReplicas is very important.
+
+We determine the observedGeneration == CR generation to guarantee the newest CR and observedWorkloadGeneration == workload generation to guarantee the newest workload instance when the webhook is mutating Pod.
+
+Sometimes the kruise informer may have a bigger latency, which will cause the webhook to get two generations are all old data.
+It may cause some error when the webhook is mutating Pod.
 
 ## Caution
 When you adjust the subset's maxReplicas, you need to trigger the workload's rollout to make the existing Pods meeting the new topology spread.

--- a/docs/proposals/20210628-workloadspread.md
+++ b/docs/proposals/20210628-workloadspread.md
@@ -21,8 +21,6 @@ any additional information provided beyond the standard proposal template.
 
 ## Motivation
 
-
-
 Define a CRD named WorkloadSpread, which can support configuration and management for elastic and multi-domain applications,
 even more powerful and flexible than [UnitedDeployment](https://openkruise.io/en-us/docs/uniteddeployment.html) in some ways.
 
@@ -273,6 +271,7 @@ ECS should hold on 30 replicas, and the extra Pods should be scheduled to virtua
         - key: virtual-kubelet.io/provider
           operator: Exists
 ```
+**If the workload instance is scaled out, but the WorkloadSpread CR is not adjusted accordingly, unexpected behaviors may happen.**
 
 ### NodeAffinity
 

--- a/docs/proposals/20210628-workloadspread.md
+++ b/docs/proposals/20210628-workloadspread.md
@@ -7,7 +7,7 @@ reviewers:
   - "@furykerry"
   - "@FillZpp"
 creation-date: 2021-06-28
-last-updated: 2021-06-28
+last-updated: 2021-07-05
 status: implementable
 ---
 


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->
Signed-off-by: BoltsLei  [Caofree286@gmail.com](Caofree286@gmail.com)

### Ⅰ. Describe what this PR does
Add proposal of WorkloadSpread, a bypass scheme for elasticity and multi-domain management.

### Ⅴ. Special notes for reviews
WorkloadSpread supports configuration and management for elastic and multi-domain applications,
even more powerful and flexible than UnitedDeployment in some ways.

Not like the workload type, WorkloadSpread can be used with those stateless workloads, such as CloneSet, Deployment and ReplicaSet.

So users needn't learn the usage of a new workload and how to deploy and update their application by it.
They only have to create WorkloadSpread CRs related to their existing workloads.

