### PR TITLE
Optimize WorkloadSpread via reducing update conflicts

### DIFF
--- a/pkg/util/cache.go
+++ b/pkg/util/cache.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2021 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/cache"
+)
+
+// GlobalCache using GVK/namespace/name as key
+var GlobalCache = cache.NewStore(func(obj interface{}) (string, error) {
+	metaObj, ok := obj.(metav1.Object)
+	if !ok {
+		return "", fmt.Errorf("failed to convert obj to metav1.Object")
+	}
+	namespacedName := fmt.Sprintf("%s/%s", metaObj.GetNamespace(), metaObj.GetName())
+
+	runtimeObj, ok := obj.(runtime.Object)
+	if !ok {
+		return "", fmt.Errorf("failed to convert obj to runtime.Object")
+	}
+	key := fmt.Sprintf("%v/%s", runtimeObj.GetObjectKind().GroupVersionKind(), namespacedName)
+	return key, nil
+})

--- a/pkg/util/cache_test.go
+++ b/pkg/util/cache_test.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2020 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+
+	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestGlobalCache(t *testing.T) {
+	podObj := &v1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "pod",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "pod-name",
+			Namespace:       "pod-namespace",
+			ResourceVersion: "1",
+		},
+	}
+	ws1Obj := &appsv1alpha1.WorkloadSpread{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps.kruise.io/v1alpha1",
+			Kind:       "WorkloadSpread",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "ws1-name",
+			Namespace:       "ws1-namespace",
+			ResourceVersion: "1",
+		},
+	}
+	ws2Obj := &appsv1alpha1.WorkloadSpread{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps.kruise.io/v1alpha1",
+			Kind:       "WorkloadSpread",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "ws2-name",
+			Namespace:       "ws2-namespace",
+			ResourceVersion: "1",
+		},
+	}
+	ws3Obj := &appsv1alpha1.WorkloadSpread{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps.kruise.io/v1alpha1",
+			Kind:       "WorkloadSpread",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "ws3-name",
+			Namespace:       "ws3-namespace",
+			ResourceVersion: "1",
+		},
+	}
+
+	// add
+	if err := GlobalCache.Add(podObj); err != nil {
+		t.Fatalf("Failed to add obj to GlobalCache, %v", err)
+	}
+	if err := GlobalCache.Add(ws1Obj); err != nil {
+		t.Fatalf("Failed to add obj to GlobalCache, %v", err)
+	}
+	if err := GlobalCache.Add(ws2Obj); err != nil {
+		t.Fatalf("Failed to add obj to GlobalCache, %v", err)
+	}
+	if err := GlobalCache.Add(ws3Obj); err != nil {
+		t.Fatalf("Failed to add obj to GlobalCache, %v", err)
+	}
+
+	// update
+	podObj.SetResourceVersion("2")
+	ws1Obj.SetResourceVersion("2")
+	if err := GlobalCache.Add(podObj); err != nil {
+		t.Fatalf("Failed to update obj to GlobalCache, %v", err)
+	}
+	if err := GlobalCache.Add(ws1Obj); err != nil {
+		t.Fatalf("Failed to update obj to GlobalCache, %v", err)
+	}
+
+	// delete
+	if err := GlobalCache.Delete(&appsv1alpha1.WorkloadSpread{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps.kruise.io/v1alpha1",
+			Kind:       "WorkloadSpread",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ws3Obj.GetNamespace(),
+			Name:      ws3Obj.GetName(),
+		},
+	}); err != nil {
+		t.Fatalf("Failed to delete obj to GlobalCache, %v", err)
+	}
+
+	// list & Get
+	objs := GlobalCache.List()
+	expected := map[string]runtime.Object{
+		"pod-name": podObj,
+		"ws1-name": ws1Obj,
+		"ws2-name": ws2Obj,
+	}
+	expectedResourceVersion := map[string]string{
+		"pod-name": "2",
+		"ws1-name": "2",
+		"ws2-name": "1",
+	}
+	if len(objs) != len(expected) {
+		t.Fatalf("the number of expected cached objects is %d, but got %d", len(expected), len(objs))
+	}
+	for key, obj := range expected {
+		item, ok, err := GlobalCache.Get(obj)
+		if !ok || err != nil {
+			t.Fatalf("expected object(%s) not found in GlobalCache", key)
+		}
+		cachedObj := item.(metav1.Object)
+		if cachedObj.GetName() != key ||
+			cachedObj.GetResourceVersion() != expectedResourceVersion[key] {
+			t.Fatalf("get wrong version of cached object")
+		}
+	}
+}

--- a/pkg/util/lock.go
+++ b/pkg/util/lock.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2021 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"sync"
+)
+
+type KeyedMutex struct {
+	mutexes sync.Map
+}
+
+var GlobalKeyedMutex = &KeyedMutex{}
+
+func (m *KeyedMutex) Lock(key string) func() {
+	value, _ := m.mutexes.LoadOrStore(key, &sync.Mutex{})
+	mtx := value.(*sync.Mutex)
+	mtx.Lock()
+	return func() { mtx.Unlock() }
+}
+
+func (m *KeyedMutex) Unlock(key string) {
+	value, ok := m.mutexes.Load(key)
+	if !ok {
+		return
+	}
+	mtx := value.(*sync.Mutex)
+	mtx.Unlock()
+}

--- a/pkg/util/lock_test.go
+++ b/pkg/util/lock_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2021 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"math/rand"
+	"strconv"
+	"sync"
+	"testing"
+)
+
+func TestKeyedMutex(t *testing.T) {
+	NumberOfKey := 5
+	NumberOfGoroutine := 100000
+	keys := make([]string, 0)
+	expectCount := make(map[string]int)
+	realCount := make(map[string]*int, NumberOfKey)
+	for i := 0; i < NumberOfKey; i++ {
+		var x int
+		key := strconv.Itoa(i)
+		keys = append(keys, key)
+		realCount[key] = &x
+	}
+
+	km := KeyedMutex{}
+	wait := sync.WaitGroup{}
+	wait.Add(NumberOfGoroutine)
+	for i := 0; i < NumberOfGoroutine; i++ {
+		selectedKey := keys[rand.Int()%NumberOfKey]
+		expectCount[selectedKey]++
+		go func(key string) {
+			unlock := km.Lock(key)
+			// test two types of unlock function
+			defer func() {
+				if key == keys[0] {
+					unlock()
+				} else {
+					km.Unlock(key)
+				}
+			}()
+			count := realCount[key]
+			*count++
+			wait.Done()
+		}(selectedKey)
+	}
+
+	wait.Wait()
+	for key, expected := range expectCount {
+		if times, ok := realCount[key]; !ok || *times != expected {
+			t.Fatalf("Expected count times: %d, but got %d", expected, *times)
+		}
+	}
+}

--- a/pkg/util/workloadspread/workloadspread_test.go
+++ b/pkg/util/workloadspread/workloadspread_test.go
@@ -36,6 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
+	"github.com/openkruise/kruise/pkg/util"
 )
 
 var (
@@ -779,6 +780,7 @@ func TestWorkloadSpreadMutatingPod(t *testing.T) {
 				fmt.Println(cs.expectWorkloadSpread().Status)
 				t.Fatalf("workloadSpread DeepEqual failed")
 			}
+			util.GlobalCache.Delete(workloadSpreadIn)
 		})
 	}
 }


### PR DESCRIPTION
Signed-off-by: veophi <vec.g.sun@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Optimize WorkloadSpread via reducing update conflicts:
1.  Use a mutex for each WorkloadSpread to reduce frequent update conflicts;
2. Use `Get` operation **without cache** to avoid informer cache latency that causes the update to fail frequently.;
3. Use global cache for each WorkloadSpread to record the latest revision which can be observed by each kruise-webhook to reduce the `Get` operation;
4. We also keep the optimistic lock to solve the conflicts between different kruise-webhooks.

### Ⅱ. Describe how to verify it
We test our optimization in a cluster that looks like this:
```
NAME   STATUS   ROLES                  AGE   VERSION
cn-1   Ready    control-plane,master   50d   v1.20.4
cn-2   Ready    control-plane,master   50d   v1.20.4
cn-3   Ready    control-plane,master   50d   v1.20.4
cn-4   Ready    <none>                 50d   v1.20.4
cn-6   Ready    <none>                 50d   v1.20.4
```
and get the optimized results as follows:
![image](https://user-images.githubusercontent.com/28217554/132955804-0839ea1e-73f2-4520-a823-65eb65e43631.png)




