### PR TITLE
Mark revision stable when all pods updated to it

### DIFF
--- a/pkg/controller/cloneset/cloneset_status.go
+++ b/pkg/controller/cloneset/cloneset_status.go
@@ -97,8 +97,8 @@ func (r *realStatusUpdater) calculateStatus(cs *appsv1alpha1.CloneSet, newStatus
 			newStatus.UpdatedReadyReplicas++
 		}
 	}
-	if newStatus.UpdatedReplicas == newStatus.Replicas &&
-		newStatus.ReadyReplicas == newStatus.Replicas {
+	// Consider the update revision as stable if revisions of all pods are consistent to it, no need to wait all of them ready
+	if newStatus.UpdatedReplicas == newStatus.Replicas {
 		newStatus.CurrentRevision = newStatus.UpdateRevision
 	}
 }

--- a/pkg/util/imagejob/utilfunction/imagejob_util.go
+++ b/pkg/util/imagejob/utilfunction/imagejob_util.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/klog/v2"
 	utilpointer "k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -74,9 +75,11 @@ func DeleteJobsForWorkload(c client.Client, ownerObj metav1.Object) error {
 
 	for i := range jobList.Items {
 		job := &jobList.Items[i]
-		if owner := metav1.GetControllerOf(job); owner == nil || owner.UID != ownerObj.GetUID() {
+		owner := metav1.GetControllerOf(job)
+		if owner == nil || owner.UID != ownerObj.GetUID() {
 			continue
 		}
+		klog.Infof("Deleting ImagePullJob %s for workload %s %s/%s", job.Name, owner.Kind, ownerObj.GetNamespace(), ownerObj.GetName())
 		if err := c.Delete(context.TODO(), job); err != nil {
 			return err
 		}

--- a/test/e2e/apps/cloneset.go
+++ b/test/e2e/apps/cloneset.go
@@ -251,7 +251,8 @@ var _ = SIGDescribe("CloneSet", func() {
 		var err error
 
 		ginkgo.It("pre-download for new image", func() {
-			cs := tester.NewCloneSet("clone-"+randStr, 5, appsv1alpha1.CloneSetUpdateStrategy{Type: appsv1alpha1.InPlaceIfPossibleCloneSetUpdateStrategyType})
+			partition := intstr.FromInt(1)
+			cs := tester.NewCloneSet("clone-"+randStr, 5, appsv1alpha1.CloneSetUpdateStrategy{Type: appsv1alpha1.InPlaceIfPossibleCloneSetUpdateStrategyType, Partition: &partition})
 			cs, err = tester.CreateCloneSet(cs)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(cs.Spec.UpdateStrategy.Type).To(gomega.Equal(appsv1alpha1.InPlaceIfPossibleCloneSetUpdateStrategyType))


### PR DESCRIPTION
Signed-off-by: FillZpp <FillZpp.pub@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Consider the update revision as stable if revisions of all pods are consistent to it, no need to wait all of them ready.

