### PR TITLE
fix sidecar name changed panic issue

### DIFF
--- a/pkg/controller/podunavailablebudget/podunavailablebudget_controller.go
+++ b/pkg/controller/podunavailablebudget/podunavailablebudget_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"runtime/debug"
 	"time"
 
 	policyv1alpha1 "github.com/openkruise/kruise/apis/policy/v1alpha1"
@@ -143,6 +144,12 @@ type ReconcilePodUnavailableBudget struct {
 
 // pkg/controller/cloneset/cloneset_controller.go Watch for changes to CloneSet
 func (r *ReconcilePodUnavailableBudget) Reconcile(req ctrl.Request) (ctrl.Result, error) {
+	defer func() {
+		if r := recover(); r != nil {
+			klog.Errorf("panic: %v [recovered]\n\n%s", r, debug.Stack())
+		}
+	}()
+
 	// Fetch the PodUnavailableBudget instance
 	pub := &policyv1alpha1.PodUnavailableBudget{}
 	err := r.Get(context.TODO(), req.NamespacedName, pub)

--- a/pkg/controller/sidecarset/sidecarset_controller.go
+++ b/pkg/controller/sidecarset/sidecarset_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"flag"
 	"reflect"
+	"runtime/debug"
 
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
 	"github.com/openkruise/kruise/pkg/control/sidecarcontrol"
@@ -127,6 +128,11 @@ type ReconcileSidecarSet struct {
 // Reconcile reads that state of the cluster for a SidecarSet object and makes changes based on the state read
 // and what is in the SidecarSet.Spec
 func (r *ReconcileSidecarSet) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	defer func() {
+		if r := recover(); r != nil {
+			klog.Errorf("panic: %v [recovered]\n\n%s", r, debug.Stack())
+		}
+	}()
 	// Fetch the SidecarSet instance
 	sidecarSet := &appsv1alpha1.SidecarSet{}
 	err := r.Get(context.TODO(), request.NamespacedName, sidecarSet)

--- a/pkg/controller/sidecarset/sidecarset_controller_test.go
+++ b/pkg/controller/sidecarset/sidecarset_controller_test.go
@@ -57,7 +57,8 @@ var (
 	podDemo = &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
-				sidecarcontrol.SidecarSetHashAnnotation: `{"test-sidecarset":{"hash":"aaa"}}`,
+				sidecarcontrol.SidecarSetHashAnnotation: `{"test-sidecarset":{"hash":"aaa","sidecarList":["test-sidecar"]}}`,
+				sidecarcontrol.SidecarSetListAnnotation: "test-sidecarset",
 			},
 			Name:            "test-pod-1",
 			Namespace:       "default",
@@ -260,7 +261,7 @@ func testUpdateWhenMaxUnavailableNotZero(t *testing.T, sidecarSetInput *appsv1al
 		t.Errorf("get latest pod failed, err: %v", err)
 	}
 	if !isSidecarImageUpdated(podOutput, "test-sidecar", "test-image:v2") {
-		t.Errorf("should update sidecar with unavailable number not zero")
+		t.Errorf("sidecarset upgrade image failed")
 	}
 }
 

--- a/pkg/controller/sidecarset/sidecarset_hotupgrade_test.go
+++ b/pkg/controller/sidecarset/sidecarset_hotupgrade_test.go
@@ -69,7 +69,7 @@ var (
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
 				//hash
-				sidecarcontrol.SidecarSetHashAnnotation: `{"test-sidecarset":{"hash":"aaa"}}`,
+				sidecarcontrol.SidecarSetHashAnnotation: `{"test-sidecarset":{"hash":"aaa","sidecarList":["test-sidecar"]}}`,
 				//111111111
 				sidecarcontrol.SidecarSetHashWithoutImageAnnotation: `{"test-sidecarset":{"hash":"111111111"}}`,
 				//sidecar version

--- a/pkg/controller/sidecarset/sidecarset_strategy_test.go
+++ b/pkg/controller/sidecarset/sidecarset_strategy_test.go
@@ -42,8 +42,8 @@ func factoryPodsCommon(count, upgraded int, sidecarSet *appsv1alpha1.SidecarSet)
 		pod := &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
-					sidecarcontrol.SidecarSetHashAnnotation:             `{"test-sidecarset":{"hash":"aaa"}}`,
-					sidecarcontrol.SidecarSetHashWithoutImageAnnotation: `{"test-sidecarset":{"hash":"without-aaa"}}`,
+					sidecarcontrol.SidecarSetHashAnnotation:             `{"test-sidecarset":{"hash":"aaa","sidecarList":["test-sidecar"]}}`,
+					sidecarcontrol.SidecarSetHashWithoutImageAnnotation: `{"test-sidecarset":{"hash":"without-aaa","sidecarList":["test-sidecar"]}}`,
 				},
 				Name: fmt.Sprintf("pod-%d", i),
 				Labels: map[string]string{

--- a/pkg/webhook/sidecarset/validating/sidecarset_create_update_handler.go
+++ b/pkg/webhook/sidecarset/validating/sidecarset_create_update_handler.go
@@ -239,6 +239,7 @@ func validateSidecarContainerConflict(newContainers, oldContainers []appsv1alpha
 			}
 		}
 	}
+
 	return allErrs
 }
 


### PR DESCRIPTION
Signed-off-by: liheng.zms <liheng.zms@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Fix the kruise exception caused by the change of container name in sidecarSet.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
When sidecarSet container namge changed, then sidecarSet controller upgrading pods logic will be exception. The controller determines if it is the same container in pod by container name.
![image](https://user-images.githubusercontent.com/25051767/128691634-b07fe1a5-7010-4bbe-a268-00a283dc237e.png)


The fix idea is as follows:
1. SidecarSet controller determine whether sidecar name in pod and sidecar name in sidecarSet are the same, if not, then do not perform the upgrade operation. 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


