### PR TITLE
support `-o wide` fields for kruise resources

### DIFF
--- a/apis/apps/v1alpha1/cloneset_types.go
+++ b/apis/apps/v1alpha1/cloneset_types.go
@@ -215,6 +215,9 @@ type CloneSetCondition struct {
 // +kubebuilder:printcolumn:name="READY",type="integer",JSONPath=".status.readyReplicas",description="The number of pods ready."
 // +kubebuilder:printcolumn:name="TOTAL",type="integer",JSONPath=".status.replicas",description="The number of currently all pods."
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp",description="CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC."
+// +kubebuilder:printcolumn:name="CONTAINERS",type="string",priority=1,JSONPath=".spec.template.spec.containers[*].name",description="The containers of currently cloneset."
+// +kubebuilder:printcolumn:name="IMAGES",type="string",priority=1,JSONPath=".spec.template.spec.containers[*].image",description="The images of currently cloneset."
+// +kubebuilder:printcolumn:name="SELECTOR",type="string",priority=1,JSONPath=".status.labelSelector",description="The selector of currently cloneset."
 
 // CloneSet is the Schema for the clonesets API
 type CloneSet struct {

--- a/apis/apps/v1alpha1/daemonset_types.go
+++ b/apis/apps/v1alpha1/daemonset_types.go
@@ -244,6 +244,8 @@ const (
 // +kubebuilder:printcolumn:name="CurrentNumber",type="integer",JSONPath=".status.currentNumberScheduled",description="The current number of pods."
 // +kubebuilder:printcolumn:name="UpdatedNumberScheduled",type="integer",JSONPath=".status.updatedNumberScheduled",description="The updated number of pods."
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp",description="CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC."
+// +kubebuilder:printcolumn:name="CONTAINERS",type="string",priority=1,JSONPath=".spec.template.spec.containers[*].name",description="The containers of currently  daemonset."
+// +kubebuilder:printcolumn:name="IMAGES",type="string",priority=1,JSONPath=".spec.template.spec.containers[*].image",description="The images of currently advanced daemonset."
 
 // DaemonSet is the Schema for the daemonsets API
 type DaemonSet struct {

--- a/apis/apps/v1alpha1/statefulset_types.go
+++ b/apis/apps/v1alpha1/statefulset_types.go
@@ -239,6 +239,8 @@ const (
 // +kubebuilder:printcolumn:name="UPDATED",type="integer",JSONPath=".status.updatedReplicas",description="The number of pods updated."
 // +kubebuilder:printcolumn:name="READY",type="integer",JSONPath=".status.readyReplicas",description="The number of pods ready."
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp",description="CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC."
+// +kubebuilder:printcolumn:name="CONTAINERS",type="string",priority=1,JSONPath=".spec.template.spec.containers[*].name",description="The containers of currently advanced statefulset."
+// +kubebuilder:printcolumn:name="IMAGES",type="string",priority=1,JSONPath=".spec.template.spec.containers[*].image",description="The images of currently advanced statefulset."
 
 // StatefulSet is the Schema for the statefulsets API
 type StatefulSet struct {

--- a/apis/apps/v1beta1/statefulset_types.go
+++ b/apis/apps/v1beta1/statefulset_types.go
@@ -265,6 +265,8 @@ const (
 // +kubebuilder:printcolumn:name="UPDATED",type="integer",JSONPath=".status.updatedReplicas",description="The number of pods updated."
 // +kubebuilder:printcolumn:name="READY",type="integer",JSONPath=".status.readyReplicas",description="The number of pods ready."
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp",description="CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC."
+// +kubebuilder:printcolumn:name="CONTAINERS",type="string",priority=1,JSONPath=".spec.template.spec.containers[*].name",description="The containers of currently advanced statefulset."
+// +kubebuilder:printcolumn:name="IMAGES",type="string",priority=1,JSONPath=".spec.template.spec.containers[*].image",description="The images of currently advanced statefulset."
 
 // StatefulSet is the Schema for the statefulsets API
 type StatefulSet struct {

--- a/config/crd/bases/apps.kruise.io_clonesets.yaml
+++ b/config/crd/bases/apps.kruise.io_clonesets.yaml
@@ -36,6 +36,21 @@ spec:
       in RFC3339 form and is in UTC.
     name: AGE
     type: date
+  - JSONPath: .spec.template.spec.containers[*].name
+    description: The containers of currently cloneset.
+    name: CONTAINERS
+    priority: 1
+    type: string
+  - JSONPath: .spec.template.spec.containers[*].image
+    description: The images of currently cloneset.
+    name: IMAGES
+    priority: 1
+    type: string
+  - JSONPath: .status.labelSelector
+    description: The selector of currently cloneset.
+    name: SELECTOR
+    priority: 1
+    type: string
   group: apps.kruise.io
   names:
     kind: CloneSet

--- a/config/crd/bases/apps.kruise.io_daemonsets.yaml
+++ b/config/crd/bases/apps.kruise.io_daemonsets.yaml
@@ -28,6 +28,16 @@ spec:
       in RFC3339 form and is in UTC.
     name: AGE
     type: date
+  - JSONPath: .spec.template.spec.containers[*].name
+    description: The containers of currently  daemonset.
+    name: CONTAINERS
+    priority: 1
+    type: string
+  - JSONPath: .spec.template.spec.containers[*].image
+    description: The images of currently advanced daemonset.
+    name: IMAGES
+    priority: 1
+    type: string
   group: apps.kruise.io
   names:
     kind: DaemonSet

--- a/config/crd/bases/apps.kruise.io_statefulsets.yaml
+++ b/config/crd/bases/apps.kruise.io_statefulsets.yaml
@@ -32,6 +32,16 @@ spec:
       in RFC3339 form and is in UTC.
     name: AGE
     type: date
+  - JSONPath: .spec.template.spec.containers[*].name
+    description: The containers of currently advanced statefulset.
+    name: CONTAINERS
+    priority: 1
+    type: string
+  - JSONPath: .spec.template.spec.containers[*].image
+    description: The images of currently advanced statefulset.
+    name: IMAGES
+    priority: 1
+    type: string
   group: apps.kruise.io
   names:
     kind: StatefulSet


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
- support `kubectl get xxx -o wide` to show more fields for kruise resources.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

 https://github.com/openkruise/kruise/issues/724



### Ⅳ. Describe how to verify it
`make manifests  && make install ` then create a cloneset or asts, use `kubectl get asts -o wide` to verify additional columns.

![image](https://user-images.githubusercontent.com/7600925/131077310-2b5dabc8-3f2e-4b36-b7ab-a73e17dfa876.png)


### Ⅴ. Special notes for reviews


