### PR TITLE
Fix pod NodeSelectorTerms length 0 when UnitedDeployment NodeSelector…

### DIFF
--- a/pkg/controller/uniteddeployment/adapter/adapter_util.go
+++ b/pkg/controller/uniteddeployment/adapter/adapter_util.go
@@ -35,6 +35,10 @@ func getSubsetPrefix(controllerName, subsetName string) string {
 }
 
 func attachNodeAffinity(podSpec *corev1.PodSpec, subsetConfig *appsv1alpha1.Subset) {
+	if len(subsetConfig.NodeSelectorTerm.MatchExpressions) == 0 {
+		return
+	}
+
 	if podSpec.Affinity == nil {
 		podSpec.Affinity = &corev1.Affinity{}
 	}


### PR DESCRIPTION
…Terms is nil

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Avoid UnitedDeployment cretae workload template NodeSelectorTerms length 0

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #807 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it
follow the reproduce procedure in issue.


### Ⅴ. Special notes for reviews


