### PR TITLE
Make WorkloadSpread support percentage configuration of subset.MaxReplicas

### DIFF
--- a/apis/apps/v1alpha1/workloadspread_types.go
+++ b/apis/apps/v1alpha1/workloadspread_types.go
@@ -120,7 +120,12 @@ type WorkloadSpreadStatus struct {
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 
-	// ObservedGeneration is the most recent replicas of target workload observed for this WorkloadSpread.
+	// ObservedWorkloadGeneration is the most recent generation observed for the TargetReference Workload when reconciling.
+	//It corresponds to this Workload's generation, which is updated on mutation by the API Server.
+	// +optional
+	ObservedWorkloadGeneration int64 `json:"observedWorkloadGeneration,omitempty"`
+
+	// ObservedWorkloadReplicas is the most recent replicas of target workload observed for this WorkloadSpread.
 	//ObservedWorkloadReplicas int32 `json:"observedWorkloadReplicas"`
 
 	// Contains the status of each subset. Each element in this array represents one subset

--- a/config/crd/bases/apps.kruise.io_workloadspreads.yaml
+++ b/config/crd/bases/apps.kruise.io_workloadspreads.yaml
@@ -138,6 +138,10 @@ spec:
                 description: ObservedGeneration is the most recent generation observed for this WorkloadSpread. It corresponds to the WorkloadSpread's generation, which is updated on mutation by the API Server.
                 format: int64
                 type: integer
+              observedWorkloadGeneration:
+                description: ObservedWorkloadGeneration is the most recent generation observed for the TargetReference Workload when reconciling. It corresponds to this Workload's generation, which is updated on mutation by the API Server.
+                format: int64
+                type: integer
               subsetStatuses:
                 description: Contains the status of each subset. Each element in this array represents one subset
                 items:

--- a/pkg/control/pubcontrol/pub_control.go
+++ b/pkg/control/pubcontrol/pub_control.go
@@ -73,7 +73,7 @@ func (c *commonControl) GetPodsForPub() ([]*corev1.Pod, int32, error) {
 	var listOptions *client.ListOptions
 	if pub.Spec.TargetReference != nil {
 		ref := pub.Spec.TargetReference
-		matchedPods, expectedCount, err := c.controllerFinder.GetPodsForRef(ref.APIVersion, ref.Kind, ref.Name, pub.Namespace, true)
+		matchedPods, _, expectedCount, err := c.controllerFinder.GetPodsForRef(ref.APIVersion, ref.Kind, ref.Name, pub.Namespace, true)
 		return matchedPods, expectedCount, err
 	} else if pub.Spec.Selector == nil {
 		klog.Warningf("pub(%s/%s) spec.Selector cannot be empty", pub.Namespace, pub.Name)

--- a/pkg/controller/podunavailablebudget/podunavailablebudget_controller.go
+++ b/pkg/controller/podunavailablebudget/podunavailablebudget_controller.go
@@ -366,7 +366,7 @@ func (r *ReconcilePodUnavailableBudget) getPodsForPub(pub *policyv1alpha1.PodUna
 	var listOptions *client.ListOptions
 	if pub.Spec.TargetReference != nil {
 		ref := pub.Spec.TargetReference
-		matchedPods, _, err := r.controllerFinder.GetPodsForRef(ref.APIVersion, ref.Kind, ref.Name, pub.Namespace, true)
+		matchedPods, _, _, err := r.controllerFinder.GetPodsForRef(ref.APIVersion, ref.Kind, ref.Name, pub.Namespace, true)
 		return matchedPods, err
 	} else if pub.Spec.Selector == nil {
 		r.recorder.Eventf(pub, corev1.EventTypeWarning, "NoSelector", "Selector cannot be empty")

--- a/pkg/controller/workloadspread/workloadspread_controller_test.go
+++ b/pkg/controller/workloadspread/workloadspread_controller_test.go
@@ -1435,6 +1435,7 @@ func TestWorkloadSpreadReconcile(t *testing.T) {
 			}
 
 			latestStatus := latestWorkloadSpread.Status
+			latestStatus.ObservedWorkloadGeneration = 0
 			by, _ := json.Marshal(latestStatus)
 			fmt.Println(string(by))
 
@@ -1484,7 +1485,7 @@ func TestUpdateSubsetSequence(t *testing.T) {
 	subsetsPods := groupPod(workloadSpread, pods)
 
 	r := ReconcileWorkloadSpread{}
-	status, _ := r.calculateWorkloadSpreadStatus(workloadSpread, subsetsPods, 5)
+	status, _ := r.calculateWorkloadSpreadStatus(workloadSpread, subsetsPods, nil, 5)
 	if status == nil {
 		t.Fatalf("error get WorkloadSpread status")
 	} else {

--- a/pkg/controller/workloadspread/workloadspread_event_handler_test.go
+++ b/pkg/controller/workloadspread/workloadspread_event_handler_test.go
@@ -773,7 +773,7 @@ func TestWorkloadEventHandlerForUpdate(t *testing.T) {
 	updateQ := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
 	oldReplicaSet := replicaSetDemo.DeepCopy()
 	newReplicaSet := replicaSetDemo.DeepCopy()
-	newReplicaSet.Spec.Replicas = pointer.Int32Ptr(*(oldReplicaSet.Spec.Replicas) + 1)
+	newReplicaSet.Generation = oldReplicaSet.Generation + 1
 
 	updateEvt := event.UpdateEvent{
 		ObjectOld: oldReplicaSet,

--- a/test/e2e/apps/workloadspread.go
+++ b/test/e2e/apps/workloadspread.go
@@ -776,206 +776,206 @@ var _ = SIGDescribe("workloadspread", func() {
 			ginkgo.By("workloadSpread reschedule subset-a, done")
 		})
 
-		//ginkgo.It("deploy in two zone, maxReplicas=50%", func() {
-		//	cloneSet := tester.NewBaseCloneSet(ns)
-		//	// create workloadSpread
-		//	targetRef := appsv1alpha1.TargetReference{
-		//		APIVersion: KruiseKindCloneSet.GroupVersion().String(),
-		//		Kind:       KruiseKindCloneSet.Kind,
-		//		Name:       cloneSet.Name,
-		//	}
-		//	subset1 := appsv1alpha1.WorkloadSpreadSubset{
-		//		Name: "zone-a",
-		//		RequiredNodeSelectorTerm: &corev1.NodeSelectorTerm{
-		//			MatchExpressions: []corev1.NodeSelectorRequirement{
-		//				{
-		//					Key:      TopologyLabelKey,
-		//					Operator: corev1.NodeSelectorOpIn,
-		//					Values:   []string{"zone-a"},
-		//				},
-		//			},
-		//		},
-		//		MaxReplicas: &intstr.IntOrString{Type: intstr.String, StrVal: "50%"},
-		//		Patch: runtime.RawExtension{
-		//			Raw: []byte(`{"metadata":{"annotations":{"subset":"zone-a"}}}`),
-		//		},
-		//	}
-		//	subset2 := appsv1alpha1.WorkloadSpreadSubset{
-		//		Name: "zone-b",
-		//		RequiredNodeSelectorTerm: &corev1.NodeSelectorTerm{
-		//			MatchExpressions: []corev1.NodeSelectorRequirement{
-		//				{
-		//					Key:      TopologyLabelKey,
-		//					Operator: corev1.NodeSelectorOpIn,
-		//					Values:   []string{"zone-b"},
-		//				},
-		//			},
-		//		},
-		//		MaxReplicas: &intstr.IntOrString{Type: intstr.String, StrVal: "50%"},
-		//		Patch: runtime.RawExtension{
-		//			Raw: []byte(`{"metadata":{"annotations":{"subset":"zone-b"}}}`),
-		//		},
-		//	}
-		//	workloadSpread := tester.NewWorkloadSpread(ns, workloadSpreadName, &targetRef, []appsv1alpha1.WorkloadSpreadSubset{subset1, subset2})
-		//	workloadSpread = tester.CreateWorkloadSpread(workloadSpread)
-		//
-		//	// create cloneset, replicas = 2
-		//	cloneSet.Spec.Template.Spec.Containers[0].Image = "busybox:latest"
-		//	cloneSet = tester.CreateCloneSet(cloneSet)
-		//	tester.WaitForCloneSetRunning(cloneSet)
-		//
-		//	// get pods, and check workloadSpread
-		//	ginkgo.By(fmt.Sprintf("get cloneSet(%s/%s) pods, and check workloadSpread(%s/%s) status", cloneSet.Namespace, cloneSet.Name, workloadSpread.Namespace, workloadSpread.Name))
-		//	pods, err := tester.GetSelectorPods(cloneSet.Namespace, cloneSet.Spec.Selector)
-		//	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		//	gomega.Expect(pods).To(gomega.HaveLen(2))
-		//	subset1Pods := 0
-		//	subset2Pods := 0
-		//	for _, pod := range pods {
-		//		if str, ok := pod.Annotations[workloadspread.MatchedWorkloadSpreadSubsetAnnotations]; ok {
-		//			var injectWorkloadSpread *workloadspread.InjectWorkloadSpread
-		//			err := json.Unmarshal([]byte(str), &injectWorkloadSpread)
-		//			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		//			if injectWorkloadSpread.Subset == subset1.Name {
-		//				subset1Pods++
-		//				gomega.Expect(injectWorkloadSpread.Name).To(gomega.Equal(workloadSpread.Name))
-		//				gomega.Expect(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions).To(gomega.Equal(subset1.RequiredNodeSelectorTerm.MatchExpressions))
-		//				gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal("200"))
-		//			} else if injectWorkloadSpread.Subset == subset2.Name {
-		//				subset2Pods++
-		//				gomega.Expect(injectWorkloadSpread.Name).To(gomega.Equal(workloadSpread.Name))
-		//				gomega.Expect(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions).To(gomega.Equal(subset2.RequiredNodeSelectorTerm.MatchExpressions))
-		//				gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal("100"))
-		//			}
-		//		} else {
-		//			// others PodDeletionCostAnnotation not set
-		//			gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal(""))
-		//		}
-		//	}
-		//	gomega.Expect(subset1Pods).To(gomega.Equal(1))
-		//	gomega.Expect(subset2Pods).To(gomega.Equal(1))
-		//
-		//	// update cloneset image
-		//	ginkgo.By(fmt.Sprintf("update cloneSet(%s/%s) image=%s", cloneSet.Namespace, cloneSet.Name, "nginx:alpine"))
-		//	cloneSet.Spec.Template.Spec.Containers[0].Image = "nginx:alpine"
-		//	tester.UpdateCloneSet(cloneSet)
-		//	tester.WaitForCloneSetRunning(cloneSet)
-		//
-		//	// get pods, and check workloadSpread
-		//	ginkgo.By(fmt.Sprintf("get cloneSet(%s/%s) pods, and check workloadSpread(%s/%s) status", cloneSet.Namespace, cloneSet.Name, workloadSpread.Namespace, workloadSpread.Name))
-		//	pods, err = tester.GetSelectorPods(cloneSet.Namespace, cloneSet.Spec.Selector)
-		//	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		//	gomega.Expect(pods).To(gomega.HaveLen(2))
-		//	subset1Pods = 0
-		//	subset2Pods = 0
-		//	for _, pod := range pods {
-		//		if str, ok := pod.Annotations[workloadspread.MatchedWorkloadSpreadSubsetAnnotations]; ok {
-		//			var injectWorkloadSpread *workloadspread.InjectWorkloadSpread
-		//			err := json.Unmarshal([]byte(str), &injectWorkloadSpread)
-		//			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		//			if injectWorkloadSpread.Subset == subset1.Name {
-		//				subset1Pods++
-		//				gomega.Expect(injectWorkloadSpread.Name).To(gomega.Equal(workloadSpread.Name))
-		//				gomega.Expect(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions).To(gomega.Equal(subset1.RequiredNodeSelectorTerm.MatchExpressions))
-		//				gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal("200"))
-		//			} else if injectWorkloadSpread.Subset == subset2.Name {
-		//				subset2Pods++
-		//				gomega.Expect(injectWorkloadSpread.Name).To(gomega.Equal(workloadSpread.Name))
-		//				gomega.Expect(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions).To(gomega.Equal(subset2.RequiredNodeSelectorTerm.MatchExpressions))
-		//				gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal("100"))
-		//			}
-		//		} else {
-		//			// others PodDeletionCostAnnotation not set
-		//			gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal(""))
-		//		}
-		//	}
-		//	gomega.Expect(subset1Pods).To(gomega.Equal(1))
-		//	gomega.Expect(subset2Pods).To(gomega.Equal(1))
-		//
-		//	//scale up cloneSet.replicas = 6
-		//	ginkgo.By(fmt.Sprintf("scale up cloneSet(%s/%s) replicas=6", cloneSet.Namespace, cloneSet.Name))
-		//	cloneSet.Spec.Replicas = pointer.Int32Ptr(6)
-		//	tester.UpdateCloneSet(cloneSet)
-		//	tester.WaitForCloneSetRunning(cloneSet)
-		//
-		//	// get pods, and check workloadSpread
-		//	ginkgo.By(fmt.Sprintf("get cloneSet(%s/%s) pods, and check workloadSpread(%s/%s) status", cloneSet.Namespace, cloneSet.Name, workloadSpread.Namespace, workloadSpread.Name))
-		//	pods, err = tester.GetSelectorPods(cloneSet.Namespace, cloneSet.Spec.Selector)
-		//	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		//	gomega.Expect(pods).To(gomega.HaveLen(6))
-		//	subset1Pods = 0
-		//	subset2Pods = 0
-		//	for _, pod := range pods {
-		//		if str, ok := pod.Annotations[workloadspread.MatchedWorkloadSpreadSubsetAnnotations]; ok {
-		//			var injectWorkloadSpread *workloadspread.InjectWorkloadSpread
-		//			err := json.Unmarshal([]byte(str), &injectWorkloadSpread)
-		//			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		//			if injectWorkloadSpread.Subset == subset1.Name {
-		//				subset1Pods++
-		//				gomega.Expect(injectWorkloadSpread.Name).To(gomega.Equal(workloadSpread.Name))
-		//				gomega.Expect(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions).To(gomega.Equal(subset1.RequiredNodeSelectorTerm.MatchExpressions))
-		//				gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal("200"))
-		//			} else if injectWorkloadSpread.Subset == subset2.Name {
-		//				subset2Pods++
-		//				gomega.Expect(injectWorkloadSpread.Name).To(gomega.Equal(workloadSpread.Name))
-		//				gomega.Expect(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions).To(gomega.Equal(subset2.RequiredNodeSelectorTerm.MatchExpressions))
-		//				gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal("100"))
-		//			}
-		//		} else {
-		//			// others PodDeletionCostAnnotation not set
-		//			gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal(""))
-		//		}
-		//	}
-		//	gomega.Expect(subset1Pods).To(gomega.Equal(3))
-		//	gomega.Expect(subset2Pods).To(gomega.Equal(3))
-		//
-		//	workloadSpread, err = kc.AppsV1alpha1().WorkloadSpreads(workloadSpread.Namespace).Get(workloadSpread.Name, metav1.GetOptions{})
-		//	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		//
-		//	gomega.Expect(workloadSpread.Status.SubsetStatuses[0].Name).To(gomega.Equal(workloadSpread.Spec.Subsets[0].Name))
-		//	gomega.Expect(workloadSpread.Status.SubsetStatuses[0].MissingReplicas).To(gomega.Equal(int32(0)))
-		//	gomega.Expect(len(workloadSpread.Status.SubsetStatuses[0].CreatingPods)).To(gomega.Equal(0))
-		//	gomega.Expect(len(workloadSpread.Status.SubsetStatuses[0].DeletingPods)).To(gomega.Equal(0))
-		//
-		//	//scale down cloneSet.replicas = 2
-		//	ginkgo.By(fmt.Sprintf("scale down cloneSet(%s/%s) replicas=2", cloneSet.Namespace, cloneSet.Name))
-		//	cloneSet.Spec.Replicas = pointer.Int32Ptr(2)
-		//	tester.UpdateCloneSet(cloneSet)
-		//	tester.WaitForCloneSetRunning(cloneSet)
-		//
-		//	// get pods, and check workloadSpread
-		//	ginkgo.By(fmt.Sprintf("get cloneSet(%s/%s) pods, and check workloadSpread(%s/%s) status", cloneSet.Namespace, cloneSet.Name, workloadSpread.Namespace, workloadSpread.Name))
-		//	pods, err = tester.GetSelectorPods(cloneSet.Namespace, cloneSet.Spec.Selector)
-		//	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		//	gomega.Expect(pods).To(gomega.HaveLen(2))
-		//	subset1Pods = 0
-		//	subset2Pods = 0
-		//	for _, pod := range pods {
-		//		if str, ok := pod.Annotations[workloadspread.MatchedWorkloadSpreadSubsetAnnotations]; ok {
-		//			var injectWorkloadSpread *workloadspread.InjectWorkloadSpread
-		//			err := json.Unmarshal([]byte(str), &injectWorkloadSpread)
-		//			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		//			if injectWorkloadSpread.Subset == subset1.Name {
-		//				subset1Pods++
-		//				gomega.Expect(injectWorkloadSpread.Name).To(gomega.Equal(workloadSpread.Name))
-		//				gomega.Expect(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions).To(gomega.Equal(subset1.RequiredNodeSelectorTerm.MatchExpressions))
-		//				gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal("200"))
-		//			} else if injectWorkloadSpread.Subset == subset2.Name {
-		//				subset2Pods++
-		//				gomega.Expect(injectWorkloadSpread.Name).To(gomega.Equal(workloadSpread.Name))
-		//				gomega.Expect(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions).To(gomega.Equal(subset2.RequiredNodeSelectorTerm.MatchExpressions))
-		//				gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal("100"))
-		//			}
-		//		} else {
-		//			// others PodDeletionCostAnnotation not set
-		//			gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal(""))
-		//		}
-		//	}
-		//	gomega.Expect(subset1Pods).To(gomega.Equal(1))
-		//	gomega.Expect(subset2Pods).To(gomega.Equal(1))
-		//
-		//	ginkgo.By("deploy in two zone, maxReplicas=50%, done")
-		//})
+		ginkgo.It("deploy in two zone, maxReplicas=50%", func() {
+			cloneSet := tester.NewBaseCloneSet(ns)
+			// create workloadSpread
+			targetRef := appsv1alpha1.TargetReference{
+				APIVersion: KruiseKindCloneSet.GroupVersion().String(),
+				Kind:       KruiseKindCloneSet.Kind,
+				Name:       cloneSet.Name,
+			}
+			subset1 := appsv1alpha1.WorkloadSpreadSubset{
+				Name: "zone-a",
+				RequiredNodeSelectorTerm: &corev1.NodeSelectorTerm{
+					MatchExpressions: []corev1.NodeSelectorRequirement{
+						{
+							Key:      TopologyLabelKey,
+							Operator: corev1.NodeSelectorOpIn,
+							Values:   []string{"zone-a"},
+						},
+					},
+				},
+				MaxReplicas: &intstr.IntOrString{Type: intstr.String, StrVal: "50%"},
+				Patch: runtime.RawExtension{
+					Raw: []byte(`{"metadata":{"annotations":{"subset":"zone-a"}}}`),
+				},
+			}
+			subset2 := appsv1alpha1.WorkloadSpreadSubset{
+				Name: "zone-b",
+				RequiredNodeSelectorTerm: &corev1.NodeSelectorTerm{
+					MatchExpressions: []corev1.NodeSelectorRequirement{
+						{
+							Key:      TopologyLabelKey,
+							Operator: corev1.NodeSelectorOpIn,
+							Values:   []string{"zone-b"},
+						},
+					},
+				},
+				MaxReplicas: &intstr.IntOrString{Type: intstr.String, StrVal: "50%"},
+				Patch: runtime.RawExtension{
+					Raw: []byte(`{"metadata":{"annotations":{"subset":"zone-b"}}}`),
+				},
+			}
+			workloadSpread := tester.NewWorkloadSpread(ns, workloadSpreadName, &targetRef, []appsv1alpha1.WorkloadSpreadSubset{subset1, subset2})
+			workloadSpread = tester.CreateWorkloadSpread(workloadSpread)
+
+			// create cloneset, replicas = 2
+			cloneSet.Spec.Template.Spec.Containers[0].Image = "busybox:latest"
+			cloneSet = tester.CreateCloneSet(cloneSet)
+			tester.WaitForCloneSetRunning(cloneSet)
+
+			// get pods, and check workloadSpread
+			ginkgo.By(fmt.Sprintf("get cloneSet(%s/%s) pods, and check workloadSpread(%s/%s) status", cloneSet.Namespace, cloneSet.Name, workloadSpread.Namespace, workloadSpread.Name))
+			pods, err := tester.GetSelectorPods(cloneSet.Namespace, cloneSet.Spec.Selector)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(pods).To(gomega.HaveLen(2))
+			subset1Pods := 0
+			subset2Pods := 0
+			for _, pod := range pods {
+				if str, ok := pod.Annotations[workloadspread.MatchedWorkloadSpreadSubsetAnnotations]; ok {
+					var injectWorkloadSpread *workloadspread.InjectWorkloadSpread
+					err := json.Unmarshal([]byte(str), &injectWorkloadSpread)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					if injectWorkloadSpread.Subset == subset1.Name {
+						subset1Pods++
+						gomega.Expect(injectWorkloadSpread.Name).To(gomega.Equal(workloadSpread.Name))
+						gomega.Expect(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions).To(gomega.Equal(subset1.RequiredNodeSelectorTerm.MatchExpressions))
+						gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal("200"))
+					} else if injectWorkloadSpread.Subset == subset2.Name {
+						subset2Pods++
+						gomega.Expect(injectWorkloadSpread.Name).To(gomega.Equal(workloadSpread.Name))
+						gomega.Expect(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions).To(gomega.Equal(subset2.RequiredNodeSelectorTerm.MatchExpressions))
+						gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal("100"))
+					}
+				} else {
+					// others PodDeletionCostAnnotation not set
+					gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal(""))
+				}
+			}
+			gomega.Expect(subset1Pods).To(gomega.Equal(1))
+			gomega.Expect(subset2Pods).To(gomega.Equal(1))
+
+			// update cloneset image
+			ginkgo.By(fmt.Sprintf("update cloneSet(%s/%s) image=%s", cloneSet.Namespace, cloneSet.Name, "nginx:alpine"))
+			cloneSet.Spec.Template.Spec.Containers[0].Image = "nginx:alpine"
+			tester.UpdateCloneSet(cloneSet)
+			tester.WaitForCloneSetRunning(cloneSet)
+
+			// get pods, and check workloadSpread
+			ginkgo.By(fmt.Sprintf("get cloneSet(%s/%s) pods, and check workloadSpread(%s/%s) status", cloneSet.Namespace, cloneSet.Name, workloadSpread.Namespace, workloadSpread.Name))
+			pods, err = tester.GetSelectorPods(cloneSet.Namespace, cloneSet.Spec.Selector)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(pods).To(gomega.HaveLen(2))
+			subset1Pods = 0
+			subset2Pods = 0
+			for _, pod := range pods {
+				if str, ok := pod.Annotations[workloadspread.MatchedWorkloadSpreadSubsetAnnotations]; ok {
+					var injectWorkloadSpread *workloadspread.InjectWorkloadSpread
+					err := json.Unmarshal([]byte(str), &injectWorkloadSpread)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					if injectWorkloadSpread.Subset == subset1.Name {
+						subset1Pods++
+						gomega.Expect(injectWorkloadSpread.Name).To(gomega.Equal(workloadSpread.Name))
+						gomega.Expect(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions).To(gomega.Equal(subset1.RequiredNodeSelectorTerm.MatchExpressions))
+						gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal("200"))
+					} else if injectWorkloadSpread.Subset == subset2.Name {
+						subset2Pods++
+						gomega.Expect(injectWorkloadSpread.Name).To(gomega.Equal(workloadSpread.Name))
+						gomega.Expect(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions).To(gomega.Equal(subset2.RequiredNodeSelectorTerm.MatchExpressions))
+						gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal("100"))
+					}
+				} else {
+					// others PodDeletionCostAnnotation not set
+					gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal(""))
+				}
+			}
+			gomega.Expect(subset1Pods).To(gomega.Equal(1))
+			gomega.Expect(subset2Pods).To(gomega.Equal(1))
+
+			//scale up cloneSet.replicas = 6
+			ginkgo.By(fmt.Sprintf("scale up cloneSet(%s/%s) replicas=6", cloneSet.Namespace, cloneSet.Name))
+			cloneSet.Spec.Replicas = pointer.Int32Ptr(6)
+			tester.UpdateCloneSet(cloneSet)
+			tester.WaitForCloneSetRunning(cloneSet)
+
+			// get pods, and check workloadSpread
+			ginkgo.By(fmt.Sprintf("get cloneSet(%s/%s) pods, and check workloadSpread(%s/%s) status", cloneSet.Namespace, cloneSet.Name, workloadSpread.Namespace, workloadSpread.Name))
+			pods, err = tester.GetSelectorPods(cloneSet.Namespace, cloneSet.Spec.Selector)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(pods).To(gomega.HaveLen(6))
+			subset1Pods = 0
+			subset2Pods = 0
+			for _, pod := range pods {
+				if str, ok := pod.Annotations[workloadspread.MatchedWorkloadSpreadSubsetAnnotations]; ok {
+					var injectWorkloadSpread *workloadspread.InjectWorkloadSpread
+					err := json.Unmarshal([]byte(str), &injectWorkloadSpread)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					if injectWorkloadSpread.Subset == subset1.Name {
+						subset1Pods++
+						gomega.Expect(injectWorkloadSpread.Name).To(gomega.Equal(workloadSpread.Name))
+						gomega.Expect(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions).To(gomega.Equal(subset1.RequiredNodeSelectorTerm.MatchExpressions))
+						gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal("200"))
+					} else if injectWorkloadSpread.Subset == subset2.Name {
+						subset2Pods++
+						gomega.Expect(injectWorkloadSpread.Name).To(gomega.Equal(workloadSpread.Name))
+						gomega.Expect(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions).To(gomega.Equal(subset2.RequiredNodeSelectorTerm.MatchExpressions))
+						gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal("100"))
+					}
+				} else {
+					// others PodDeletionCostAnnotation not set
+					gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal(""))
+				}
+			}
+			gomega.Expect(subset1Pods).To(gomega.Equal(3))
+			gomega.Expect(subset2Pods).To(gomega.Equal(3))
+
+			workloadSpread, err = kc.AppsV1alpha1().WorkloadSpreads(workloadSpread.Namespace).Get(context.TODO(), workloadSpread.Name, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			gomega.Expect(workloadSpread.Status.SubsetStatuses[0].Name).To(gomega.Equal(workloadSpread.Spec.Subsets[0].Name))
+			gomega.Expect(workloadSpread.Status.SubsetStatuses[0].MissingReplicas).To(gomega.Equal(int32(0)))
+			gomega.Expect(len(workloadSpread.Status.SubsetStatuses[0].CreatingPods)).To(gomega.Equal(0))
+			gomega.Expect(len(workloadSpread.Status.SubsetStatuses[0].DeletingPods)).To(gomega.Equal(0))
+
+			//scale down cloneSet.replicas = 2
+			ginkgo.By(fmt.Sprintf("scale down cloneSet(%s/%s) replicas=2", cloneSet.Namespace, cloneSet.Name))
+			cloneSet.Spec.Replicas = pointer.Int32Ptr(2)
+			tester.UpdateCloneSet(cloneSet)
+			tester.WaitForCloneSetRunning(cloneSet)
+
+			// get pods, and check workloadSpread
+			ginkgo.By(fmt.Sprintf("get cloneSet(%s/%s) pods, and check workloadSpread(%s/%s) status", cloneSet.Namespace, cloneSet.Name, workloadSpread.Namespace, workloadSpread.Name))
+			pods, err = tester.GetSelectorPods(cloneSet.Namespace, cloneSet.Spec.Selector)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(pods).To(gomega.HaveLen(2))
+			subset1Pods = 0
+			subset2Pods = 0
+			for _, pod := range pods {
+				if str, ok := pod.Annotations[workloadspread.MatchedWorkloadSpreadSubsetAnnotations]; ok {
+					var injectWorkloadSpread *workloadspread.InjectWorkloadSpread
+					err := json.Unmarshal([]byte(str), &injectWorkloadSpread)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					if injectWorkloadSpread.Subset == subset1.Name {
+						subset1Pods++
+						gomega.Expect(injectWorkloadSpread.Name).To(gomega.Equal(workloadSpread.Name))
+						gomega.Expect(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions).To(gomega.Equal(subset1.RequiredNodeSelectorTerm.MatchExpressions))
+						gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal("200"))
+					} else if injectWorkloadSpread.Subset == subset2.Name {
+						subset2Pods++
+						gomega.Expect(injectWorkloadSpread.Name).To(gomega.Equal(workloadSpread.Name))
+						gomega.Expect(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions).To(gomega.Equal(subset2.RequiredNodeSelectorTerm.MatchExpressions))
+						gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal("100"))
+					}
+				} else {
+					// others PodDeletionCostAnnotation not set
+					gomega.Expect(pod.Annotations[workloadspread.PodDeletionCostAnnotation]).To(gomega.Equal(""))
+				}
+			}
+			gomega.Expect(subset1Pods).To(gomega.Equal(1))
+			gomega.Expect(subset2Pods).To(gomega.Equal(1))
+
+			ginkgo.By("deploy in two zone, maxReplicas=50%, done")
+		})
 
 		// test k8s cluster version >= 1.21
 		//ginkgo.It("elastic deploy for deployment, zone-a=2, zone-b=nil", func() {

--- a/test/e2e/framework/workloadspread_util.go
+++ b/test/e2e/framework/workloadspread_util.go
@@ -90,9 +90,10 @@ func (t *WorkloadSpreadTester) NewBaseCloneSet(namespace string) *appsv1alpha1.C
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Name:    "main",
-							Image:   "busybox:1.32",
-							Command: []string{"/bin/sh", "-c", "sleep 10000000"},
+							Name:            "main",
+							Image:           "busybox:1.32",
+							ImagePullPolicy: "IfNotPresent",
+							Command:         []string{"/bin/sh", "-c", "sleep 10000000"},
 						},
 					},
 				},


### PR DESCRIPTION
Signed-off-by: veophi <vec.g.sun@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
This pr allow WorkloadSpread to config percentage for MaxReplicas in each subset.

This pr add  `ObservedWorkloadGeneration` field for WorkloadSpread.Status, and 
- **when scaling down:** reject pod deletion request if  `ObservedWorkloadGeneration` < `Workload.Generation`;
- **when scaling up:** re-calculate status for each subset if  `ObservedWorkloadGeneration` != `Workload.Generation`;

### Ⅱ. Describe how to verify it
**Unit Test & E2E Test**



