### PR TITLE
add pod no pub-protection annotations

### DIFF
--- a/pkg/control/pubcontrol/utils.go
+++ b/pkg/control/pubcontrol/utils.go
@@ -56,6 +56,9 @@ type Operation string
 const (
 	UpdateOperation = "UPDATE"
 	//DeleteOperation = "DELETE"
+
+	// Marked pods will not be pub-protected, solving the scenario of force pod deletion
+	PodPubNoProtectionAnnotation = "pub.kruise.io/no-protect"
 )
 
 // parameters:


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Marked pods will not be pub-protected (annotations[pod.kruise.io/pub-no-protect]="true"), solving the scenario of force pod deletion

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


