### PR TITLE
Add crio.sock to criruntime

### DIFF
--- a/pkg/daemon/criruntime/factory.go
+++ b/pkg/daemon/criruntime/factory.go
@@ -197,7 +197,7 @@ func detectRuntime(varRunPath string) []runtimeConfig {
 		}
 	}
 
-	// containerd
+	// other implements of cri, include containerd, crio
 	{
 		if _, err = os.Stat(fmt.Sprintf("%s/containerd.sock", varRunPath)); err == nil {
 			cfgs = append(cfgs, runtimeConfig{
@@ -209,6 +209,12 @@ func detectRuntime(varRunPath string) []runtimeConfig {
 			cfgs = append(cfgs, runtimeConfig{
 				runtimeType:      ContainerRuntimeContainerd,
 				runtimeRemoteURI: fmt.Sprintf("unix://%s/containerd/containerd.sock", varRunPath),
+			})
+		}
+		if _, err = os.Stat(fmt.Sprintf("%s/crio.sock", varRunPath)); err == nil {
+			cfgs = append(cfgs, runtimeConfig{
+				runtimeType:      ContainerRuntimeContainerd,
+				runtimeRemoteURI: fmt.Sprintf("unix://%s/crio.sock", varRunPath),
 			})
 		}
 	}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
Add crio.sock to criruntime
当前代码定义了三个容器运行时：docker、pouch、containerd，
我将CRI-O这个容器运行时直接加入到了containerd，这两个运行时可以作为标准的CRI处理

### Ⅱ. Does this pull request fix one issue?
fixes #804 

### III. Special notes for reviews
对detectRuntime这个函数有几个疑问：
1. 返回参数是一个列表（[]runtimeConfig），是考虑一个节点有多个runtime的情况吗？有这个场景吗？
2. 传入参数varRunPath是sock文件所在目录，是否直接传sock文件更合适些？


