### PR TITLE
fix: ds status is outdate, apiserver will refuse this request

### DIFF
--- a/pkg/controller/daemonset/daemonset_util.go
+++ b/pkg/controller/daemonset/daemonset_util.go
@@ -301,7 +301,6 @@ func storeDaemonSetStatus(dsClient kubeClient.Client, ds *appsv1alpha1.DaemonSet
 		}
 
 		klog.Errorf("update DaemonSet status %v failed: %v", ds.Status, updateErr)
-
 		//Stop retrying if we exceed statusUpdateRetries - the DaemonSet will be requeued with a rate limit.
 		if i >= StatusUpdateRetries {
 			break

--- a/pkg/controller/daemonset/daemonset_util.go
+++ b/pkg/controller/daemonset/daemonset_util.go
@@ -19,26 +19,25 @@ package daemonset
 import (
 	"context"
 	"fmt"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/util/retry"
 	"time"
 
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
+
 	apps "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/klog"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	kubeClient "sigs.k8s.io/controller-runtime/pkg/client"
-
-	"k8s.io/kubernetes/pkg/scheduler/algorithm/predicates"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	intstrutil "k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/klog"
+	"k8s.io/kubernetes/pkg/scheduler/algorithm/predicates"
 	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	kubeClient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // nodeInSameCondition returns true if all effective types ("Status" is true) equals;


### PR DESCRIPTION
Signed-off-by: Noisyes <kyf19970408@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
It's easy to get update conflict when processing a DaemonSet continuously. storeDaemonSetStatus had a retry logic that it gets the resource from api server to update the DaemonSet with the latest resource. However, version.daemonset.metadata.resourceVersion is outdate, api server will  refuse this request and always made an useless get call.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.
little fix

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


