### PR TITLE
Add E2E test for WorkloadSpread

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -415,6 +415,9 @@ jobs:
           fi
       - name: Run E2E Tests
         run: |
+          kubectl label nodes ${KIND_CLUSTER_NAME}-worker topology.kubernetes.io/zone=ack
+          kubectl label nodes ${KIND_CLUSTER_NAME}-worker2 topology.kubernetes.io/zone=eci
+          kubectl label nodes ${KIND_CLUSTER_NAME}-worker3 topology.kubernetes.io/zone=eci
           export KUBECONFIG=/home/runner/.kube/config
           go install github.com/onsi/ginkgo/ginkgo
           ./scripts/generate_bindata.sh

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -415,9 +415,6 @@ jobs:
           fi
       - name: Run E2E Tests
         run: |
-          kubectl label nodes ${KIND_CLUSTER_NAME}-worker topology.kubernetes.io/zone=ack
-          kubectl label nodes ${KIND_CLUSTER_NAME}-worker2 topology.kubernetes.io/zone=eci
-          kubectl label nodes ${KIND_CLUSTER_NAME}-worker3 topology.kubernetes.io/zone=eci
           export KUBECONFIG=/home/runner/.kube/config
           go install github.com/onsi/ginkgo/ginkgo
           ./scripts/generate_bindata.sh

--- a/apis/apps/v1alpha1/workloadspread_types.go
+++ b/apis/apps/v1alpha1/workloadspread_types.go
@@ -164,14 +164,14 @@ type WorkloadSpreadSubsetStatus struct {
 	// Name should be unique between all of the subsets under one WorkloadSpread.
 	Name string `json:"name"`
 
-	// Replicas is the most recently observed number of replicas for subset.
+	// Replicas is the most recently observed number of active replicas for subset.
 	Replicas int32 `json:"replicas"`
 
 	// Conditions is an array of current observed subset conditions.
 	// +optional
 	Conditions []WorkloadSpreadSubsetCondition `json:"conditions,omitempty"`
 
-	// MissingReplicas is the number of replicas belong to this subset not be found.
+	// MissingReplicas is the number of active replicas belong to this subset not be found.
 	// MissingReplicas > 0 indicates the subset is still missing MissingReplicas pods to create
 	// MissingReplicas = 0 indicates the subset already has enough pods, there is no need to create
 	// MissingReplicas = -1 indicates the subset's MaxReplicas not set, then there is no limit for pods number

--- a/config/crd/bases/apps.kruise.io_workloadspreads.yaml
+++ b/config/crd/bases/apps.kruise.io_workloadspreads.yaml
@@ -229,9 +229,9 @@ spec:
                       contains information about pod deletion.
                     type: object
                   missingReplicas:
-                    description: MissingReplicas is the number of replicas belong
-                      to this subset not be found. MissingReplicas > 0 indicates the
-                      subset is still missing MissingReplicas pods to create MissingReplicas
+                    description: MissingReplicas is the number of active replicas
+                      belong to this subset not be found. MissingReplicas > 0 indicates
+                      the subset is still missing MissingReplicas pods to create MissingReplicas
                       = 0 indicates the subset already has enough pods, there is no
                       need to create MissingReplicas = -1 indicates the subset's MaxReplicas
                       not set, then there is no limit for pods number
@@ -243,7 +243,7 @@ spec:
                     type: string
                   replicas:
                     description: Replicas is the most recently observed number of
-                      replicas for subset.
+                      active replicas for subset.
                     format: int32
                     type: integer
                 required:

--- a/pkg/controller/workloadspread/workloadspread_controller.go
+++ b/pkg/controller/workloadspread/workloadspread_controller.go
@@ -406,7 +406,6 @@ func (r *ReconcileWorkloadSpread) calculateWorkloadSpreadSubsetStatus(ws *appsv1
 	// current subsetStatus in this reconcile
 	subsetStatus := &appsv1alpha1.WorkloadSpreadSubsetStatus{}
 	subsetStatus.Name = subset.Name
-	subsetStatus.Replicas = int32(len(pods))
 	subsetStatus.CreatingPods = make(map[string]metav1.Time)
 	subsetStatus.DeletingPods = make(map[string]metav1.Time)
 
@@ -437,6 +436,7 @@ func (r *ReconcileWorkloadSpread) calculateWorkloadSpreadSubsetStatus(ws *appsv1
 		}
 		oldDeletingPods = oldSubsetStatus.DeletingPods
 	}
+	var active int32 = 0
 
 	for _, pod := range pods {
 		// remove this Pod from creatingPods map because this Pod has been created.
@@ -454,6 +454,7 @@ func (r *ReconcileWorkloadSpread) calculateWorkloadSpreadSubsetStatus(ws *appsv1
 		if !kubecontroller.IsPodActive(pod) {
 			continue
 		}
+		active++
 
 		// count missingReplicas
 		if subsetStatus.MissingReplicas > 0 {
@@ -481,6 +482,9 @@ func (r *ReconcileWorkloadSpread) calculateWorkloadSpreadSubsetStatus(ws *appsv1
 			}
 		}
 	}
+
+	// record active replicas number
+	subsetStatus.Replicas = active
 
 	// oldCreatingPods has remaining Pods that not be found by controller.
 	for podID, createTime := range oldCreatingPods {

--- a/pkg/controller/workloadspread/workloadspread_controller.go
+++ b/pkg/controller/workloadspread/workloadspread_controller.go
@@ -454,8 +454,8 @@ func (r *ReconcileWorkloadSpread) calculateWorkloadSpreadSubsetStatus(ws *appsv1
 		if !kubecontroller.IsPodActive(pod) {
 			continue
 		}
-		active++
 
+		active++
 		// count missingReplicas
 		if subsetStatus.MissingReplicas > 0 {
 			subsetStatus.MissingReplicas--

--- a/pkg/controller/workloadspread/workloadspread_controller_test.go
+++ b/pkg/controller/workloadspread/workloadspread_controller_test.go
@@ -1126,7 +1126,7 @@ func TestWorkloadSpreadReconcile(t *testing.T) {
 				workloadSpread := workloadSpreadDemo.DeepCopy()
 				//workloadSpread.Status.ObservedWorkloadReplicas = int32(10)
 				workloadSpread.Status.SubsetStatuses[0].MissingReplicas = 3
-				workloadSpread.Status.SubsetStatuses[0].Replicas = 5
+				workloadSpread.Status.SubsetStatuses[0].Replicas = 2
 				workloadSpread.Status.SubsetStatuses[0].CreatingPods = map[string]metav1.Time{}
 				workloadSpread.Status.SubsetStatuses[0].DeletingPods = map[string]metav1.Time{}
 				return workloadSpread
@@ -1226,7 +1226,7 @@ func TestWorkloadSpreadReconcile(t *testing.T) {
 				workloadSpread := workloadSpreadDemo.DeepCopy()
 				//workloadSpread.Status.ObservedWorkloadReplicas = int32(10)
 				workloadSpread.Status.SubsetStatuses[0].MissingReplicas = 1
-				workloadSpread.Status.SubsetStatuses[0].Replicas = 5
+				workloadSpread.Status.SubsetStatuses[0].Replicas = 4
 				workloadSpread.Status.SubsetStatuses[0].CreatingPods = map[string]metav1.Time{}
 				workloadSpread.Status.SubsetStatuses[0].DeletingPods = map[string]metav1.Time{}
 				return workloadSpread

--- a/pkg/controller/workloadspread/workloadspread_event_handler.go
+++ b/pkg/controller/workloadspread/workloadspread_event_handler.go
@@ -61,7 +61,6 @@ func (p *podEventHandler) Update(evt event.UpdateEvent, q workqueue.RateLimiting
 
 	if kubecontroller.IsPodActive(oldPod) && !kubecontroller.IsPodActive(newPod) {
 		p.handlePod(q, newPod, UpdateEventAction)
-		return
 	}
 }
 

--- a/test/e2e/apps/workloadspread.go
+++ b/test/e2e/apps/workloadspread.go
@@ -1,0 +1,1269 @@
+/*
+Copyright 2021 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apps
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/utils/pointer"
+	"time"
+
+	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
+	kruiseclientset "github.com/openkruise/kruise/pkg/client/clientset/versioned"
+	"github.com/openkruise/kruise/pkg/util/workloadspread"
+	"github.com/openkruise/kruise/test/e2e/framework"
+)
+
+var (
+	KruiseKindCloneSet = appsv1alpha1.SchemeGroupVersion.WithKind("CloneSet")
+	//controllerKindDep  = appsv1.SchemeGroupVersion.WithKind("Deployment")
+	//controllerKindJob  = batchv1.SchemeGroupVersion.WithKind("Job")
+)
+
+var _ = SIGDescribe("workloadspread", func() {
+	f := framework.NewDefaultFramework("workloadspread")
+	workloadSpreadName := "test-workload-spread"
+	var ns string
+	var c clientset.Interface
+	var kc kruiseclientset.Interface
+	var tester *framework.WorkloadSpreadTester
+
+	ginkgo.BeforeEach(func() {
+		c = f.ClientSet
+		kc = f.KruiseClientSet
+		ns = f.Namespace.Name
+		tester = framework.NewWorkloadSpreadTester(c, kc)
+	})
+
+	framework.KruiseDescribe("WorkloadSpread functionality", func() {
+		ginkgo.AfterEach(func() {
+			if ginkgo.CurrentGinkgoTestDescription().Failed {
+				framework.DumpDebugInfo(c, ns)
+			}
+		})
+
+		ginkgo.It("deploy in two zone, the type of maxReplicas is Integer", func() {
+			cloneSet := tester.NewBaseCloneSet(ns)
+			// create workloadSpread
+			targetRef := appsv1alpha1.TargetReference{
+				APIVersion: KruiseKindCloneSet.GroupVersion().String(),
+				Kind:       KruiseKindCloneSet.Kind,
+				Name:       cloneSet.Name,
+			}
+			subset1 := appsv1alpha1.WorkloadSpreadSubset{
+				Name: "ack",
+				RequiredNodeSelectorTerm: &corev1.NodeSelectorTerm{
+					MatchExpressions: []corev1.NodeSelectorRequirement{
+						{
+							Key:      "topology.kubernetes.io/zone",
+							Operator: corev1.NodeSelectorOpIn,
+							Values:   []string{"ack"},
+						},
+					},
+				},
+				MaxReplicas: &intstr.IntOrString{Type: intstr.Int, IntVal: 3},
+				Patch: runtime.RawExtension{
+					Raw: []byte(`{"metadata":{"annotations":{"subset":"ack"}}}`),
+				},
+			}
+			subset2 := appsv1alpha1.WorkloadSpreadSubset{
+				Name: "eci",
+				RequiredNodeSelectorTerm: &corev1.NodeSelectorTerm{
+					MatchExpressions: []corev1.NodeSelectorRequirement{
+						{
+							Key:      "topology.kubernetes.io/zone",
+							Operator: corev1.NodeSelectorOpIn,
+							Values:   []string{"eci"},
+						},
+					},
+				},
+				MaxReplicas: &intstr.IntOrString{Type: intstr.Int, IntVal: 3},
+				Patch: runtime.RawExtension{
+					Raw: []byte(`{"metadata":{"annotations":{"subset":"eci"}}}`),
+				},
+			}
+			workloadSpread := tester.NewWorkloadSpread(ns, workloadSpreadName, &targetRef, []appsv1alpha1.WorkloadSpreadSubset{subset1, subset2})
+			workloadSpread = tester.CreateWorkloadSpread(workloadSpread)
+
+			// create cloneset, replicas = 6
+			cloneSet.Spec.Template.Spec.Containers[0].Image = "busybox:latest"
+			cloneSet.Spec.Replicas = pointer.Int32Ptr(6)
+			cloneSet = tester.CreateCloneSet(cloneSet)
+			tester.WaitForCloneSetRunning(cloneSet)
+
+			// get pods, and check workloadSpread
+			ginkgo.By(fmt.Sprintf("get cloneSet(%s/%s) pods, and check workloadSpread(%s/%s) status", cloneSet.Namespace, cloneSet.Name, workloadSpread.Namespace, workloadSpread.Name))
+			pods, err := tester.GetSelectorPods(cloneSet.Namespace, cloneSet.Spec.Selector)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(pods).To(gomega.HaveLen(6))
+			subset1Pods := 0
+			subset2Pods := 0
+			for _, pod := range pods {
+				if str, ok := pod.Annotations[workloadspread.MatchedWorkloadSpreadSubsetAnnotations]; ok {
+					var injectWorkloadSpread *workloadspread.InjectWorkloadSpread
+					err := json.Unmarshal([]byte(str), &injectWorkloadSpread)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					if injectWorkloadSpread.Subset == subset1.Name {
+						subset1Pods++
+						gomega.Expect(injectWorkloadSpread.Name).To(gomega.Equal(workloadSpread.Name))
+						gomega.Expect(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions).To(gomega.Equal(subset1.RequiredNodeSelectorTerm.MatchExpressions))
+						gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal("200"))
+					} else if injectWorkloadSpread.Subset == subset2.Name {
+						subset2Pods++
+						gomega.Expect(injectWorkloadSpread.Name).To(gomega.Equal(workloadSpread.Name))
+						gomega.Expect(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions).To(gomega.Equal(subset2.RequiredNodeSelectorTerm.MatchExpressions))
+						gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal("100"))
+					}
+				} else {
+					// others PodDeletionCostAnnotation not set
+					gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal(""))
+				}
+			}
+			gomega.Expect(subset1Pods).To(gomega.Equal(3))
+			gomega.Expect(subset2Pods).To(gomega.Equal(3))
+
+			workloadSpread, err = kc.AppsV1alpha1().WorkloadSpreads(workloadSpread.Namespace).Get(context.TODO(), workloadSpread.Name, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(workloadSpread.Status.SubsetStatuses[0].Name).To(gomega.Equal(workloadSpread.Spec.Subsets[0].Name))
+			gomega.Expect(workloadSpread.Status.SubsetStatuses[0].MissingReplicas).To(gomega.Equal(int32(0)))
+			gomega.Expect(workloadSpread.Status.SubsetStatuses[0].Replicas).To(gomega.Equal(int32(3)))
+			gomega.Expect(len(workloadSpread.Status.SubsetStatuses[0].CreatingPods)).To(gomega.Equal(0))
+			gomega.Expect(len(workloadSpread.Status.SubsetStatuses[0].DeletingPods)).To(gomega.Equal(0))
+			gomega.Expect(workloadSpread.Status.SubsetStatuses[1].Name).To(gomega.Equal(workloadSpread.Spec.Subsets[1].Name))
+			gomega.Expect(workloadSpread.Status.SubsetStatuses[1].MissingReplicas).To(gomega.Equal(int32(0)))
+			gomega.Expect(workloadSpread.Status.SubsetStatuses[1].Replicas).To(gomega.Equal(int32(3)))
+			gomega.Expect(len(workloadSpread.Status.SubsetStatuses[1].CreatingPods)).To(gomega.Equal(0))
+			gomega.Expect(len(workloadSpread.Status.SubsetStatuses[1].DeletingPods)).To(gomega.Equal(0))
+
+			// update cloneset image
+			ginkgo.By(fmt.Sprintf("update cloneSet(%s/%s) image=%s", cloneSet.Namespace, cloneSet.Name, "nginx:alpine"))
+			cloneSet.Spec.Template.Spec.Containers[0].Image = "nginx:alpine"
+			tester.UpdateCloneSet(cloneSet)
+			tester.WaitForCloneSetRunning(cloneSet)
+
+			// get pods, and check workloadSpread
+			ginkgo.By(fmt.Sprintf("get cloneSet(%s/%s) pods, and check workloadSpread(%s/%s) status", cloneSet.Namespace, cloneSet.Name, workloadSpread.Namespace, workloadSpread.Name))
+			pods, err = tester.GetSelectorPods(cloneSet.Namespace, cloneSet.Spec.Selector)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(pods).To(gomega.HaveLen(6))
+			subset1Pods = 0
+			subset2Pods = 0
+			for _, pod := range pods {
+				if str, ok := pod.Annotations[workloadspread.MatchedWorkloadSpreadSubsetAnnotations]; ok {
+					var injectWorkloadSpread *workloadspread.InjectWorkloadSpread
+					err := json.Unmarshal([]byte(str), &injectWorkloadSpread)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					if injectWorkloadSpread.Subset == subset1.Name {
+						subset1Pods++
+						gomega.Expect(injectWorkloadSpread.Name).To(gomega.Equal(workloadSpread.Name))
+						gomega.Expect(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions).To(gomega.Equal(subset1.RequiredNodeSelectorTerm.MatchExpressions))
+						gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal("200"))
+					} else if injectWorkloadSpread.Subset == subset2.Name {
+						subset2Pods++
+						gomega.Expect(injectWorkloadSpread.Name).To(gomega.Equal(workloadSpread.Name))
+						gomega.Expect(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions).To(gomega.Equal(subset2.RequiredNodeSelectorTerm.MatchExpressions))
+						gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal("100"))
+					}
+				} else {
+					// others PodDeletionCostAnnotation not set
+					gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal(""))
+				}
+			}
+			gomega.Expect(subset1Pods).To(gomega.Equal(3))
+			gomega.Expect(subset2Pods).To(gomega.Equal(3))
+
+			workloadSpread, err = kc.AppsV1alpha1().WorkloadSpreads(workloadSpread.Namespace).Get(context.TODO(), workloadSpread.Name, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(workloadSpread.Status.SubsetStatuses[0].Name).To(gomega.Equal(workloadSpread.Spec.Subsets[0].Name))
+			gomega.Expect(workloadSpread.Status.SubsetStatuses[0].MissingReplicas).To(gomega.Equal(int32(0)))
+			gomega.Expect(workloadSpread.Status.SubsetStatuses[0].Replicas).To(gomega.Equal(int32(3)))
+			gomega.Expect(len(workloadSpread.Status.SubsetStatuses[0].CreatingPods)).To(gomega.Equal(0))
+			gomega.Expect(len(workloadSpread.Status.SubsetStatuses[0].DeletingPods)).To(gomega.Equal(0))
+			gomega.Expect(workloadSpread.Status.SubsetStatuses[1].Name).To(gomega.Equal(workloadSpread.Spec.Subsets[1].Name))
+			gomega.Expect(workloadSpread.Status.SubsetStatuses[1].MissingReplicas).To(gomega.Equal(int32(0)))
+			gomega.Expect(workloadSpread.Status.SubsetStatuses[1].Replicas).To(gomega.Equal(int32(3)))
+			gomega.Expect(len(workloadSpread.Status.SubsetStatuses[1].CreatingPods)).To(gomega.Equal(0))
+			gomega.Expect(len(workloadSpread.Status.SubsetStatuses[1].DeletingPods)).To(gomega.Equal(0))
+
+			//scale down cloneSet.replicas = 4, maxReplicas = 2.
+			ginkgo.By(fmt.Sprintf("scale up cloneSet(%s/%s) replicas=4", cloneSet.Namespace, cloneSet.Name))
+			workloadSpread.Spec.Subsets[0].MaxReplicas.IntVal = 2
+			workloadSpread.Spec.Subsets[1].MaxReplicas.IntVal = 2
+			tester.UpdateWorkloadSpread(workloadSpread)
+
+			cloneSet.Spec.Replicas = pointer.Int32Ptr(4)
+			tester.UpdateCloneSet(cloneSet)
+			tester.WaitForCloneSetRunning(cloneSet)
+
+			// get pods, and check workloadSpread
+			ginkgo.By(fmt.Sprintf("get cloneSet(%s/%s) pods, and check workloadSpread(%s/%s) status", cloneSet.Namespace, cloneSet.Name, workloadSpread.Namespace, workloadSpread.Name))
+			pods, err = tester.GetSelectorPods(cloneSet.Namespace, cloneSet.Spec.Selector)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(pods).To(gomega.HaveLen(4))
+			subset1Pods = 0
+			subset2Pods = 0
+			for _, pod := range pods {
+				if str, ok := pod.Annotations[workloadspread.MatchedWorkloadSpreadSubsetAnnotations]; ok {
+					var injectWorkloadSpread *workloadspread.InjectWorkloadSpread
+					err := json.Unmarshal([]byte(str), &injectWorkloadSpread)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					if injectWorkloadSpread.Subset == subset1.Name {
+						subset1Pods++
+						gomega.Expect(injectWorkloadSpread.Name).To(gomega.Equal(workloadSpread.Name))
+						gomega.Expect(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions).To(gomega.Equal(subset1.RequiredNodeSelectorTerm.MatchExpressions))
+						gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal("200"))
+					} else if injectWorkloadSpread.Subset == subset2.Name {
+						subset2Pods++
+						gomega.Expect(injectWorkloadSpread.Name).To(gomega.Equal(workloadSpread.Name))
+						gomega.Expect(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions).To(gomega.Equal(subset2.RequiredNodeSelectorTerm.MatchExpressions))
+						gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal("100"))
+					}
+				} else {
+					// others PodDeletionCostAnnotation not set
+					gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal(""))
+				}
+			}
+			gomega.Expect(subset1Pods).To(gomega.Equal(2))
+			gomega.Expect(subset2Pods).To(gomega.Equal(2))
+
+			workloadSpread, err = kc.AppsV1alpha1().WorkloadSpreads(workloadSpread.Namespace).Get(context.TODO(), workloadSpread.Name, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			gomega.Expect(workloadSpread.Status.SubsetStatuses[0].Name).To(gomega.Equal(workloadSpread.Spec.Subsets[0].Name))
+			gomega.Expect(workloadSpread.Status.SubsetStatuses[0].MissingReplicas).To(gomega.Equal(int32(0)))
+			gomega.Expect(workloadSpread.Status.SubsetStatuses[0].Replicas).To(gomega.Equal(int32(2)))
+			gomega.Expect(len(workloadSpread.Status.SubsetStatuses[0].CreatingPods)).To(gomega.Equal(0))
+			gomega.Expect(len(workloadSpread.Status.SubsetStatuses[0].DeletingPods)).To(gomega.Equal(0))
+			gomega.Expect(workloadSpread.Status.SubsetStatuses[1].Name).To(gomega.Equal(workloadSpread.Spec.Subsets[1].Name))
+			gomega.Expect(workloadSpread.Status.SubsetStatuses[1].MissingReplicas).To(gomega.Equal(int32(0)))
+			gomega.Expect(workloadSpread.Status.SubsetStatuses[1].Replicas).To(gomega.Equal(int32(2)))
+			gomega.Expect(len(workloadSpread.Status.SubsetStatuses[1].CreatingPods)).To(gomega.Equal(0))
+			gomega.Expect(len(workloadSpread.Status.SubsetStatuses[1].DeletingPods)).To(gomega.Equal(0))
+
+			//scale up cloneSet.replicas = 8
+			ginkgo.By(fmt.Sprintf("scale up cloneSet(%s/%s) replicas=8, maxReplicas=4", cloneSet.Namespace, cloneSet.Name))
+			workloadSpread.Spec.Subsets[0].MaxReplicas.IntVal = 4
+			workloadSpread.Spec.Subsets[1].MaxReplicas.IntVal = 4
+			tester.UpdateWorkloadSpread(workloadSpread)
+			cloneSet.Spec.Replicas = pointer.Int32Ptr(8)
+			tester.UpdateCloneSet(cloneSet)
+			tester.WaitForCloneSetRunning(cloneSet)
+
+			// get pods, and check workloadSpread
+			ginkgo.By(fmt.Sprintf("get cloneSet(%s/%s) pods, and check workloadSpread(%s/%s) status", cloneSet.Namespace, cloneSet.Name, workloadSpread.Namespace, workloadSpread.Name))
+			pods, err = tester.GetSelectorPods(cloneSet.Namespace, cloneSet.Spec.Selector)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(pods).To(gomega.HaveLen(8))
+			subset1Pods = 0
+			subset2Pods = 0
+			for _, pod := range pods {
+				if str, ok := pod.Annotations[workloadspread.MatchedWorkloadSpreadSubsetAnnotations]; ok {
+					var injectWorkloadSpread *workloadspread.InjectWorkloadSpread
+					err := json.Unmarshal([]byte(str), &injectWorkloadSpread)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					if injectWorkloadSpread.Subset == subset1.Name {
+						subset1Pods++
+						gomega.Expect(injectWorkloadSpread.Name).To(gomega.Equal(workloadSpread.Name))
+						gomega.Expect(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions).To(gomega.Equal(subset1.RequiredNodeSelectorTerm.MatchExpressions))
+						gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal("200"))
+					} else if injectWorkloadSpread.Subset == subset2.Name {
+						subset2Pods++
+						gomega.Expect(injectWorkloadSpread.Name).To(gomega.Equal(workloadSpread.Name))
+						gomega.Expect(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions).To(gomega.Equal(subset2.RequiredNodeSelectorTerm.MatchExpressions))
+						gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal("100"))
+					}
+				} else {
+					// others PodDeletionCostAnnotation not set
+					gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal(""))
+				}
+			}
+			gomega.Expect(subset1Pods).To(gomega.Equal(4))
+			gomega.Expect(subset2Pods).To(gomega.Equal(4))
+
+			workloadSpread, err = kc.AppsV1alpha1().WorkloadSpreads(workloadSpread.Namespace).Get(context.TODO(), workloadSpread.Name, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			gomega.Expect(workloadSpread.Status.SubsetStatuses[0].Name).To(gomega.Equal(workloadSpread.Spec.Subsets[0].Name))
+			gomega.Expect(workloadSpread.Status.SubsetStatuses[0].MissingReplicas).To(gomega.Equal(int32(0)))
+			gomega.Expect(workloadSpread.Status.SubsetStatuses[0].Replicas).To(gomega.Equal(int32(4)))
+			gomega.Expect(len(workloadSpread.Status.SubsetStatuses[0].CreatingPods)).To(gomega.Equal(0))
+			gomega.Expect(len(workloadSpread.Status.SubsetStatuses[0].DeletingPods)).To(gomega.Equal(0))
+			gomega.Expect(workloadSpread.Status.SubsetStatuses[1].Name).To(gomega.Equal(workloadSpread.Spec.Subsets[1].Name))
+			gomega.Expect(workloadSpread.Status.SubsetStatuses[1].MissingReplicas).To(gomega.Equal(int32(0)))
+			gomega.Expect(workloadSpread.Status.SubsetStatuses[1].Replicas).To(gomega.Equal(int32(4)))
+			gomega.Expect(len(workloadSpread.Status.SubsetStatuses[1].CreatingPods)).To(gomega.Equal(0))
+			gomega.Expect(len(workloadSpread.Status.SubsetStatuses[1].DeletingPods)).To(gomega.Equal(0))
+
+			ginkgo.By("deploy in two zone, the type of maxReplicas is Integer, done")
+		})
+
+		ginkgo.It("elastic deployment, ack=2, eci=nil", func() {
+			cloneSet := tester.NewBaseCloneSet(ns)
+			// create workloadSpread
+			targetRef := appsv1alpha1.TargetReference{
+				APIVersion: KruiseKindCloneSet.GroupVersion().String(),
+				Kind:       KruiseKindCloneSet.Kind,
+				Name:       cloneSet.Name,
+			}
+			subset1 := appsv1alpha1.WorkloadSpreadSubset{
+				Name: "ack",
+				RequiredNodeSelectorTerm: &corev1.NodeSelectorTerm{
+					MatchExpressions: []corev1.NodeSelectorRequirement{
+						{
+							Key:      "topology.kubernetes.io/zone",
+							Operator: corev1.NodeSelectorOpIn,
+							Values:   []string{"ack"},
+						},
+					},
+				},
+				MaxReplicas: &intstr.IntOrString{Type: intstr.Int, IntVal: 2},
+				Patch: runtime.RawExtension{
+					Raw: []byte(`{"metadata":{"annotations":{"subset":"ack"}}}`),
+				},
+			}
+			subset2 := appsv1alpha1.WorkloadSpreadSubset{
+				Name: "eci",
+				RequiredNodeSelectorTerm: &corev1.NodeSelectorTerm{
+					MatchExpressions: []corev1.NodeSelectorRequirement{
+						{
+							Key:      "topology.kubernetes.io/zone",
+							Operator: corev1.NodeSelectorOpIn,
+							Values:   []string{"eci"},
+						},
+					},
+				},
+				MaxReplicas: nil,
+				Patch: runtime.RawExtension{
+					Raw: []byte(`{"metadata":{"annotations":{"subset":"eci"}}}`),
+				},
+			}
+			workloadSpread := tester.NewWorkloadSpread(ns, workloadSpreadName, &targetRef, []appsv1alpha1.WorkloadSpreadSubset{subset1, subset2})
+			workloadSpread = tester.CreateWorkloadSpread(workloadSpread)
+
+			// create cloneset, replicas = 2
+			cloneSet.Spec.Template.Spec.Containers[0].Image = "busybox:latest"
+			cloneSet = tester.CreateCloneSet(cloneSet)
+			tester.WaitForCloneSetRunning(cloneSet)
+
+			// get pods, and check workloadSpread
+			ginkgo.By(fmt.Sprintf("get cloneSet(%s/%s) pods, and check workloadSpread(%s/%s) status", cloneSet.Namespace, cloneSet.Name, workloadSpread.Namespace, workloadSpread.Name))
+			pods, err := tester.GetSelectorPods(cloneSet.Namespace, cloneSet.Spec.Selector)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(pods).To(gomega.HaveLen(2))
+			subset1Pods := 0
+			subset2Pods := 0
+			for _, pod := range pods {
+				if str, ok := pod.Annotations[workloadspread.MatchedWorkloadSpreadSubsetAnnotations]; ok {
+					var injectWorkloadSpread *workloadspread.InjectWorkloadSpread
+					err := json.Unmarshal([]byte(str), &injectWorkloadSpread)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					if injectWorkloadSpread.Subset == subset1.Name {
+						subset1Pods++
+						gomega.Expect(injectWorkloadSpread.Name).To(gomega.Equal(workloadSpread.Name))
+						gomega.Expect(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions).To(gomega.Equal(subset1.RequiredNodeSelectorTerm.MatchExpressions))
+						gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal("200"))
+					} else if injectWorkloadSpread.Subset == subset2.Name {
+						subset2Pods++
+						gomega.Expect(injectWorkloadSpread.Name).To(gomega.Equal(workloadSpread.Name))
+						gomega.Expect(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions).To(gomega.Equal(subset2.RequiredNodeSelectorTerm.MatchExpressions))
+						gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal("100"))
+					}
+				} else {
+					// others PodDeletionCostAnnotation not set
+					gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal(""))
+				}
+			}
+			gomega.Expect(subset1Pods).To(gomega.Equal(2))
+			gomega.Expect(subset2Pods).To(gomega.Equal(0))
+
+			workloadSpread, err = kc.AppsV1alpha1().WorkloadSpreads(workloadSpread.Namespace).Get(context.TODO(), workloadSpread.Name, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			gomega.Expect(workloadSpread.Status.SubsetStatuses[0].Name).To(gomega.Equal(workloadSpread.Spec.Subsets[0].Name))
+			gomega.Expect(workloadSpread.Status.SubsetStatuses[0].MissingReplicas).To(gomega.Equal(int32(0)))
+			gomega.Expect(workloadSpread.Status.SubsetStatuses[0].Replicas).To(gomega.Equal(int32(2)))
+			gomega.Expect(len(workloadSpread.Status.SubsetStatuses[0].CreatingPods)).To(gomega.Equal(0))
+			gomega.Expect(len(workloadSpread.Status.SubsetStatuses[0].DeletingPods)).To(gomega.Equal(0))
+			gomega.Expect(workloadSpread.Status.SubsetStatuses[1].Name).To(gomega.Equal(workloadSpread.Spec.Subsets[1].Name))
+			gomega.Expect(workloadSpread.Status.SubsetStatuses[1].MissingReplicas).To(gomega.Equal(int32(-1)))
+			gomega.Expect(workloadSpread.Status.SubsetStatuses[1].Replicas).To(gomega.Equal(int32(0)))
+			gomega.Expect(len(workloadSpread.Status.SubsetStatuses[1].CreatingPods)).To(gomega.Equal(0))
+			gomega.Expect(len(workloadSpread.Status.SubsetStatuses[1].DeletingPods)).To(gomega.Equal(0))
+
+			//scale up cloneSet.replicas = 6
+			ginkgo.By(fmt.Sprintf("scale up cloneSet(%s/%s) replicas=6", cloneSet.Namespace, cloneSet.Name))
+			cloneSet.Spec.Replicas = pointer.Int32Ptr(6)
+			tester.UpdateCloneSet(cloneSet)
+			tester.WaitForCloneSetRunning(cloneSet)
+
+			// get pods, and check workloadSpread
+			ginkgo.By(fmt.Sprintf("get cloneSet(%s/%s) pods, and check workloadSpread(%s/%s) status", cloneSet.Namespace, cloneSet.Name, workloadSpread.Namespace, workloadSpread.Name))
+			pods, err = tester.GetSelectorPods(cloneSet.Namespace, cloneSet.Spec.Selector)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(pods).To(gomega.HaveLen(6))
+			subset1Pods = 0
+			subset2Pods = 0
+			for _, pod := range pods {
+				if str, ok := pod.Annotations[workloadspread.MatchedWorkloadSpreadSubsetAnnotations]; ok {
+					var injectWorkloadSpread *workloadspread.InjectWorkloadSpread
+					err := json.Unmarshal([]byte(str), &injectWorkloadSpread)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					if injectWorkloadSpread.Subset == subset1.Name {
+						subset1Pods++
+						gomega.Expect(injectWorkloadSpread.Name).To(gomega.Equal(workloadSpread.Name))
+						gomega.Expect(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions).To(gomega.Equal(subset1.RequiredNodeSelectorTerm.MatchExpressions))
+						gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal("200"))
+					} else if injectWorkloadSpread.Subset == subset2.Name {
+						subset2Pods++
+						gomega.Expect(injectWorkloadSpread.Name).To(gomega.Equal(workloadSpread.Name))
+						gomega.Expect(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions).To(gomega.Equal(subset2.RequiredNodeSelectorTerm.MatchExpressions))
+						gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal("100"))
+					}
+				} else {
+					// others PodDeletionCostAnnotation not set
+					gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal(""))
+				}
+			}
+			gomega.Expect(subset1Pods).To(gomega.Equal(2))
+			gomega.Expect(subset2Pods).To(gomega.Equal(4))
+
+			workloadSpread, err = kc.AppsV1alpha1().WorkloadSpreads(workloadSpread.Namespace).Get(context.TODO(), workloadSpread.Name, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			gomega.Expect(workloadSpread.Status.SubsetStatuses[0].Name).To(gomega.Equal(workloadSpread.Spec.Subsets[0].Name))
+			gomega.Expect(workloadSpread.Status.SubsetStatuses[0].MissingReplicas).To(gomega.Equal(int32(0)))
+			gomega.Expect(workloadSpread.Status.SubsetStatuses[0].Replicas).To(gomega.Equal(int32(2)))
+			gomega.Expect(len(workloadSpread.Status.SubsetStatuses[0].CreatingPods)).To(gomega.Equal(0))
+			gomega.Expect(len(workloadSpread.Status.SubsetStatuses[0].DeletingPods)).To(gomega.Equal(0))
+			gomega.Expect(workloadSpread.Status.SubsetStatuses[1].Name).To(gomega.Equal(workloadSpread.Spec.Subsets[1].Name))
+			gomega.Expect(workloadSpread.Status.SubsetStatuses[1].MissingReplicas).To(gomega.Equal(int32(-1)))
+			gomega.Expect(workloadSpread.Status.SubsetStatuses[1].Replicas).To(gomega.Equal(int32(4)))
+			gomega.Expect(len(workloadSpread.Status.SubsetStatuses[1].CreatingPods)).To(gomega.Equal(0))
+			gomega.Expect(len(workloadSpread.Status.SubsetStatuses[1].DeletingPods)).To(gomega.Equal(0))
+
+			// update cloneset image
+			ginkgo.By(fmt.Sprintf("update cloneSet(%s/%s) image=%s", cloneSet.Namespace, cloneSet.Name, "nginx:alpine"))
+			cloneSet.Spec.Template.Spec.Containers[0].Image = "nginx:alpine"
+			tester.UpdateCloneSet(cloneSet)
+			tester.WaitForCloneSetRunning(cloneSet)
+
+			// get pods, and check workloadSpread
+			ginkgo.By(fmt.Sprintf("get cloneSet(%s/%s) pods, and check workloadSpread(%s/%s) status", cloneSet.Namespace, cloneSet.Name, workloadSpread.Namespace, workloadSpread.Name))
+			pods, err = tester.GetSelectorPods(cloneSet.Namespace, cloneSet.Spec.Selector)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(pods).To(gomega.HaveLen(6))
+			subset1Pods = 0
+			subset2Pods = 0
+			for _, pod := range pods {
+				if str, ok := pod.Annotations[workloadspread.MatchedWorkloadSpreadSubsetAnnotations]; ok {
+					var injectWorkloadSpread *workloadspread.InjectWorkloadSpread
+					err := json.Unmarshal([]byte(str), &injectWorkloadSpread)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					if injectWorkloadSpread.Subset == subset1.Name {
+						subset1Pods++
+						gomega.Expect(injectWorkloadSpread.Name).To(gomega.Equal(workloadSpread.Name))
+						gomega.Expect(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions).To(gomega.Equal(subset1.RequiredNodeSelectorTerm.MatchExpressions))
+						gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal("200"))
+					} else if injectWorkloadSpread.Subset == subset2.Name {
+						subset2Pods++
+						gomega.Expect(injectWorkloadSpread.Name).To(gomega.Equal(workloadSpread.Name))
+						gomega.Expect(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions).To(gomega.Equal(subset2.RequiredNodeSelectorTerm.MatchExpressions))
+						gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal("100"))
+					}
+				} else {
+					// others PodDeletionCostAnnotation not set
+					gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal(""))
+				}
+			}
+			gomega.Expect(subset1Pods).To(gomega.Equal(2))
+			gomega.Expect(subset2Pods).To(gomega.Equal(4))
+
+			workloadSpread, err = kc.AppsV1alpha1().WorkloadSpreads(workloadSpread.Namespace).Get(context.TODO(), workloadSpread.Name, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			gomega.Expect(workloadSpread.Status.SubsetStatuses[0].Name).To(gomega.Equal(workloadSpread.Spec.Subsets[0].Name))
+			gomega.Expect(workloadSpread.Status.SubsetStatuses[0].MissingReplicas).To(gomega.Equal(int32(0)))
+			gomega.Expect(workloadSpread.Status.SubsetStatuses[0].Replicas).To(gomega.Equal(int32(2)))
+			gomega.Expect(len(workloadSpread.Status.SubsetStatuses[0].CreatingPods)).To(gomega.Equal(0))
+			gomega.Expect(len(workloadSpread.Status.SubsetStatuses[0].DeletingPods)).To(gomega.Equal(0))
+			gomega.Expect(workloadSpread.Status.SubsetStatuses[1].Name).To(gomega.Equal(workloadSpread.Spec.Subsets[1].Name))
+			gomega.Expect(workloadSpread.Status.SubsetStatuses[1].MissingReplicas).To(gomega.Equal(int32(-1)))
+			gomega.Expect(workloadSpread.Status.SubsetStatuses[1].Replicas).To(gomega.Equal(int32(4)))
+			gomega.Expect(len(workloadSpread.Status.SubsetStatuses[1].CreatingPods)).To(gomega.Equal(0))
+			gomega.Expect(len(workloadSpread.Status.SubsetStatuses[1].DeletingPods)).To(gomega.Equal(0))
+
+			//scale down cloneSet.replicas = 2
+			ginkgo.By(fmt.Sprintf("scale down cloneSet(%s/%s) replicas=2", cloneSet.Namespace, cloneSet.Name))
+			cloneSet.Spec.Replicas = pointer.Int32Ptr(2)
+			tester.UpdateCloneSet(cloneSet)
+			tester.WaitForCloneSetRunning(cloneSet)
+
+			// get pods, and check workloadSpread
+			ginkgo.By(fmt.Sprintf("get cloneSet(%s/%s) pods, and check workloadSpread(%s/%s) status", cloneSet.Namespace, cloneSet.Name, workloadSpread.Namespace, workloadSpread.Name))
+			pods, err = tester.GetSelectorPods(cloneSet.Namespace, cloneSet.Spec.Selector)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(pods).To(gomega.HaveLen(2))
+			subset1Pods = 0
+			subset2Pods = 0
+			for _, pod := range pods {
+				if str, ok := pod.Annotations[workloadspread.MatchedWorkloadSpreadSubsetAnnotations]; ok {
+					var injectWorkloadSpread *workloadspread.InjectWorkloadSpread
+					err := json.Unmarshal([]byte(str), &injectWorkloadSpread)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					if injectWorkloadSpread.Subset == subset1.Name {
+						subset1Pods++
+						gomega.Expect(injectWorkloadSpread.Name).To(gomega.Equal(workloadSpread.Name))
+						gomega.Expect(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions).To(gomega.Equal(subset1.RequiredNodeSelectorTerm.MatchExpressions))
+						gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal("200"))
+					} else if injectWorkloadSpread.Subset == subset2.Name {
+						subset2Pods++
+						gomega.Expect(injectWorkloadSpread.Name).To(gomega.Equal(workloadSpread.Name))
+						gomega.Expect(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions).To(gomega.Equal(subset2.RequiredNodeSelectorTerm.MatchExpressions))
+						gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal("100"))
+					}
+				} else {
+					// others PodDeletionCostAnnotation not set
+					gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal(""))
+				}
+			}
+			gomega.Expect(subset1Pods).To(gomega.Equal(2))
+			gomega.Expect(subset2Pods).To(gomega.Equal(0))
+
+			workloadSpread, err = kc.AppsV1alpha1().WorkloadSpreads(workloadSpread.Namespace).Get(context.TODO(), workloadSpread.Name, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			gomega.Expect(workloadSpread.Status.SubsetStatuses[0].Name).To(gomega.Equal(workloadSpread.Spec.Subsets[0].Name))
+			gomega.Expect(workloadSpread.Status.SubsetStatuses[0].MissingReplicas).To(gomega.Equal(int32(0)))
+			gomega.Expect(workloadSpread.Status.SubsetStatuses[0].Replicas).To(gomega.Equal(int32(2)))
+			gomega.Expect(len(workloadSpread.Status.SubsetStatuses[0].CreatingPods)).To(gomega.Equal(0))
+			gomega.Expect(len(workloadSpread.Status.SubsetStatuses[0].DeletingPods)).To(gomega.Equal(0))
+			gomega.Expect(workloadSpread.Status.SubsetStatuses[1].Name).To(gomega.Equal(workloadSpread.Spec.Subsets[1].Name))
+			gomega.Expect(workloadSpread.Status.SubsetStatuses[1].MissingReplicas).To(gomega.Equal(int32(-1)))
+			gomega.Expect(workloadSpread.Status.SubsetStatuses[1].Replicas).To(gomega.Equal(int32(0)))
+			gomega.Expect(len(workloadSpread.Status.SubsetStatuses[1].CreatingPods)).To(gomega.Equal(0))
+			gomega.Expect(len(workloadSpread.Status.SubsetStatuses[1].DeletingPods)).To(gomega.Equal(0))
+
+			ginkgo.By("elastic deployment, ack=2, eci=nil, done")
+		})
+
+		ginkgo.It("reschedule subset-a", func() {
+			cloneSet := tester.NewBaseCloneSet(ns)
+			// create workloadSpread
+			targetRef := appsv1alpha1.TargetReference{
+				APIVersion: KruiseKindCloneSet.GroupVersion().String(),
+				Kind:       KruiseKindCloneSet.Kind,
+				Name:       cloneSet.Name,
+			}
+			subset1 := appsv1alpha1.WorkloadSpreadSubset{
+				Name: "subset-a",
+				RequiredNodeSelectorTerm: &corev1.NodeSelectorTerm{
+					MatchExpressions: []corev1.NodeSelectorRequirement{
+						{
+							Key:      "topology.kubernetes.io/zone",
+							Operator: corev1.NodeSelectorOpIn,
+							// Pod is not schedulable due to incorrect configuration
+							Values: []string{"asi"},
+						},
+					},
+				},
+				MaxReplicas: &intstr.IntOrString{Type: intstr.Int, IntVal: 2},
+				Patch: runtime.RawExtension{
+					Raw: []byte(`{"metadata":{"annotations":{"subset":"subset-a"}}}`),
+				},
+			}
+			subset2 := appsv1alpha1.WorkloadSpreadSubset{
+				Name: "subset-b",
+				RequiredNodeSelectorTerm: &corev1.NodeSelectorTerm{
+					MatchExpressions: []corev1.NodeSelectorRequirement{
+						{
+							Key:      "topology.kubernetes.io/zone",
+							Operator: corev1.NodeSelectorOpIn,
+							Values:   []string{"eci"},
+						},
+					},
+				},
+				Patch: runtime.RawExtension{
+					Raw: []byte(`{"metadata":{"annotations":{"subset":"subset-b"}}}`),
+				},
+			}
+			workloadSpread := tester.NewWorkloadSpread(ns, workloadSpreadName, &targetRef, []appsv1alpha1.WorkloadSpreadSubset{subset1, subset2})
+			workloadSpread.Spec.ScheduleStrategy = appsv1alpha1.WorkloadSpreadScheduleStrategy{
+				Type: appsv1alpha1.FixedWorkloadSpreadScheduleStrategyType,
+			}
+			workloadSpread = tester.CreateWorkloadSpread(workloadSpread)
+
+			// create cloneset, replicas = 5
+			cloneSet.Spec.Replicas = pointer.Int32Ptr(5)
+			cloneSet.Spec.Template.Spec.Containers[0].Image = "busybox:latest"
+			cloneSet = tester.CreateCloneSet(cloneSet)
+			tester.WaitForCloneSetRunReplicas(cloneSet, int32(3))
+
+			// get pods, and check workloadSpread
+			ginkgo.By(fmt.Sprintf("get cloneSet(%s/%s) pods, and check workloadSpread(%s/%s) status", cloneSet.Namespace, cloneSet.Name, workloadSpread.Namespace, workloadSpread.Name))
+			pods, err := tester.GetSelectorPods(cloneSet.Namespace, cloneSet.Spec.Selector)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(pods).To(gomega.HaveLen(5))
+			subset1Pods := 0
+			subset1RunningPods := 0
+			subset2Pods := 0
+			subset2RunningPods := 0
+			for _, pod := range pods {
+				if str, ok := pod.Annotations[workloadspread.MatchedWorkloadSpreadSubsetAnnotations]; ok {
+					var injectWorkloadSpread *workloadspread.InjectWorkloadSpread
+					err := json.Unmarshal([]byte(str), &injectWorkloadSpread)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					if injectWorkloadSpread.Subset == subset1.Name {
+						subset1Pods++
+						if pod.Status.Phase == corev1.PodRunning {
+							subset1RunningPods++
+						}
+						gomega.Expect(injectWorkloadSpread.Name).To(gomega.Equal(workloadSpread.Name))
+						gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal("200"))
+						gomega.Expect(pod.Annotations["subset"]).To(gomega.Equal(subset1.Name))
+					} else if injectWorkloadSpread.Subset == subset2.Name {
+						subset2Pods++
+						if pod.Status.Phase == corev1.PodRunning {
+							subset2RunningPods++
+						}
+						gomega.Expect(injectWorkloadSpread.Name).To(gomega.Equal(workloadSpread.Name))
+						gomega.Expect(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions).To(gomega.Equal(subset2.RequiredNodeSelectorTerm.MatchExpressions))
+						gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal("100"))
+						gomega.Expect(pod.Annotations["subset"]).To(gomega.Equal(subset2.Name))
+					}
+				} else {
+					// others PodDeletionCostAnnotation not set
+					gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal(""))
+				}
+			}
+			gomega.Expect(subset1Pods).To(gomega.Equal(2))
+			gomega.Expect(subset1RunningPods).To(gomega.Equal(0))
+			gomega.Expect(subset2Pods).To(gomega.Equal(3))
+			gomega.Expect(subset2RunningPods).To(gomega.Equal(3))
+
+			// check workloadSpread status
+			ginkgo.By(fmt.Sprintf("check workloadSpread(%s/%s) status", workloadSpread.Namespace, workloadSpread.Name))
+			workloadSpread, err = kc.AppsV1alpha1().WorkloadSpreads(workloadSpread.Namespace).Get(context.TODO(), workloadSpread.Name, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			gomega.Expect(workloadSpread.Status.SubsetStatuses[0].Name).To(gomega.Equal(workloadSpread.Spec.Subsets[0].Name))
+			gomega.Expect(workloadSpread.Status.SubsetStatuses[0].MissingReplicas).To(gomega.Equal(int32(0)))
+			gomega.Expect(workloadSpread.Status.SubsetStatuses[0].Replicas).To(gomega.Equal(int32(2)))
+			gomega.Expect(len(workloadSpread.Status.SubsetStatuses[0].Conditions)).To(gomega.Equal(0))
+			gomega.Expect(workloadSpread.Status.SubsetStatuses[1].Name).To(gomega.Equal(workloadSpread.Spec.Subsets[1].Name))
+			gomega.Expect(workloadSpread.Status.SubsetStatuses[1].MissingReplicas).To(gomega.Equal(int32(-1)))
+			gomega.Expect(workloadSpread.Status.SubsetStatuses[1].Replicas).To(gomega.Equal(int32(3)))
+			gomega.Expect(len(workloadSpread.Status.SubsetStatuses[1].Conditions)).To(gomega.Equal(0))
+
+			// wait for subset schedulabe
+			ginkgo.By(fmt.Sprintf("wait workloadSpread(%s/%s) subset-a reschedulabe", workloadSpread.Namespace, workloadSpread.Name))
+			workloadSpread.Spec.ScheduleStrategy = appsv1alpha1.WorkloadSpreadScheduleStrategy{
+				Type: appsv1alpha1.AdaptiveWorkloadSpreadScheduleStrategyType,
+				Adaptive: &appsv1alpha1.AdaptiveWorkloadSpreadStrategy{
+					DisableSimulationSchedule: true,
+					RescheduleCriticalSeconds: pointer.Int32Ptr(5),
+				},
+			}
+			tester.UpdateWorkloadSpread(workloadSpread)
+			tester.WaitForWorkloadSpreadRunning(workloadSpread)
+
+			err = wait.PollImmediate(time.Second, time.Minute*6, func() (bool, error) {
+				ws, err := kc.AppsV1alpha1().WorkloadSpreads(workloadSpread.Namespace).Get(context.TODO(), workloadSpread.Name, metav1.GetOptions{})
+				if err != nil {
+					return false, err
+				}
+				for _, condition := range ws.Status.SubsetStatuses[0].Conditions {
+					if condition.Type == appsv1alpha1.SubsetSchedulable && condition.Status == corev1.ConditionFalse {
+						return true, nil
+					}
+				}
+				return false, nil
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// get pods, and check workloadSpread
+			ginkgo.By(fmt.Sprintf("get cloneSet(%s/%s) pods, and check workloadSpread(%s/%s) status", cloneSet.Namespace, cloneSet.Name, workloadSpread.Namespace, workloadSpread.Name))
+			tester.WaitForCloneSetRunReplicas(cloneSet, int32(5))
+			pods, err = tester.GetSelectorPods(cloneSet.Namespace, cloneSet.Spec.Selector)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(pods).To(gomega.HaveLen(5))
+			subset1Pods = 0
+			subset2Pods = 0
+			for _, pod := range pods {
+				if str, ok := pod.Annotations[workloadspread.MatchedWorkloadSpreadSubsetAnnotations]; ok {
+					var injectWorkloadSpread *workloadspread.InjectWorkloadSpread
+					err := json.Unmarshal([]byte(str), &injectWorkloadSpread)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					if injectWorkloadSpread.Subset == subset1.Name {
+						subset1Pods++
+					} else if injectWorkloadSpread.Subset == subset2.Name {
+						subset2Pods++
+						gomega.Expect(injectWorkloadSpread.Name).To(gomega.Equal(workloadSpread.Name))
+						gomega.Expect(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions).To(gomega.Equal(subset2.RequiredNodeSelectorTerm.MatchExpressions))
+						gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal("100"))
+						gomega.Expect(pod.Annotations["subset"]).To(gomega.Equal(subset2.Name))
+					}
+				} else {
+					// others PodDeletionCostAnnotation not set
+					gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal(""))
+				}
+			}
+			gomega.Expect(subset1Pods).To(gomega.Equal(0))
+			gomega.Expect(subset2Pods).To(gomega.Equal(5))
+
+			// wait subset-a to schedulable
+			ginkgo.By(fmt.Sprintf("wait subset-a to schedulable"))
+			err = wait.PollImmediate(time.Second, time.Minute*5, func() (bool, error) {
+				ws, err := kc.AppsV1alpha1().WorkloadSpreads(workloadSpread.Namespace).Get(context.TODO(), workloadSpread.Name, metav1.GetOptions{})
+				if err != nil {
+					return false, err
+				}
+				for _, condition := range ws.Status.SubsetStatuses[0].Conditions {
+					if condition.Type == appsv1alpha1.SubsetSchedulable && condition.Status == corev1.ConditionTrue {
+						return true, nil
+					}
+				}
+				return false, nil
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			ginkgo.By("workloadSpread reschedule subset-a, done")
+		})
+
+		//ginkgo.It("deploy in two zone, maxReplicas=50%", func() {
+		//	cloneSet := tester.NewBaseCloneSet(ns)
+		//	// create workloadSpread
+		//	targetRef := appsv1alpha1.TargetReference{
+		//		APIVersion: KruiseKindCloneSet.GroupVersion().String(),
+		//		Kind:       KruiseKindCloneSet.Kind,
+		//		Name:       cloneSet.Name,
+		//	}
+		//	subset1 := appsv1alpha1.WorkloadSpreadSubset{
+		//		Name: "ack",
+		//		RequiredNodeSelectorTerm: &corev1.NodeSelectorTerm{
+		//			MatchExpressions: []corev1.NodeSelectorRequirement{
+		//				{
+		//					Key:      "topology.kubernetes.io/zone",
+		//					Operator: corev1.NodeSelectorOpIn,
+		//					Values:   []string{"ack"},
+		//				},
+		//			},
+		//		},
+		//		MaxReplicas: &intstr.IntOrString{Type: intstr.String, StrVal: "50%"},
+		//		Patch: runtime.RawExtension{
+		//			Raw: []byte(`{"metadata":{"annotations":{"subset":"ack"}}}`),
+		//		},
+		//	}
+		//	subset2 := appsv1alpha1.WorkloadSpreadSubset{
+		//		Name: "eci",
+		//		RequiredNodeSelectorTerm: &corev1.NodeSelectorTerm{
+		//			MatchExpressions: []corev1.NodeSelectorRequirement{
+		//				{
+		//					Key:      "topology.kubernetes.io/zone",
+		//					Operator: corev1.NodeSelectorOpIn,
+		//					Values:   []string{"eci"},
+		//				},
+		//			},
+		//		},
+		//		MaxReplicas: &intstr.IntOrString{Type: intstr.String, StrVal: "50%"},
+		//		Patch: runtime.RawExtension{
+		//			Raw: []byte(`{"metadata":{"annotations":{"subset":"eci"}}}`),
+		//		},
+		//	}
+		//	workloadSpread := tester.NewWorkloadSpread(ns, workloadSpreadName, &targetRef, []appsv1alpha1.WorkloadSpreadSubset{subset1, subset2})
+		//	workloadSpread = tester.CreateWorkloadSpread(workloadSpread)
+		//
+		//	// create cloneset, replicas = 2
+		//	cloneSet.Spec.Template.Spec.Containers[0].Image = "busybox:latest"
+		//	cloneSet = tester.CreateCloneSet(cloneSet)
+		//	tester.WaitForCloneSetRunning(cloneSet)
+		//
+		//	// get pods, and check workloadSpread
+		//	ginkgo.By(fmt.Sprintf("get cloneSet(%s/%s) pods, and check workloadSpread(%s/%s) status", cloneSet.Namespace, cloneSet.Name, workloadSpread.Namespace, workloadSpread.Name))
+		//	pods, err := tester.GetSelectorPods(cloneSet.Namespace, cloneSet.Spec.Selector)
+		//	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		//	gomega.Expect(pods).To(gomega.HaveLen(2))
+		//	subset1Pods := 0
+		//	subset2Pods := 0
+		//	for _, pod := range pods {
+		//		if str, ok := pod.Annotations[workloadspread.MatchedWorkloadSpreadSubsetAnnotations]; ok {
+		//			var injectWorkloadSpread *workloadspread.InjectWorkloadSpread
+		//			err := json.Unmarshal([]byte(str), &injectWorkloadSpread)
+		//			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		//			if injectWorkloadSpread.Subset == subset1.Name {
+		//				subset1Pods++
+		//				gomega.Expect(injectWorkloadSpread.Name).To(gomega.Equal(workloadSpread.Name))
+		//				gomega.Expect(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions).To(gomega.Equal(subset1.RequiredNodeSelectorTerm.MatchExpressions))
+		//				gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal("200"))
+		//			} else if injectWorkloadSpread.Subset == subset2.Name {
+		//				subset2Pods++
+		//				gomega.Expect(injectWorkloadSpread.Name).To(gomega.Equal(workloadSpread.Name))
+		//				gomega.Expect(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions).To(gomega.Equal(subset2.RequiredNodeSelectorTerm.MatchExpressions))
+		//				gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal("100"))
+		//			}
+		//		} else {
+		//			// others PodDeletionCostAnnotation not set
+		//			gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal(""))
+		//		}
+		//	}
+		//	gomega.Expect(subset1Pods).To(gomega.Equal(1))
+		//	gomega.Expect(subset2Pods).To(gomega.Equal(1))
+		//
+		//	// update cloneset image
+		//	ginkgo.By(fmt.Sprintf("update cloneSet(%s/%s) image=%s", cloneSet.Namespace, cloneSet.Name, "nginx:alpine"))
+		//	cloneSet.Spec.Template.Spec.Containers[0].Image = "nginx:alpine"
+		//	tester.UpdateCloneSet(cloneSet)
+		//	tester.WaitForCloneSetRunning(cloneSet)
+		//
+		//	// get pods, and check workloadSpread
+		//	ginkgo.By(fmt.Sprintf("get cloneSet(%s/%s) pods, and check workloadSpread(%s/%s) status", cloneSet.Namespace, cloneSet.Name, workloadSpread.Namespace, workloadSpread.Name))
+		//	pods, err = tester.GetSelectorPods(cloneSet.Namespace, cloneSet.Spec.Selector)
+		//	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		//	gomega.Expect(pods).To(gomega.HaveLen(2))
+		//	subset1Pods = 0
+		//	subset2Pods = 0
+		//	for _, pod := range pods {
+		//		if str, ok := pod.Annotations[workloadspread.MatchedWorkloadSpreadSubsetAnnotations]; ok {
+		//			var injectWorkloadSpread *workloadspread.InjectWorkloadSpread
+		//			err := json.Unmarshal([]byte(str), &injectWorkloadSpread)
+		//			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		//			if injectWorkloadSpread.Subset == subset1.Name {
+		//				subset1Pods++
+		//				gomega.Expect(injectWorkloadSpread.Name).To(gomega.Equal(workloadSpread.Name))
+		//				gomega.Expect(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions).To(gomega.Equal(subset1.RequiredNodeSelectorTerm.MatchExpressions))
+		//				gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal("200"))
+		//			} else if injectWorkloadSpread.Subset == subset2.Name {
+		//				subset2Pods++
+		//				gomega.Expect(injectWorkloadSpread.Name).To(gomega.Equal(workloadSpread.Name))
+		//				gomega.Expect(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions).To(gomega.Equal(subset2.RequiredNodeSelectorTerm.MatchExpressions))
+		//				gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal("100"))
+		//			}
+		//		} else {
+		//			// others PodDeletionCostAnnotation not set
+		//			gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal(""))
+		//		}
+		//	}
+		//	gomega.Expect(subset1Pods).To(gomega.Equal(1))
+		//	gomega.Expect(subset2Pods).To(gomega.Equal(1))
+		//
+		//	//scale up cloneSet.replicas = 6
+		//	ginkgo.By(fmt.Sprintf("scale up cloneSet(%s/%s) replicas=6", cloneSet.Namespace, cloneSet.Name))
+		//	cloneSet.Spec.Replicas = pointer.Int32Ptr(6)
+		//	tester.UpdateCloneSet(cloneSet)
+		//	tester.WaitForCloneSetRunning(cloneSet)
+		//
+		//	// get pods, and check workloadSpread
+		//	ginkgo.By(fmt.Sprintf("get cloneSet(%s/%s) pods, and check workloadSpread(%s/%s) status", cloneSet.Namespace, cloneSet.Name, workloadSpread.Namespace, workloadSpread.Name))
+		//	pods, err = tester.GetSelectorPods(cloneSet.Namespace, cloneSet.Spec.Selector)
+		//	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		//	gomega.Expect(pods).To(gomega.HaveLen(6))
+		//	subset1Pods = 0
+		//	subset2Pods = 0
+		//	for _, pod := range pods {
+		//		if str, ok := pod.Annotations[workloadspread.MatchedWorkloadSpreadSubsetAnnotations]; ok {
+		//			var injectWorkloadSpread *workloadspread.InjectWorkloadSpread
+		//			err := json.Unmarshal([]byte(str), &injectWorkloadSpread)
+		//			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		//			if injectWorkloadSpread.Subset == subset1.Name {
+		//				subset1Pods++
+		//				gomega.Expect(injectWorkloadSpread.Name).To(gomega.Equal(workloadSpread.Name))
+		//				gomega.Expect(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions).To(gomega.Equal(subset1.RequiredNodeSelectorTerm.MatchExpressions))
+		//				gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal("200"))
+		//			} else if injectWorkloadSpread.Subset == subset2.Name {
+		//				subset2Pods++
+		//				gomega.Expect(injectWorkloadSpread.Name).To(gomega.Equal(workloadSpread.Name))
+		//				gomega.Expect(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions).To(gomega.Equal(subset2.RequiredNodeSelectorTerm.MatchExpressions))
+		//				gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal("100"))
+		//			}
+		//		} else {
+		//			// others PodDeletionCostAnnotation not set
+		//			gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal(""))
+		//		}
+		//	}
+		//	gomega.Expect(subset1Pods).To(gomega.Equal(3))
+		//	gomega.Expect(subset2Pods).To(gomega.Equal(3))
+		//
+		//	workloadSpread, err = kc.AppsV1alpha1().WorkloadSpreads(workloadSpread.Namespace).Get(workloadSpread.Name, metav1.GetOptions{})
+		//	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		//
+		//	gomega.Expect(workloadSpread.Status.SubsetStatuses[0].Name).To(gomega.Equal(workloadSpread.Spec.Subsets[0].Name))
+		//	gomega.Expect(workloadSpread.Status.SubsetStatuses[0].MissingReplicas).To(gomega.Equal(int32(0)))
+		//	gomega.Expect(len(workloadSpread.Status.SubsetStatuses[0].CreatingPods)).To(gomega.Equal(0))
+		//	gomega.Expect(len(workloadSpread.Status.SubsetStatuses[0].DeletingPods)).To(gomega.Equal(0))
+		//
+		//	//scale down cloneSet.replicas = 2
+		//	ginkgo.By(fmt.Sprintf("scale down cloneSet(%s/%s) replicas=2", cloneSet.Namespace, cloneSet.Name))
+		//	cloneSet.Spec.Replicas = pointer.Int32Ptr(2)
+		//	tester.UpdateCloneSet(cloneSet)
+		//	tester.WaitForCloneSetRunning(cloneSet)
+		//
+		//	// get pods, and check workloadSpread
+		//	ginkgo.By(fmt.Sprintf("get cloneSet(%s/%s) pods, and check workloadSpread(%s/%s) status", cloneSet.Namespace, cloneSet.Name, workloadSpread.Namespace, workloadSpread.Name))
+		//	pods, err = tester.GetSelectorPods(cloneSet.Namespace, cloneSet.Spec.Selector)
+		//	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		//	gomega.Expect(pods).To(gomega.HaveLen(2))
+		//	subset1Pods = 0
+		//	subset2Pods = 0
+		//	for _, pod := range pods {
+		//		if str, ok := pod.Annotations[workloadspread.MatchedWorkloadSpreadSubsetAnnotations]; ok {
+		//			var injectWorkloadSpread *workloadspread.InjectWorkloadSpread
+		//			err := json.Unmarshal([]byte(str), &injectWorkloadSpread)
+		//			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		//			if injectWorkloadSpread.Subset == subset1.Name {
+		//				subset1Pods++
+		//				gomega.Expect(injectWorkloadSpread.Name).To(gomega.Equal(workloadSpread.Name))
+		//				gomega.Expect(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions).To(gomega.Equal(subset1.RequiredNodeSelectorTerm.MatchExpressions))
+		//				gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal("200"))
+		//			} else if injectWorkloadSpread.Subset == subset2.Name {
+		//				subset2Pods++
+		//				gomega.Expect(injectWorkloadSpread.Name).To(gomega.Equal(workloadSpread.Name))
+		//				gomega.Expect(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions).To(gomega.Equal(subset2.RequiredNodeSelectorTerm.MatchExpressions))
+		//				gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal("100"))
+		//			}
+		//		} else {
+		//			// others PodDeletionCostAnnotation not set
+		//			gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal(""))
+		//		}
+		//	}
+		//	gomega.Expect(subset1Pods).To(gomega.Equal(1))
+		//	gomega.Expect(subset2Pods).To(gomega.Equal(1))
+		//
+		//	ginkgo.By("deploy in two zone, maxReplicas=50%, done")
+		//})
+
+		// test k8s cluster version >= 1.21
+		//ginkgo.It("elastic deploy for deployment, ack=2, eci=nil", func() {
+		//	deployment := tester.NewBaseDeployment(ns)
+		//	// create workloadSpread
+		//	targetRef := appsv1alpha1.TargetReference{
+		//		APIVersion: controllerKindDep.GroupVersion().String(),
+		//		Kind:       controllerKindDep.Kind,
+		//		Name:       deployment.Name,
+		//	}
+		//	subset1 := appsv1alpha1.WorkloadSpreadSubset{
+		//		Name: "ack",
+		//		RequiredNodeSelectorTerm: &corev1.NodeSelectorTerm{
+		//			MatchExpressions: []corev1.NodeSelectorRequirement{
+		//				{
+		//					Key:      "topology.kubernetes.io/zone",
+		//					Operator: corev1.NodeSelectorOpIn,
+		//					Values:   []string{"ack"},
+		//				},
+		//			},
+		//		},
+		//		MaxReplicas: &intstr.IntOrString{Type: intstr.Int, IntVal: 2},
+		//		Patch: runtime.RawExtension{
+		//			Raw: []byte(`{"metadata":{"annotations":{"subset":"ack"}}}`),
+		//		},
+		//	}
+		//	subset2 := appsv1alpha1.WorkloadSpreadSubset{
+		//		Name: "eci",
+		//		RequiredNodeSelectorTerm: &corev1.NodeSelectorTerm{
+		//			MatchExpressions: []corev1.NodeSelectorRequirement{
+		//				{
+		//					Key:      "topology.kubernetes.io/zone",
+		//					Operator: corev1.NodeSelectorOpIn,
+		//					Values:   []string{"eci"},
+		//				},
+		//			},
+		//		},
+		//		MaxReplicas: nil,
+		//		Patch: runtime.RawExtension{
+		//			Raw: []byte(`{"metadata":{"annotations":{"subset":"eci"}}}`),
+		//		},
+		//	}
+		//	workloadSpread := tester.NewWorkloadSpread(ns, workloadSpreadName, &targetRef, []appsv1alpha1.WorkloadSpreadSubset{subset1, subset2})
+		//	workloadSpread = tester.CreateWorkloadSpread(workloadSpread)
+		//
+		//	// create deployment, replicas = 2
+		//	deployment.Spec.Template.Spec.Containers[0].Image = "busybox:latest"
+		//	deployment = tester.CreateDeployment(deployment)
+		//	tester.WaitForDeploymentRunning(deployment)
+		//
+		//	// get pods, and check workloadSpread
+		//	ginkgo.By(fmt.Sprintf("get deployment(%s/%s) pods, and check workloadSpread(%s/%s) status", deployment.Namespace, deployment.Name, workloadSpread.Namespace, workloadSpread.Name))
+		//	pods, err := tester.GetSelectorPods(deployment.Namespace, deployment.Spec.Selector)
+		//	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		//	gomega.Expect(pods).To(gomega.HaveLen(2))
+		//	subset1Pods := 0
+		//	subset2Pods := 0
+		//	for _, pod := range pods {
+		//		if str, ok := pod.Annotations[workloadspread.MatchedWorkloadSpreadSubsetAnnotations]; ok {
+		//			var injectWorkloadSpread *workloadspread.InjectWorkloadSpread
+		//			err := json.Unmarshal([]byte(str), &injectWorkloadSpread)
+		//			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		//			if injectWorkloadSpread.Subset == subset1.Name {
+		//				subset1Pods++
+		//				gomega.Expect(injectWorkloadSpread.Name).To(gomega.Equal(workloadSpread.Name))
+		//				gomega.Expect(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions).To(gomega.Equal(subset1.RequiredNodeSelectorTerm.MatchExpressions))
+		//				gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal("200"))
+		//			} else if injectWorkloadSpread.Subset == subset2.Name {
+		//				subset2Pods++
+		//				gomega.Expect(injectWorkloadSpread.Name).To(gomega.Equal(workloadSpread.Name))
+		//				gomega.Expect(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions).To(gomega.Equal(subset2.RequiredNodeSelectorTerm.MatchExpressions))
+		//				gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal("100"))
+		//			}
+		//		} else {
+		//			// others PodDeletionCostAnnotation not set
+		//			gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal(""))
+		//		}
+		//	}
+		//	gomega.Expect(subset1Pods).To(gomega.Equal(2))
+		//	gomega.Expect(subset2Pods).To(gomega.Equal(0))
+		//
+		//	//scale up deployment.replicas = 6
+		//	ginkgo.By(fmt.Sprintf("scale up deployment(%s/%s) replicas=6", deployment.Namespace, deployment.Name))
+		//	deployment.Spec.Replicas = pointer.Int32Ptr(6)
+		//	tester.UpdateDeployment(deployment)
+		//	tester.WaitForDeploymentRunning(deployment)
+		//
+		//	// get pods, and check workloadSpread
+		//	ginkgo.By(fmt.Sprintf("get deployment(%s/%s) pods, and check workloadSpread(%s/%s) status", deployment.Namespace, deployment.Name, workloadSpread.Namespace, workloadSpread.Name))
+		//	pods, err = tester.GetSelectorPods(deployment.Namespace, deployment.Spec.Selector)
+		//	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		//	gomega.Expect(pods).To(gomega.HaveLen(6))
+		//	subset1Pods = 0
+		//	subset2Pods = 0
+		//	for _, pod := range pods {
+		//		if str, ok := pod.Annotations[workloadspread.MatchedWorkloadSpreadSubsetAnnotations]; ok {
+		//			var injectWorkloadSpread *workloadspread.InjectWorkloadSpread
+		//			err := json.Unmarshal([]byte(str), &injectWorkloadSpread)
+		//			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		//			if injectWorkloadSpread.Subset == subset1.Name {
+		//				subset1Pods++
+		//				gomega.Expect(injectWorkloadSpread.Name).To(gomega.Equal(workloadSpread.Name))
+		//				gomega.Expect(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions).To(gomega.Equal(subset1.RequiredNodeSelectorTerm.MatchExpressions))
+		//				gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal("200"))
+		//			} else if injectWorkloadSpread.Subset == subset2.Name {
+		//				subset2Pods++
+		//				gomega.Expect(injectWorkloadSpread.Name).To(gomega.Equal(workloadSpread.Name))
+		//				gomega.Expect(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions).To(gomega.Equal(subset2.RequiredNodeSelectorTerm.MatchExpressions))
+		//				gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal("100"))
+		//			}
+		//		} else {
+		//			// others PodDeletionCostAnnotation not set
+		//			gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal(""))
+		//		}
+		//	}
+		//	gomega.Expect(subset1Pods).To(gomega.Equal(2))
+		//	gomega.Expect(subset2Pods).To(gomega.Equal(4))
+		//
+		//	workloadSpread, err = kc.AppsV1alpha1().WorkloadSpreads(workloadSpread.Namespace).Get(workloadSpread.Name, metav1.GetOptions{})
+		//	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		//
+		//	gomega.Expect(workloadSpread.Status.SubsetStatuses[0].Name).To(gomega.Equal(workloadSpread.Spec.Subsets[0].Name))
+		//	gomega.Expect(workloadSpread.Status.SubsetStatuses[0].MissingReplicas).To(gomega.Equal(int32(0)))
+		//	gomega.Expect(len(workloadSpread.Status.SubsetStatuses[0].CreatingPods)).To(gomega.Equal(0))
+		//	gomega.Expect(len(workloadSpread.Status.SubsetStatuses[0].DeletingPods)).To(gomega.Equal(0))
+		//
+		//	// update deployment image
+		//	ginkgo.By(fmt.Sprintf("update deployment(%s/%s) image=%s", deployment.Namespace, deployment.Name, "nginx:alpine"))
+		//	deployment.Spec.Template.Spec.Containers[0].Image = "nginx:alpine"
+		//	tester.UpdateDeployment(deployment)
+		//	tester.WaitForDeploymentRunning(deployment)
+		//
+		//	// get pods, and check workloadSpread
+		//	ginkgo.By(fmt.Sprintf("get deployment(%s/%s) pods, and check workloadSpread(%s/%s) status", deployment.Namespace, deployment.Name, workloadSpread.Namespace, workloadSpread.Name))
+		//	pods, err = tester.GetSelectorPods(deployment.Namespace, deployment.Spec.Selector)
+		//	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		//	gomega.Expect(pods).To(gomega.HaveLen(6))
+		//	subset1Pods = 0
+		//	subset2Pods = 0
+		//	for _, pod := range pods {
+		//		if str, ok := pod.Annotations[workloadspread.MatchedWorkloadSpreadSubsetAnnotations]; ok {
+		//			var injectWorkloadSpread *workloadspread.InjectWorkloadSpread
+		//			err := json.Unmarshal([]byte(str), &injectWorkloadSpread)
+		//			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		//			if injectWorkloadSpread.Subset == subset1.Name {
+		//				subset1Pods++
+		//				gomega.Expect(injectWorkloadSpread.Name).To(gomega.Equal(workloadSpread.Name))
+		//				gomega.Expect(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions).To(gomega.Equal(subset1.RequiredNodeSelectorTerm.MatchExpressions))
+		//				gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal("200"))
+		//			} else if injectWorkloadSpread.Subset == subset2.Name {
+		//				subset2Pods++
+		//				gomega.Expect(injectWorkloadSpread.Name).To(gomega.Equal(workloadSpread.Name))
+		//				gomega.Expect(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions).To(gomega.Equal(subset2.RequiredNodeSelectorTerm.MatchExpressions))
+		//				gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal("100"))
+		//			}
+		//		} else {
+		//			// others PodDeletionCostAnnotation not set
+		//			gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal(""))
+		//		}
+		//	}
+		//	gomega.Expect(subset1Pods).To(gomega.Equal(2))
+		//	gomega.Expect(subset2Pods).To(gomega.Equal(4))
+		//
+		//	//scale down deployment.replicas = 2
+		//	ginkgo.By(fmt.Sprintf("scale down deployment(%s/%s) replicas=2", deployment.Namespace, deployment.Name))
+		//	deployment.Spec.Replicas = pointer.Int32Ptr(2)
+		//	tester.UpdateDeployment(deployment)
+		//	tester.WaitForDeploymentRunning(deployment)
+		//
+		//	time.Sleep(10 * time.Minute)
+		//
+		//	// get pods, and check workloadSpread
+		//	ginkgo.By(fmt.Sprintf("get deployment(%s/%s) pods, and check workloadSpread(%s/%s) status", deployment.Namespace, deployment.Name, workloadSpread.Namespace, workloadSpread.Name))
+		//	pods, err = tester.GetSelectorPods(deployment.Namespace, deployment.Spec.Selector)
+		//	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		//	gomega.Expect(pods).To(gomega.HaveLen(2))
+		//	subset1Pods = 0
+		//	subset2Pods = 0
+		//	for _, pod := range pods {
+		//		if str, ok := pod.Annotations[workloadspread.MatchedWorkloadSpreadSubsetAnnotations]; ok {
+		//			var injectWorkloadSpread *workloadspread.InjectWorkloadSpread
+		//			err := json.Unmarshal([]byte(str), &injectWorkloadSpread)
+		//			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		//			if injectWorkloadSpread.Subset == subset1.Name {
+		//				subset1Pods++
+		//				gomega.Expect(injectWorkloadSpread.Name).To(gomega.Equal(workloadSpread.Name))
+		//				gomega.Expect(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions).To(gomega.Equal(subset1.RequiredNodeSelectorTerm.MatchExpressions))
+		//				gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal("200"))
+		//			} else if injectWorkloadSpread.Subset == subset2.Name {
+		//				subset2Pods++
+		//				gomega.Expect(injectWorkloadSpread.Name).To(gomega.Equal(workloadSpread.Name))
+		//				gomega.Expect(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions).To(gomega.Equal(subset2.RequiredNodeSelectorTerm.MatchExpressions))
+		//				gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal("100"))
+		//			}
+		//		} else {
+		//			// others PodDeletionCostAnnotation not set
+		//			gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal(""))
+		//		}
+		//	}
+		//	gomega.Expect(subset1Pods).To(gomega.Equal(2))
+		//	gomega.Expect(subset2Pods).To(gomega.Equal(0))
+		//
+		//	ginkgo.By("elastic deploy for deployment, ack=2, eci=nil, done")
+		//})
+
+		//ginkgo.It("deploy for job, ack=1, eci=nil", func() {
+		//	job := tester.NewBaseJob(ns)
+		//	// create workloadSpread
+		//	targetRef := appsv1alpha1.TargetReference{
+		//		APIVersion: controllerKindJob.GroupVersion().String(),
+		//		Kind:       controllerKindJob.Kind,
+		//		Name:       job.Name,
+		//	}
+		//	subset1 := appsv1alpha1.WorkloadSpreadSubset{
+		//		Name: "ack",
+		//		RequiredNodeSelectorTerm: &corev1.NodeSelectorTerm{
+		//			MatchExpressions: []corev1.NodeSelectorRequirement{
+		//				{
+		//					Key:      "topology.kubernetes.io/zone",
+		//					Operator: corev1.NodeSelectorOpIn,
+		//					Values:   []string{"ack"},
+		//				},
+		//			},
+		//		},
+		//		MaxReplicas: &intstr.IntOrString{Type: intstr.Int, IntVal: 1},
+		//		Patch: runtime.RawExtension{
+		//			Raw: []byte(`{"metadata":{"annotations":{"subset":"ack"}}}`),
+		//		},
+		//	}
+		//	subset2 := appsv1alpha1.WorkloadSpreadSubset{
+		//		Name: "eci",
+		//		RequiredNodeSelectorTerm: &corev1.NodeSelectorTerm{
+		//			MatchExpressions: []corev1.NodeSelectorRequirement{
+		//				{
+		//					Key:      "topology.kubernetes.io/zone",
+		//					Operator: corev1.NodeSelectorOpIn,
+		//					Values:   []string{"eci"},
+		//				},
+		//			},
+		//		},
+		//		Patch: runtime.RawExtension{
+		//			Raw: []byte(`{"metadata":{"annotations":{"subset":"eci"}}}`),
+		//		},
+		//	}
+		//	workloadSpread := tester.NewWorkloadSpread(ns, workloadSpreadName, &targetRef, []appsv1alpha1.WorkloadSpreadSubset{subset1, subset2})
+		//	workloadSpread = tester.CreateWorkloadSpread(workloadSpread)
+		//
+		//	job.Spec.Completions = pointer.Int32Ptr(10)
+		//	job.Spec.Parallelism = pointer.Int32Ptr(2)
+		//	job.Spec.Template.Spec.Containers[0].Image = "busybox:latest"
+		//	job.Spec.Template.Spec.RestartPolicy = corev1.RestartPolicyNever
+		//	job = tester.CreateJob(job)
+		//	tester.WaitJobCompleted(job)
+		//
+		//	// get pods, and check workloadSpread
+		//	ginkgo.By(fmt.Sprintf("get job(%s/%s) pods, and check workloadSpread(%s/%s) status", job.Namespace, job.Name, workloadSpread.Namespace, workloadSpread.Name))
+		//	faster, err := util.GetFastLabelSelector(job.Spec.Selector)
+		//	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		//	podList, err := tester.C.CoreV1().Pods(job.Namespace).List(metav1.ListOptions{LabelSelector: faster.String()})
+		//	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		//
+		//	matchedPods := make([]corev1.Pod, 0, len(podList.Items))
+		//	for i := range podList.Items {
+		//		if podList.Items[i].Status.Phase == corev1.PodSucceeded {
+		//			matchedPods = append(matchedPods, podList.Items[i])
+		//		}
+		//	}
+		//
+		//	pods := matchedPods
+		//	gomega.Expect(pods).To(gomega.HaveLen(10))
+		//	subset1Pods := 0
+		//	subset2Pods := 0
+		//	for _, pod := range pods {
+		//		if str, ok := pod.Annotations[workloadspread.MatchedWorkloadSpreadSubsetAnnotations]; ok {
+		//			var injectWorkloadSpread *workloadspread.InjectWorkloadSpread
+		//			err := json.Unmarshal([]byte(str), &injectWorkloadSpread)
+		//			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		//			if injectWorkloadSpread.Subset == subset1.Name {
+		//				subset1Pods++
+		//				gomega.Expect(injectWorkloadSpread.Name).To(gomega.Equal(workloadSpread.Name))
+		//				gomega.Expect(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions).To(gomega.Equal(subset1.RequiredNodeSelectorTerm.MatchExpressions))
+		//				gomega.Expect(pod.Annotations["subset"]).To(gomega.Equal(subset1.Name))
+		//			} else if injectWorkloadSpread.Subset == subset2.Name {
+		//				subset2Pods++
+		//				gomega.Expect(injectWorkloadSpread.Name).To(gomega.Equal(workloadSpread.Name))
+		//				gomega.Expect(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions).To(gomega.Equal(subset2.RequiredNodeSelectorTerm.MatchExpressions))
+		//				gomega.Expect(pod.Annotations["subset"]).To(gomega.Equal(subset2.Name))
+		//			}
+		//		} else {
+		//			// others PodDeletionCostAnnotation not set
+		//			gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal(""))
+		//		}
+		//	}
+		//	gomega.Expect(subset1Pods).To(gomega.Equal(5))
+		//	gomega.Expect(subset2Pods).To(gomega.Equal(5))
+		//
+		//	// check workloadSpread status
+		//	ginkgo.By(fmt.Sprintf("check workloadSpread(%s/%s) status", workloadSpread.Namespace, workloadSpread.Name))
+		//	workloadSpread, err = kc.AppsV1alpha1().WorkloadSpreads(workloadSpread.Namespace).Get(workloadSpread.Name, metav1.GetOptions{})
+		//	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		//
+		//	gomega.Expect(workloadSpread.Status.SubsetStatuses[0].Name).To(gomega.Equal(workloadSpread.Spec.Subsets[0].Name))
+		//	gomega.Expect(workloadSpread.Status.SubsetStatuses[0].MissingReplicas).To(gomega.Equal(int32(1)))
+		//	gomega.Expect(len(workloadSpread.Status.SubsetStatuses[0].CreatingPods)).To(gomega.Equal(0))
+		//	gomega.Expect(len(workloadSpread.Status.SubsetStatuses[0].DeletingPods)).To(gomega.Equal(0))
+		//
+		//	gomega.Expect(workloadSpread.Status.SubsetStatuses[1].Name).To(gomega.Equal(workloadSpread.Spec.Subsets[1].Name))
+		//	gomega.Expect(workloadSpread.Status.SubsetStatuses[1].MissingReplicas).To(gomega.Equal(int32(-1)))
+		//	gomega.Expect(len(workloadSpread.Status.SubsetStatuses[1].CreatingPods)).To(gomega.Equal(0))
+		//	gomega.Expect(len(workloadSpread.Status.SubsetStatuses[1].DeletingPods)).To(gomega.Equal(0))
+		//
+		//	ginkgo.By("workloadSpread for job, done")
+		//})
+
+	})
+})

--- a/test/e2e/apps/workloadspread.go
+++ b/test/e2e/apps/workloadspread.go
@@ -74,7 +74,7 @@ var _ = SIGDescribe("workloadspread", func() {
 			}
 			workers = append(workers, &node)
 		}
-		gomega.Expect(len(workers) >= 2).Should(gomega.Equal(true))
+		gomega.Expect(len(workers) > 2).Should(gomega.Equal(true))
 		// subset-a
 		worker0 := workers[0]
 		tester.SetNodeLabel(c, worker0, TopologyLabelKey, "zone-a")

--- a/test/e2e/framework/workloadspread_util.go
+++ b/test/e2e/framework/workloadspread_util.go
@@ -1,0 +1,395 @@
+/*
+Copyright 2021 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"context"
+	"time"
+
+	"github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
+	kubecontroller "k8s.io/kubernetes/pkg/controller"
+	utilpointer "k8s.io/utils/pointer"
+
+	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
+	kruiseclientset "github.com/openkruise/kruise/pkg/client/clientset/versioned"
+	"github.com/openkruise/kruise/pkg/util"
+)
+
+type WorkloadSpreadTester struct {
+	C  clientset.Interface
+	kc kruiseclientset.Interface
+}
+
+func NewWorkloadSpreadTester(c clientset.Interface, kc kruiseclientset.Interface) *WorkloadSpreadTester {
+	return &WorkloadSpreadTester{
+		C:  c,
+		kc: kc,
+	}
+}
+
+func (t *WorkloadSpreadTester) NewWorkloadSpread(namespace, name string, targetRef *appsv1alpha1.TargetReference, subsets []appsv1alpha1.WorkloadSpreadSubset) *appsv1alpha1.WorkloadSpread {
+	return &appsv1alpha1.WorkloadSpread{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Spec: appsv1alpha1.WorkloadSpreadSpec{
+			TargetReference: targetRef,
+			Subsets:         subsets,
+		},
+	}
+}
+
+func (t *WorkloadSpreadTester) NewBaseCloneSet(namespace string) *appsv1alpha1.CloneSet {
+	return &appsv1alpha1.CloneSet{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "CloneSet",
+			APIVersion: appsv1alpha1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "busybox",
+			Namespace: namespace,
+		},
+		Spec: appsv1alpha1.CloneSetSpec{
+			Replicas: utilpointer.Int32Ptr(2),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": namespace,
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": namespace,
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:    "main",
+							Image:   "busybox:1.32",
+							Command: []string{"/bin/sh", "-c", "sleep 10000000"},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (t *WorkloadSpreadTester) NewBaseJob(namespace string) *batchv1.Job {
+	return &batchv1.Job{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Job",
+			APIVersion: "batch/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "busybox",
+			Namespace: namespace,
+		},
+		Spec: batchv1.JobSpec{
+			Completions: utilpointer.Int32Ptr(10),
+			Parallelism: utilpointer.Int32Ptr(1),
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": namespace,
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:    "main",
+							Image:   "busybox:1.32",
+							Command: []string{"/bin/sh", "-c", "sleep 5"},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (t *WorkloadSpreadTester) NewBaseDeployment(namespace string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Deployment",
+			APIVersion: "apps/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "busybox",
+			Namespace: namespace,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: utilpointer.Int32Ptr(2),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": namespace,
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": namespace,
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:    "main",
+							Image:   "busybox:1.32",
+							Command: []string{"/bin/sh", "-c", "sleep 10000000"},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (t *WorkloadSpreadTester) CreateWorkloadSpread(workloadSpread *appsv1alpha1.WorkloadSpread) *appsv1alpha1.WorkloadSpread {
+	Logf("create WorkloadSpread (%s/%s)", workloadSpread.Namespace, workloadSpread.Name)
+	_, err := t.kc.AppsV1alpha1().WorkloadSpreads(workloadSpread.Namespace).Create(context.TODO(), workloadSpread, metav1.CreateOptions{})
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	t.WaitForWorkloadSpreadRunning(workloadSpread)
+	Logf("create workloadSpread (%s/%s) success", workloadSpread.Namespace, workloadSpread.Name)
+	workloadSpread, _ = t.kc.AppsV1alpha1().WorkloadSpreads(workloadSpread.Namespace).Get(context.TODO(), workloadSpread.Name, metav1.GetOptions{})
+	return workloadSpread
+}
+
+func (t *WorkloadSpreadTester) WaitForWorkloadSpreadRunning(ws *appsv1alpha1.WorkloadSpread) {
+	pollErr := wait.PollImmediate(time.Second, time.Minute*5,
+		func() (bool, error) {
+			inner, err := t.kc.AppsV1alpha1().WorkloadSpreads(ws.Namespace).Get(context.TODO(), ws.Name, metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
+			if inner.Generation == inner.Status.ObservedGeneration {
+				return true, nil
+			}
+			return false, nil
+		})
+	if pollErr != nil {
+		Failf("Failed waiting for workloadSpread to enter running: %v", pollErr)
+	}
+}
+
+func (t *WorkloadSpreadTester) CreateCloneSet(cloneSet *appsv1alpha1.CloneSet) *appsv1alpha1.CloneSet {
+	Logf("create CloneSet (%s/%s)", cloneSet.Namespace, cloneSet.Name)
+	_, err := t.kc.AppsV1alpha1().CloneSets(cloneSet.Namespace).Create(context.TODO(), cloneSet, metav1.CreateOptions{})
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	Logf("create cloneSet (%s/%s) success", cloneSet.Namespace, cloneSet.Name)
+	cloneSet, _ = t.kc.AppsV1alpha1().CloneSets(cloneSet.Namespace).Get(context.TODO(), cloneSet.Name, metav1.GetOptions{})
+	return cloneSet
+}
+
+func (t *WorkloadSpreadTester) CreateDeployment(deployment *appsv1.Deployment) *appsv1.Deployment {
+	Logf("create Deployment (%s/%s)", deployment.Namespace, deployment.Name)
+	_, err := t.C.AppsV1().Deployments(deployment.Namespace).Create(context.TODO(), deployment, metav1.CreateOptions{})
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	Logf("create deployment (%s/%s) success", deployment.Namespace, deployment.Name)
+	deployment, _ = t.C.AppsV1().Deployments(deployment.Namespace).Get(context.TODO(), deployment.Name, metav1.GetOptions{})
+	return deployment
+}
+
+func (t *WorkloadSpreadTester) CreateJob(job *batchv1.Job) *batchv1.Job {
+	Logf("create Deployment (%s/%s)", job.Namespace, job.Name)
+	_, err := t.C.BatchV1().Jobs(job.Namespace).Create(context.TODO(), job, metav1.CreateOptions{})
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	Logf("create job (%s/%s) success", job.Namespace, job.Name)
+	job, _ = t.C.BatchV1().Jobs(job.Namespace).Get(context.TODO(), job.Name, metav1.GetOptions{})
+	return job
+}
+
+func (t *WorkloadSpreadTester) WaitForCloneSetRunning(cloneSet *appsv1alpha1.CloneSet) {
+	pollErr := wait.PollImmediate(time.Second, time.Minute*10,
+		func() (bool, error) {
+			inner, err := t.kc.AppsV1alpha1().CloneSets(cloneSet.Namespace).Get(context.TODO(), cloneSet.Name, metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
+			if *inner.Spec.Replicas == inner.Status.ReadyReplicas && *inner.Spec.Replicas == inner.Status.UpdatedReplicas &&
+				*inner.Spec.Replicas == inner.Status.Replicas {
+				return true, nil
+			}
+			return false, nil
+		})
+	if pollErr != nil {
+		Failf("Failed waiting for cloneSet to enter running: %v", pollErr)
+	}
+}
+
+func (t *WorkloadSpreadTester) WaitForCloneSetRunReplicas(cloneSet *appsv1alpha1.CloneSet, replicas int32) {
+	pollErr := wait.PollImmediate(time.Second, time.Minute*5,
+		func() (bool, error) {
+			inner, err := t.kc.AppsV1alpha1().CloneSets(cloneSet.Namespace).Get(context.TODO(), cloneSet.Name, metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
+			if replicas == inner.Status.ReadyReplicas && replicas == inner.Status.UpdatedReadyReplicas {
+				return true, nil
+			}
+			return false, nil
+		})
+	if pollErr != nil {
+		Failf("Failed waiting for cloneSet to enter running: %v", pollErr)
+	}
+}
+
+func (t *WorkloadSpreadTester) WaitForDeploymentRunning(deployment *appsv1.Deployment) {
+	pollErr := wait.PollImmediate(time.Second, time.Minute*5,
+		func() (bool, error) {
+			inner, err := t.C.AppsV1().Deployments(deployment.Namespace).Get(context.TODO(), deployment.Name, metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
+			if *inner.Spec.Replicas == inner.Status.ReadyReplicas && *inner.Spec.Replicas == inner.Status.UpdatedReplicas &&
+				*inner.Spec.Replicas == inner.Status.Replicas {
+				return true, nil
+			}
+			return false, nil
+		})
+	if pollErr != nil {
+		Failf("Failed waiting for deployment to enter running: %v", pollErr)
+	}
+}
+
+func (t *WorkloadSpreadTester) WaitJobCompleted(job *batchv1.Job) {
+	pollErr := wait.PollImmediate(time.Second, time.Minute*5,
+		func() (bool, error) {
+			inner, err := t.C.BatchV1().Jobs(job.Namespace).Get(context.TODO(), job.Name, metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
+			if inner.Status.Succeeded == *job.Spec.Completions {
+				return true, nil
+			}
+			return false, nil
+		})
+	if pollErr != nil {
+		Failf("Failed waiting for deployment to enter running: %v", pollErr)
+	}
+}
+
+func (t *WorkloadSpreadTester) GetSelectorPods(namespace string, selector *metav1.LabelSelector) ([]corev1.Pod, error) {
+	faster, err := util.GetFastLabelSelector(selector)
+	if err != nil {
+		return nil, err
+	}
+	podList, err := t.C.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: faster.String()})
+	if err != nil {
+		return nil, err
+	}
+
+	matchedPods := make([]corev1.Pod, 0, len(podList.Items))
+	for i := range podList.Items {
+		if kubecontroller.IsPodActive(&podList.Items[i]) {
+			matchedPods = append(matchedPods, podList.Items[i])
+		}
+	}
+	return matchedPods, nil
+}
+
+func (t *WorkloadSpreadTester) UpdateCloneSet(cloneSet *appsv1alpha1.CloneSet) {
+	Logf("update cloneSet (%s/%s)", cloneSet.Namespace, cloneSet.Name)
+	clone, _ := t.kc.AppsV1alpha1().CloneSets(cloneSet.Namespace).Get(context.TODO(), cloneSet.Name, metav1.GetOptions{})
+	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		clone.Spec = cloneSet.Spec
+		_, updateErr := t.kc.AppsV1alpha1().CloneSets(clone.Namespace).Update(context.TODO(), clone, metav1.UpdateOptions{})
+		if updateErr == nil {
+			return nil
+		}
+		clone, _ = t.kc.AppsV1alpha1().CloneSets(clone.Namespace).Get(context.TODO(), clone.Name, metav1.GetOptions{})
+		return updateErr
+	})
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+}
+
+func (t *WorkloadSpreadTester) UpdateDeployment(deployment *appsv1.Deployment) {
+	Logf("update deployment (%s/%s)", deployment.Namespace, deployment.Name)
+	clone, _ := t.C.AppsV1().Deployments(deployment.Namespace).Get(context.TODO(), deployment.Name, metav1.GetOptions{})
+	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		clone.Spec = deployment.Spec
+		_, updateErr := t.C.AppsV1().Deployments(clone.Namespace).Update(context.TODO(), clone, metav1.UpdateOptions{})
+		if updateErr == nil {
+			return nil
+		}
+		clone, _ = t.C.AppsV1().Deployments(clone.Namespace).Get(context.TODO(), clone.Name, metav1.GetOptions{})
+		return updateErr
+	})
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+}
+
+func (t *WorkloadSpreadTester) WaiteCloneSetUpdate(cloneSet *appsv1alpha1.CloneSet) {
+	pollErr := wait.PollImmediate(time.Second, time.Minute*5,
+		func() (bool, error) {
+			inner, err := t.kc.AppsV1alpha1().CloneSets(cloneSet.Namespace).Get(context.TODO(), cloneSet.Name, metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
+
+			if *inner.Spec.Replicas == inner.Status.ReadyReplicas && *inner.Spec.Replicas == inner.Status.UpdatedReplicas &&
+				*inner.Spec.Replicas == inner.Status.Replicas {
+				return true, nil
+			}
+			return false, nil
+		})
+	if pollErr != nil {
+		Failf("Failed waiting for cloneSet to enter running: %v", pollErr)
+	}
+}
+
+func (t *WorkloadSpreadTester) WaiteDeploymentUpdate(deployment *appsv1.Deployment) {
+	pollErr := wait.PollImmediate(time.Second, time.Minute*5,
+		func() (bool, error) {
+			inner, err := t.C.AppsV1().Deployments(deployment.Namespace).Get(context.TODO(), deployment.Name, metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
+
+			if *inner.Spec.Replicas == inner.Status.ReadyReplicas && *inner.Spec.Replicas == inner.Status.UpdatedReplicas &&
+				*inner.Spec.Replicas == inner.Status.Replicas {
+				return true, nil
+			}
+			return false, nil
+		})
+	if pollErr != nil {
+		Failf("Failed waiting for cloneSet to enter running: %v", pollErr)
+	}
+}
+
+func (t *WorkloadSpreadTester) UpdateWorkloadSpread(workloadSpread *appsv1alpha1.WorkloadSpread) {
+	Logf("update workloadSpread (%s/%s)", workloadSpread.Namespace, workloadSpread.Name)
+	clone, _ := t.kc.AppsV1alpha1().WorkloadSpreads(workloadSpread.Namespace).Get(context.TODO(), workloadSpread.Name, metav1.GetOptions{})
+	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		clone.Spec = workloadSpread.Spec
+		_, updateErr := t.kc.AppsV1alpha1().WorkloadSpreads(clone.Namespace).Update(context.TODO(), clone, metav1.UpdateOptions{})
+		if updateErr == nil {
+			return nil
+		}
+		clone, _ = t.kc.AppsV1alpha1().WorkloadSpreads(clone.Namespace).Get(context.TODO(), clone.Name, metav1.GetOptions{})
+		return updateErr
+	})
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+}

--- a/test/e2e/framework/workloadspread_util.go
+++ b/test/e2e/framework/workloadspread_util.go
@@ -168,6 +168,17 @@ func (t *WorkloadSpreadTester) NewBaseDeployment(namespace string) *appsv1.Deplo
 	}
 }
 
+func (t *WorkloadSpreadTester) SetNodeLabel(c clientset.Interface, node *corev1.Node, key, value string) {
+	labels := node.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	labels[key] = value
+	node.SetLabels(labels)
+	_, err := c.CoreV1().Nodes().Update(context.TODO(), node, metav1.UpdateOptions{})
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+}
+
 func (t *WorkloadSpreadTester) CreateWorkloadSpread(workloadSpread *appsv1alpha1.WorkloadSpread) *appsv1alpha1.WorkloadSpread {
 	Logf("create WorkloadSpread (%s/%s)", workloadSpread.Namespace, workloadSpread.Name)
 	_, err := t.kc.AppsV1alpha1().WorkloadSpreads(workloadSpread.Namespace).Create(context.TODO(), workloadSpread, metav1.CreateOptions{})


### PR DESCRIPTION
Signed-off-by: bolstlei <1606880753@qq.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Fix #739, and add e2e test for WorkloadSpread.

#### E2E test include:
- Clonset is deployed in two zone and the type of maxReplicas is Int.
- Clonset is deployed in two subset for elastic deployment. The first subset is called `zone-a`, and the second subset is called `zone-b`, which is the elastic domain.
- Rechedule the unscheduled Pods of subset.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


