### PR TITLE
fix unpredictable numbers of pods when interval of reserveOrdinals > …

### DIFF
--- a/pkg/controller/statefulset/stateful_set_control.go
+++ b/pkg/controller/statefulset/stateful_set_control.go
@@ -479,7 +479,10 @@ func (ssc *defaultStatefulSetControl) updateStatefulSet(
 				i, replicas)
 		}
 		// If we find a Pod that has not been created we create the Pod
-		if !isCreated(replicas[i]) {
+		// 1. If `condemned` has item represent the reverseOrdinals has changed
+		// 2. If `status.Replicas` is not equal `set.Spec.Replicas` represent has failed pod in the set
+		// One of the two conditions is established, we can create the Pod.
+		if !isCreated(replicas[i]) && (len(condemned) > 0 || status.Replicas != *set.Spec.Replicas) {
 			lifecycle.SetPodLifecycle(appspub.LifecycleStateNormal)(replicas[i])
 			if err := ssc.podControl.CreateStatefulPod(set, replicas[i]); err != nil {
 				msg := fmt.Sprintf("StatefulPodControl failed to create Pod error: %s", err)


### PR DESCRIPTION
…ordinals of pods

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
  don`t create pods when interval of reserveOrdinals > max(pod.ordinal) and replicas stay the same
### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixed #746 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


