### PR TITLE
fix rolling update stuck caused by deleting terminating pod

### DIFF
--- a/pkg/controller/daemonset/update.go
+++ b/pkg/controller/daemonset/update.go
@@ -170,6 +170,12 @@ func (dsc *ReconcileDaemonSet) standardRollingUpdate(ds *appsv1alpha1.DaemonSet,
 			dsc.eventRecorder.Eventf(ds, corev1.EventTypeWarning, "numUnavailable >= maxUnavailable", "%s/%s number of unavailable DaemonSet pods: %d, is equal to or exceeds allowed maximum: %d", ds.Namespace, ds.Name, numUnavailable, maxUnavailable)
 			break
 		}
+
+		// Skip deleting if there are some pods stuck at terminating but still report as available.
+		if pod.DeletionTimestamp != nil {
+			continue
+		}
+
 		klog.V(6).Infof("Marking pod %s/%s for deletion", ds.Name, pod.Name)
 		oldPodsToDelete = append(oldPodsToDelete, pod.Name)
 		numUnavailable++


### PR DESCRIPTION

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

Daemonset controller figures out which pods should be update, deletes them and set expectation in syncNodes method.  However when it deletes a terminating pod that reports its PodReady condition as True on a not-ready node, the pod will stuck in terminating state and informer will not receives pod delete event which cause expectations never be satisfied.

DamonSet controller skips unavailable terminating pods (which reports as not ready) but does not skip available terminating pods, and this PR fixes this.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

N/A

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

N/A

### Ⅳ. Describe how to verify it

N/A

### Ⅴ. Special notes for reviews


