### PR TITLE
Fix the kruise exception caused by the change of container name in sidecarSet.

### DIFF
--- a/pkg/controller/sidecarset/sidecarset_controller_test.go
+++ b/pkg/controller/sidecarset/sidecarset_controller_test.go
@@ -57,7 +57,8 @@ var (
 	podDemo = &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
-				sidecarcontrol.SidecarSetHashAnnotation: `{"test-sidecarset":{"hash":"aaa"}}`,
+				sidecarcontrol.SidecarSetHashAnnotation: `{"test-sidecarset":{"hash":"aaa","sidecarList":["test-sidecar"]}}`,
+				sidecarcontrol.SidecarSetListAnnotation: "test-sidecarset",
 			},
 			Name:            "test-pod-1",
 			Namespace:       "default",
@@ -260,7 +261,7 @@ func testUpdateWhenMaxUnavailableNotZero(t *testing.T, sidecarSetInput *appsv1al
 		t.Errorf("get latest pod failed, err: %v", err)
 	}
 	if !isSidecarImageUpdated(podOutput, "test-sidecar", "test-image:v2") {
-		t.Errorf("should update sidecar with unavailable number not zero")
+		t.Errorf("sidecarset upgrade image failed")
 	}
 }
 

--- a/pkg/controller/sidecarset/sidecarset_hotupgrade_test.go
+++ b/pkg/controller/sidecarset/sidecarset_hotupgrade_test.go
@@ -69,7 +69,7 @@ var (
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
 				//hash
-				sidecarcontrol.SidecarSetHashAnnotation: `{"test-sidecarset":{"hash":"aaa"}}`,
+				sidecarcontrol.SidecarSetHashAnnotation: `{"test-sidecarset":{"hash":"aaa","sidecarList":["test-sidecar"]}}`,
 				//111111111
 				sidecarcontrol.SidecarSetHashWithoutImageAnnotation: `{"test-sidecarset":{"hash":"111111111"}}`,
 				//sidecar version

--- a/pkg/controller/sidecarset/sidecarset_pod_event_handler.go
+++ b/pkg/controller/sidecarset/sidecarset_pod_event_handler.go
@@ -56,7 +56,7 @@ func (p *enqueueRequestForPod) addPod(q workqueue.RateLimitingInterface, obj run
 	}
 
 	for _, sidecarSet := range sidecarSets {
-		klog.V(3).Infof("Create pod(%s.%s) and reconcile sidecarSet", pod.Namespace, pod.Name)
+		klog.V(3).Infof("Create pod(%s.%s) and reconcile sidecarSet(%s)", pod.Namespace, pod.Name, sidecarSet.Name)
 		q.Add(reconcile.Request{
 			NamespacedName: types.NamespacedName{
 				Name: sidecarSet.Name,
@@ -72,29 +72,15 @@ func (p *enqueueRequestForPod) updatePod(q workqueue.RateLimitingInterface, old,
 		return
 	}
 
-	//labels changed, and reconcile union sidecarSets
-	/*if !reflect.DeepEqual(newPod.Labels, oldPod.Labels) {
-		sidecarSets,err := p.getUnionSidecarSets(oldPod, newPod)
-		if err!=nil {
-			klog.Errorf("unable to get sidecarSets of pod %s/%s, err: %v", newPod.Namespace, newPod.Name, err)
-			return
-		}
-		for name := range sidecarSets {
-			q.Add(reconcile.Request{
-				NamespacedName: types.NamespacedName{
-					Name: name,
-				},
-			})
-		}
-		return
-	}*/
-
 	matchedSidecarSets, err := p.getPodMatchedSidecarSets(newPod)
 	if err != nil {
 		klog.Errorf("unable to get sidecarSets of pod %s/%s, err: %v", newPod.Namespace, newPod.Name, err)
 		return
 	}
 	for _, sidecarSet := range matchedSidecarSets {
+		if sidecarSet.Spec.UpdateStrategy.Type == appsv1alpha1.NotUpdateSidecarSetStrategyType {
+			continue
+		}
 		var isChanged bool
 		var enqueueDelayTime time.Duration
 		//check whether pod status is changed
@@ -113,32 +99,6 @@ func (p *enqueueRequestForPod) updatePod(q workqueue.RateLimitingInterface, old,
 
 }
 
-/*func (p *enqueueRequestForPod) getUnionSidecarSets(oldPod, newPod *corev1.Pod) (sets.String, error) {
-	//if labels changed, then union older,new sidecarSets
-	sidecarSets, err := p.getPodSidecarSetMemberships(newPod)
-	if err != nil {
-		return nil, err
-	}
-	oldSidecarSets, err := p.getPodSidecarSetMemberships(oldPod)
-	if err != nil {
-		return nil, err
-	}
-	sidecarSets = sidecarSets.Difference(oldSidecarSets).Union(oldSidecarSets.Difference(sidecarSets))
-	return sidecarSets, nil
-}
-
-func (p *enqueueRequestForPod) getPodSidecarSetMemberships(pod *corev1.Pod) (sets.String, error) {
-	set := sets.String{}
-	sidecarSets, err := p.getPodMatchedSidecarSets(pod)
-	if err != nil {
-		return set, err
-	}
-	for _, sidecarSet := range sidecarSets {
-		set.Insert(sidecarSet.Name)
-	}
-	return set, nil
-}*/
-
 func (p *enqueueRequestForPod) getPodMatchedSidecarSets(pod *corev1.Pod) ([]*appsv1alpha1.SidecarSet, error) {
 	sidecarSetNames, ok := pod.Annotations[sidecarcontrol.SidecarSetListAnnotation]
 
@@ -150,7 +110,7 @@ func (p *enqueueRequestForPod) getPodMatchedSidecarSets(pod *corev1.Pod) ([]*app
 				Name: sidecarSetName,
 			}, sidecarSet); err != nil {
 				if errors.IsNotFound(err) {
-					klog.Errorf("sidecarSet %v not fount", sidecarSetName)
+					klog.V(6).Infof("pod(%s/%s) sidecarSet(%s) Not Found", pod.Namespace, pod.Name, sidecarSetName)
 					continue
 				}
 				return nil, err
@@ -160,7 +120,9 @@ func (p *enqueueRequestForPod) getPodMatchedSidecarSets(pod *corev1.Pod) ([]*app
 		return matchedSidecarSets, nil
 	}
 
-	sidecarSets := appsv1alpha1.SidecarSetList{}
+	// This code will trigger an invalid reconcile, where the Pod matches the sidecarSet selector but does not inject the sidecar container.
+	// Comment out this code to reduce some invalid reconcile.
+	/*sidecarSets := appsv1alpha1.SidecarSetList{}
 	if err := p.reader.List(context.TODO(), &sidecarSets); err != nil {
 		return nil, err
 	}
@@ -173,14 +135,14 @@ func (p *enqueueRequestForPod) getPodMatchedSidecarSets(pod *corev1.Pod) ([]*app
 		if matched {
 			matchedSidecarSets = append(matchedSidecarSets, &sidecarSet)
 		}
-	}
+	}*/
 	return matchedSidecarSets, nil
 }
 
 func isPodStatusChanged(oldPod, newPod *corev1.Pod) bool {
 	// If the pod's deletion timestamp is set, remove endpoint from ready address.
 	if oldPod.DeletionTimestamp.IsZero() && !newPod.DeletionTimestamp.IsZero() {
-		klog.V(3).Infof("pod(%s.%s) DeletionTimestamp changed, and reconcile sidecarSet", newPod.Namespace, newPod.Name)
+		klog.V(3).Infof("pod(%s/%s) DeletionTimestamp changed, and reconcile sidecarSet", newPod.Namespace, newPod.Name)
 		return true
 		// oldPod Deletion is set, then no reconcile
 	} else if !oldPod.DeletionTimestamp.IsZero() {
@@ -194,7 +156,7 @@ func isPodStatusChanged(oldPod, newPod *corev1.Pod) bool {
 	oldReady := podutil.IsPodReady(oldPod)
 	newReady := podutil.IsPodReady(newPod)
 	if oldReady != newReady {
-		klog.V(3).Infof("pod(%s.%s) Ready changed(from %v to %v), and reconcile sidecarSet",
+		klog.V(3).Infof("pod(%s/%s) Ready changed(from %v to %v), and reconcile sidecarSet",
 			newPod.Namespace, newPod.Name, oldReady, newReady)
 		return true
 	}
@@ -209,8 +171,8 @@ func isPodConsistentChanged(oldPod, newPod *corev1.Pod, sidecarSet *appsv1alpha1
 	oldConsistent := control.IsPodStateConsistent(oldPod, nil)
 	newConsistent := control.IsPodStateConsistent(newPod, nil)
 	if oldConsistent != newConsistent {
-		klog.V(3).Infof("pod(%s.%s) sidecarSet consistent(all sidecar containers) changed(from %v to %v), and reconcile sidecarSet",
-			newPod.Namespace, newPod.Name, oldConsistent, newConsistent)
+		klog.V(3).Infof("pod(%s/%s) sidecar containers consistent changed(from %v to %v), and reconcile sidecarSet(%s)",
+			newPod.Namespace, newPod.Name, oldConsistent, newConsistent, sidecarSet.Name)
 		enqueueDelayTime = 5 * time.Second
 		return true, enqueueDelayTime
 	}

--- a/pkg/controller/sidecarset/sidecarset_strategy_test.go
+++ b/pkg/controller/sidecarset/sidecarset_strategy_test.go
@@ -42,8 +42,8 @@ func factoryPodsCommon(count, upgraded int, sidecarSet *appsv1alpha1.SidecarSet)
 		pod := &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
-					sidecarcontrol.SidecarSetHashAnnotation:             `{"test-sidecarset":{"hash":"aaa"}}`,
-					sidecarcontrol.SidecarSetHashWithoutImageAnnotation: `{"test-sidecarset":{"hash":"without-aaa"}}`,
+					sidecarcontrol.SidecarSetHashAnnotation:             `{"test-sidecarset":{"hash":"aaa","sidecarList":["test-sidecar"]}}`,
+					sidecarcontrol.SidecarSetHashWithoutImageAnnotation: `{"test-sidecarset":{"hash":"without-aaa","sidecarList":["test-sidecar"]}}`,
 				},
 				Name: fmt.Sprintf("pod-%d", i),
 				Labels: map[string]string{

--- a/pkg/webhook/sidecarset/validating/sidecarset_create_update_handler.go
+++ b/pkg/webhook/sidecarset/validating/sidecarset_create_update_handler.go
@@ -239,6 +239,7 @@ func validateSidecarContainerConflict(newContainers, oldContainers []appsv1alpha
 			}
 		}
 	}
+
 	return allErrs
 }
 


### PR DESCRIPTION
Signed-off-by: liheng.zms <liheng.zms@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Fix the kruise exception caused by the change of container name in sidecarSet.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
When sidecarSet container namge changed, then sidecarSet controller upgrading pods logic will be exception. The controller determines if it is the same container in pod by container name.
<img width="1500" alt="A8EA35C5-5C9B-435D-ABAF-CAFA41F3B80F" src="https://user-images.githubusercontent.com/25051767/128820407-86fa6730-822e-4c58-a8d7-2ca750906982.png">

The fix idea is as follows:
1. pod annotations[kruise.io/sidecarset-hash] record injection of sidecar container list.
2. SidecarSet controller determine whether sidecar name in pod and sidecar name in sidecarSet are the same, if not, then do not perform the upgrade operation. 
3. The community version function **IsSidecarSetUpgradable** does not need to be adjusted, because it already determines whether kruise.io/sidecarset-hash-without-image is changed or not.

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
