### PR TITLE
Improve reschedule strategy of WorkloadSpread

### DIFF
--- a/pkg/controller/workloadspread/workloadspread_controller.go
+++ b/pkg/controller/workloadspread/workloadspread_controller.go
@@ -463,18 +463,10 @@ func (r *ReconcileWorkloadSpread) calculateWorkloadSpreadStatus(ws *appsv1alpha1
 			return nil, nil
 		}
 
-		// don't reschedule the last subset.
+		// reschedule failed-scheduled pods
 		if rescheduleCriticalSeconds > 0 {
-			if i != len(ws.Spec.Subsets)-1 {
-				pods := r.rescheduleSubset(ws, podMap[subset.Name], subsetStatus, oldSubsetStatusMap[subset.Name])
-				scheduleFailedPodMap[subset.Name] = pods
-			} else {
-				oldCondition := GetWorkloadSpreadSubsetCondition(oldSubsetStatusMap[subset.Name], appsv1alpha1.SubsetSchedulable)
-				if oldCondition != nil {
-					setWorkloadSpreadSubsetCondition(subsetStatus, oldCondition.DeepCopy())
-				}
-				setWorkloadSpreadSubsetCondition(subsetStatus, NewWorkloadSpreadSubsetCondition(appsv1alpha1.SubsetSchedulable, corev1.ConditionTrue, "", ""))
-			}
+			pods := r.rescheduleSubset(ws, podMap[subset.Name], subsetStatus, oldSubsetStatusMap[subset.Name])
+			scheduleFailedPodMap[subset.Name] = pods
 		} else {
 			removeWorkloadSpreadSubsetCondition(subsetStatus, appsv1alpha1.SubsetSchedulable)
 		}

--- a/pkg/webhook/workloadspread/validating/workloadspread_validation.go
+++ b/pkg/webhook/workloadspread/validating/workloadspread_validation.go
@@ -132,10 +132,10 @@ func validateWorkloadSpreadSpec(obj *appsv1alpha1.WorkloadSpread, fldPath *field
 				spec.ScheduleStrategy.Adaptive.RescheduleCriticalSeconds, "the scheduleStrategy's type must be adaptive when using adaptive scheduleStrategy"))
 		}
 
-		if len(spec.Subsets) > 1 && spec.Subsets[len(spec.Subsets)-1].MaxReplicas != nil {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("scheduleStrategy").Child("adaptive"),
-				spec.ScheduleStrategy.Adaptive.RescheduleCriticalSeconds, "the last subset must be not specified when using adaptive scheduleStrategy"))
-		}
+		//if len(spec.Subsets) > 1 && spec.Subsets[len(spec.Subsets)-1].MaxReplicas != nil {
+		//	allErrs = append(allErrs, field.Invalid(fldPath.Child("scheduleStrategy").Child("adaptive"),
+		//		spec.ScheduleStrategy.Adaptive.RescheduleCriticalSeconds, "the last subset must be not specified when using adaptive scheduleStrategy"))
+		//}
 
 		if spec.ScheduleStrategy.Adaptive.RescheduleCriticalSeconds != nil &&
 			*spec.ScheduleStrategy.Adaptive.RescheduleCriticalSeconds <= 0 {

--- a/pkg/webhook/workloadspread/validating/workloadspread_validation_test.go
+++ b/pkg/webhook/workloadspread/validating/workloadspread_validation_test.go
@@ -678,22 +678,22 @@ func TestValidateWorkloadSpreadCreate(t *testing.T) {
 			},
 			errorSuffix: "spec.scheduleStrategy.type",
 		},
-		{
-			name: "the last subset's maxReplicas is not nil when using adaptive",
-			getWorkloadSpread: func() *appsv1alpha1.WorkloadSpread {
-				workloadSpread := workloadSpreadDemo.DeepCopy()
-				workloadSpread.Spec.ScheduleStrategy = appsv1alpha1.WorkloadSpreadScheduleStrategy{
-					Type: appsv1alpha1.AdaptiveWorkloadSpreadScheduleStrategyType,
-					Adaptive: &appsv1alpha1.AdaptiveWorkloadSpreadStrategy{
-						RescheduleCriticalSeconds: pointer.Int32Ptr(20),
-						DisableSimulationSchedule: true,
-					},
-				}
-				workloadSpread.Spec.Subsets[2].MaxReplicas = &maxReplicasDemo
-				return workloadSpread
-			},
-			errorSuffix: "spec.scheduleStrategy.adaptive",
-		},
+		//{
+		//	name: "the last subset's maxReplicas is not nil when using adaptive",
+		//	getWorkloadSpread: func() *appsv1alpha1.WorkloadSpread {
+		//		workloadSpread := workloadSpreadDemo.DeepCopy()
+		//		workloadSpread.Spec.ScheduleStrategy = appsv1alpha1.WorkloadSpreadScheduleStrategy{
+		//			Type: appsv1alpha1.AdaptiveWorkloadSpreadScheduleStrategyType,
+		//			Adaptive: &appsv1alpha1.AdaptiveWorkloadSpreadStrategy{
+		//				RescheduleCriticalSeconds: pointer.Int32Ptr(20),
+		//				DisableSimulationSchedule: true,
+		//			},
+		//		}
+		//		workloadSpread.Spec.Subsets[2].MaxReplicas = &maxReplicasDemo
+		//		return workloadSpread
+		//	},
+		//	errorSuffix: "spec.scheduleStrategy.adaptive",
+		//},
 	}
 
 	for _, errorCase := range errorCases {


### PR DESCRIPTION
Signed-off-by: veophi <vec.g.sun@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Improve reschedule strategy of WorkloadSpread:
- Remove the constraint that must set the `MaxReplicas` of the last subset  as `nil` (**more flexible to use**)
- Remove the strict `MaxReplicas` constraint to safeguard the privilege of pod creation (**more safe to use**) 

### Ⅱ. Describe how to verify it
E2E Test

### Ⅲ. Special notes for reviews
**If all of the subsets are unschedulable, workloadSpread will inject nothing to pods.**
