### PR TITLE
Add internal ContainerService and pod informer for kruise-daemon

### DIFF
--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -23,6 +23,9 @@ import (
 
 	"github.com/openkruise/kruise/pkg/client"
 	"github.com/openkruise/kruise/pkg/daemon"
+	"github.com/openkruise/kruise/pkg/features"
+	utilfeature "github.com/openkruise/kruise/pkg/util/feature"
+	"github.com/spf13/pflag"
 	"k8s.io/klog"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
@@ -33,9 +36,12 @@ var (
 )
 
 func main() {
+	utilfeature.DefaultMutableFeatureGate.AddFlag(pflag.CommandLine)
 	klog.InitFlags(nil)
-	flag.Parse()
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+	pflag.Parse()
 	rand.Seed(time.Now().UnixNano())
+	features.SetDefaultFeatureGates()
 
 	cfg := config.GetConfigOrDie()
 	cfg.UserAgent = "kruise-daemon"

--- a/config/rbac/daemon_role.yaml
+++ b/config/rbac/daemon_role.yaml
@@ -46,3 +46,21 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/status
+  verbs:
+  - get
+  - patch
+  - update

--- a/main.go
+++ b/main.go
@@ -92,11 +92,7 @@ func main() {
 	pflag.Parse()
 	rand.Seed(time.Now().UnixNano())
 	ctrl.SetLogger(klogr.New())
-
-	if err := features.ValidateFeatureGates(); err != nil {
-		setupLog.Error(err, "unable to setup feature-gates")
-		os.Exit(1)
-	}
+	features.SetDefaultFeatureGates()
 
 	if enablePprof {
 		go func() {

--- a/pkg/daemon/criruntime/containerruntime/containerd.go
+++ b/pkg/daemon/criruntime/containerruntime/containerd.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2021 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package containerruntime
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/namespaces"
+	"github.com/openkruise/kruise/pkg/util"
+	"google.golang.org/grpc"
+)
+
+const (
+	k8sContainerdNamespace = "k8s.io"
+)
+
+// NewContainerdContainerService returns containerd-type ContainerService
+func NewContainerdContainerService(conn *grpc.ClientConn) (ContainerService, error) {
+	client, err := containerd.NewWithConn(conn)
+	if err != nil {
+		return nil, err
+	}
+	return &containerdContainerClient{client: client}, nil
+}
+
+type containerdContainerClient struct {
+	client *containerd.Client
+}
+
+func (d *containerdContainerClient) ContainerStatus(ctx context.Context, containerID string) (*ContainerStatus, error) {
+	ctx = namespaces.WithNamespace(ctx, k8sContainerdNamespace)
+	container, err := d.client.LoadContainer(ctx, containerID)
+	if err != nil {
+		return nil, err
+	}
+	spec, err := container.Spec(ctx)
+	if err != nil {
+		return nil, err
+	} else if spec.Process == nil {
+		return nil, fmt.Errorf("no process found in %s container spec from containerd: %v", containerID, util.DumpJSON(spec))
+	}
+	return &ContainerStatus{Env: spec.Process.Env}, nil
+}

--- a/pkg/daemon/criruntime/containerruntime/docker.go
+++ b/pkg/daemon/criruntime/containerruntime/docker.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2021 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package containerruntime
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	dockerapi "github.com/docker/docker/client"
+	daemonutil "github.com/openkruise/kruise/pkg/daemon/util"
+	"github.com/openkruise/kruise/pkg/util"
+)
+
+func NewDockerContainerService(runtimeURI string) (ContainerService, error) {
+	d := &dockerContainerService{runtimeURI: runtimeURI}
+	if err := d.createRuntimeClientIfNecessary(); err != nil {
+		return nil, err
+	}
+	return d, nil
+}
+
+type dockerContainerService struct {
+	sync.Mutex
+	runtimeURI string
+	client     *dockerapi.Client
+}
+
+func (d *dockerContainerService) createRuntimeClientIfNecessary() error {
+	d.Lock()
+	defer d.Unlock()
+	if d.client != nil {
+		return nil
+	}
+	c, err := dockerapi.NewClient(d.runtimeURI, "1.23", nil, nil)
+	if err != nil {
+		return err
+	}
+	d.client = c
+	return nil
+}
+
+func (d *dockerContainerService) handleRuntimeError(err error) {
+	if daemonutil.FilterCloseErr(err) {
+		d.Lock()
+		defer d.Unlock()
+		d.client = nil
+	}
+}
+
+func (d *dockerContainerService) ContainerStatus(ctx context.Context, containerID string) (*ContainerStatus, error) {
+	var err error
+	if err = d.createRuntimeClientIfNecessary(); err != nil {
+		return nil, err
+	}
+
+	containerJSON, err := d.client.ContainerInspect(ctx, containerID)
+	if err != nil {
+		d.handleRuntimeError(err)
+		return nil, err
+	} else if containerJSON.Config == nil {
+		return nil, fmt.Errorf("no config found in %s container inspect from docker: %v", containerID, util.DumpJSON(containerJSON))
+	}
+	return &ContainerStatus{Env: containerJSON.Config.Env}, nil
+}

--- a/pkg/daemon/criruntime/containerruntime/interface.go
+++ b/pkg/daemon/criruntime/containerruntime/interface.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2021 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package containerruntime
+
+import "context"
+
+type ContainerService interface {
+	// ContainerStatus returns the status of the container.
+	ContainerStatus(ctx context.Context, containerID string) (*ContainerStatus, error)
+}
+
+type ContainerStatus struct {
+	Env []string
+}

--- a/pkg/daemon/criruntime/containerruntime/pouch.go
+++ b/pkg/daemon/criruntime/containerruntime/pouch.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2021 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package containerruntime
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	pouchapi "github.com/alibaba/pouch/client"
+	daemonutil "github.com/openkruise/kruise/pkg/daemon/util"
+	"github.com/openkruise/kruise/pkg/util"
+)
+
+// NewPouchContainerService create a pouch runtime client
+func NewPouchContainerService(runtimeURI string) (ContainerService, error) {
+	r := &pouchContainerService{runtimeURI: runtimeURI}
+	if err := r.createRuntimeClientIfNecessary(); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+type pouchContainerService struct {
+	sync.Mutex
+	runtimeURI string
+	client     pouchapi.ContainerAPIClient
+}
+
+func (d *pouchContainerService) createRuntimeClientIfNecessary() error {
+	d.Lock()
+	defer d.Unlock()
+	if d.client != nil {
+		return nil
+	}
+	c, err := pouchapi.NewAPIClient(d.runtimeURI, pouchapi.TLSConfig{})
+	if err != nil {
+		return err
+	}
+	d.client = c
+	return nil
+}
+
+func (d *pouchContainerService) handleRuntimeError(err error) {
+	if daemonutil.FilterCloseErr(err) {
+		d.Lock()
+		defer d.Unlock()
+		d.client = nil
+	}
+}
+
+func (d *pouchContainerService) ContainerStatus(ctx context.Context, containerID string) (*ContainerStatus, error) {
+	var err error
+	if err = d.createRuntimeClientIfNecessary(); err != nil {
+		return nil, err
+	}
+
+	containerJSON, err := d.client.ContainerGet(ctx, containerID)
+	if err != nil {
+		d.handleRuntimeError(err)
+		return nil, err
+	} else if containerJSON.Config == nil {
+		return nil, fmt.Errorf("no config found in %s container get from pouch: %v", containerID, util.DumpJSON(containerJSON))
+	}
+	return &ContainerStatus{Env: containerJSON.Config.Env}, nil
+}

--- a/pkg/daemon/criruntime/imageruntime/docker.go
+++ b/pkg/daemon/criruntime/imageruntime/docker.go
@@ -61,7 +61,7 @@ func (d *dockerImageService) createRuntimeClientIfNecessary() error {
 }
 
 func (d *dockerImageService) handleRuntimeError(err error) {
-	if filterCloseErr(err) {
+	if daemonutil.FilterCloseErr(err) {
 		d.Lock()
 		defer d.Unlock()
 		d.client = nil

--- a/pkg/daemon/criruntime/imageruntime/pouch.go
+++ b/pkg/daemon/criruntime/imageruntime/pouch.go
@@ -63,7 +63,7 @@ func (d *pouchImageService) createRuntimeClientIfNecessary() error {
 }
 
 func (d *pouchImageService) handleRuntimeError(err error) {
-	if filterCloseErr(err) {
+	if daemonutil.FilterCloseErr(err) {
 		d.Lock()
 		defer d.Unlock()
 		d.client = nil

--- a/pkg/daemon/criruntime/util.go
+++ b/pkg/daemon/criruntime/util.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2021 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package criruntime
+
+import (
+	"context"
+	"time"
+
+	"github.com/containerd/containerd/defaults"
+	"github.com/containerd/containerd/pkg/dialer"
+	"github.com/pkg/errors"
+	"google.golang.org/grpc"
+)
+
+// getContainerdConn dails to address and return grpc client conn.
+func getContainerdConn(address string) (*grpc.ClientConn, error) {
+	timeout := 10 * time.Second
+
+	gopts := []grpc.DialOption{
+		grpc.WithBlock(),
+		grpc.WithInsecure(),
+		grpc.FailOnNonTempDialError(true),
+		grpc.WithBackoffMaxDelay(3 * time.Second),
+		grpc.WithContextDialer(dialer.ContextDialer),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(defaults.DefaultMaxRecvMsgSize)),
+		grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(defaults.DefaultMaxSendMsgSize)),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	conn, err := grpc.DialContext(ctx, dialer.DialAddress(address), gopts...)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to dial %q", address)
+	}
+	return conn, nil
+}

--- a/pkg/daemon/imagepuller/imagepuller_worker.go
+++ b/pkg/daemon/imagepuller/imagepuller_worker.go
@@ -446,15 +446,15 @@ func (w *pullWorker) doPullImage(ctx context.Context, newStatus *appsv1alpha1.Im
 		select {
 		case <-w.stopCh:
 			klog.V(2).Infof("Pulling image %v:%v is stopped.", w.name, tag)
-			return fmt.Errorf("Pulling image %s:%s is stopped", w.name, tag)
+			return fmt.Errorf("pulling image %s:%s is stopped", w.name, tag)
 		case <-ctx.Done():
 			klog.V(2).Infof("Pulling image %s:%s is canceled", w.name, tag)
-			return fmt.Errorf("Pulling image %s:%s is canceled", w.name, tag)
+			return fmt.Errorf("pulling image %s:%s is canceled", w.name, tag)
 		case <-logTicker.C:
 			klog.V(2).Infof("Pulling image %s:%s, cost: %v, progress: %v%%, detail: %v", w.name, tag, time.Since(startTime.Time), progress, progressInfo)
 		case progressStatus, ok := <-statusReader.C():
 			if !ok {
-				return fmt.Errorf("Pulling image %s:%s internal error", w.name, tag)
+				return fmt.Errorf("pulling image %s:%s internal error", w.name, tag)
 			}
 			progress = progressStatus.Process
 			progressInfo = progressStatus.DetailInfo

--- a/pkg/daemon/options/options.go
+++ b/pkg/daemon/options/options.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2021 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	daemonruntime "github.com/openkruise/kruise/pkg/daemon/criruntime"
+	daemonutil "github.com/openkruise/kruise/pkg/daemon/util"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/cache"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type Options struct {
+	NodeName      string
+	Scheme        *runtime.Scheme
+	RuntimeClient runtimeclient.Client
+	PodInformer   cache.SharedIndexInformer
+
+	RuntimeFactory daemonruntime.Factory
+	Healthz        *daemonutil.Healthz
+}

--- a/pkg/daemon/util/error.go
+++ b/pkg/daemon/util/error.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2021 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"io"
+	"net"
+	"os"
+	"strings"
+	"syscall"
+
+	"github.com/pkg/errors"
+)
+
+// FilterCloseErr rewrites EOF and EPIPE errors to bool. Use when
+// returning from call or handling errors from main read loop.
+//
+// This purposely ignores errors with a wrapped cause.
+func FilterCloseErr(err error) bool {
+	switch {
+	case err == io.EOF:
+		return true
+	case errors.Cause(err) == io.EOF:
+		return true
+	case strings.Contains(err.Error(), "use of closed network connection"):
+		return true
+	case strings.Contains(err.Error(), "connect: no such file or directory"):
+		return true
+	default:
+		// if we have an epipe on a write or econnreset on a read , we cast to errclosed
+		if oerr, ok := err.(*net.OpError); ok && (oerr.Op == "write" || oerr.Op == "read") {
+			serr, sok := oerr.Err.(*os.SyscallError)
+			if sok && ((serr.Err == syscall.EPIPE && oerr.Op == "write") ||
+				(serr.Err == syscall.ECONNRESET && oerr.Op == "read")) {
+
+				return true
+			}
+		}
+	}
+
+	return false
+}

--- a/pkg/features/kruise_features.go
+++ b/pkg/features/kruise_features.go
@@ -61,11 +61,16 @@ const (
 
 	// Whether to enable pub capability, default: false
 	PodUnavailableBudgetGate featuregate.Feature = "PodUnavailableBudgetGate"
+
+	// DaemonWatchingPod enables kruise-daemon to list watch pods that belong to the same node.
+	DaemonWatchingPod featuregate.Feature = "DaemonWatchingPod"
 )
 
 var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	PodWebhook:                       {Default: true, PreRelease: featuregate.Beta},
-	KruiseDaemon:                     {Default: true, PreRelease: featuregate.Beta},
+	PodWebhook:        {Default: true, PreRelease: featuregate.Beta},
+	KruiseDaemon:      {Default: true, PreRelease: featuregate.Beta},
+	DaemonWatchingPod: {Default: true, PreRelease: featuregate.Beta},
+
 	CloneSetShortHash:                {Default: false, PreRelease: featuregate.Alpha},
 	KruisePodReadinessGate:           {Default: false, PreRelease: featuregate.Alpha},
 	PreDownloadImageForInPlaceUpdate: {Default: false, PreRelease: featuregate.Alpha},
@@ -91,9 +96,13 @@ func compatibleEnv() {
 	}
 }
 
-func ValidateFeatureGates() error {
-	if utilfeature.DefaultFeatureGate.Enabled(KruisePodReadinessGate) && !utilfeature.DefaultFeatureGate.Enabled(PodWebhook) {
-		return fmt.Errorf("can not enable feature-gate %s because of %s disabled", KruisePodReadinessGate, PodWebhook)
+func SetDefaultFeatureGates() {
+	if !utilfeature.DefaultFeatureGate.Enabled(PodWebhook) {
+		_ = utilfeature.DefaultMutableFeatureGate.Set(fmt.Sprintf("%s=false", KruisePodReadinessGate))
+		_ = utilfeature.DefaultMutableFeatureGate.Set(fmt.Sprintf("%s=false", ResourcesDeletionProtection))
 	}
-	return nil
+	if !utilfeature.DefaultFeatureGate.Enabled(KruiseDaemon) {
+		_ = utilfeature.DefaultMutableFeatureGate.Set(fmt.Sprintf("%s=false", PreDownloadImageForInPlaceUpdate))
+		_ = utilfeature.DefaultMutableFeatureGate.Set(fmt.Sprintf("%s=false", DaemonWatchingPod))
+	}
 }


### PR DESCRIPTION
Signed-off-by: FillZpp <FillZpp.pub@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Add internal ContainerService and pod informer for kruise-daemon.

The internal ContainerService is to get data that CRI does not support, such as environments of an existing container.

### II. Special notes for reviews
This is a basic (step 1) PR for #644 and #641 .

