### PR TITLE
Make workloadSpread more robust and easily-used.

### DIFF
--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -273,6 +273,27 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /validate-apps-kruise-io-v1alpha1-workloadspread
+  failurePolicy: Fail
+  name: vworkloadspread.kb.io
+  rules:
+  - apiGroups:
+    - apps.kruise.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - workloadspreads
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /validate-apps-kruise-io-v1alpha1-advancedcronjob
   failurePolicy: Fail
   name: vadvancedcronjob.kb.io
@@ -621,25 +642,4 @@ webhooks:
     - DELETE
     resources:
     - uniteddeployments
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: webhook-service
-      namespace: system
-      path: /validate-apps-kruise-io-v1alpha1-workloadspread
-  failurePolicy: Fail
-  name: vworkloadspread.kb.io
-  rules:
-  - apiGroups:
-    - apps.kruise.io
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - workloadspreads
   sideEffects: None

--- a/pkg/controller/workloadspread/reschedule.go
+++ b/pkg/controller/workloadspread/reschedule.go
@@ -24,9 +24,8 @@ import (
 	"k8s.io/klog/v2"
 
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
+	wsutil "github.com/openkruise/kruise/pkg/webhook/workloadspread/validating"
 )
-
-const ScheduledFailedDuration = 5 * time.Minute
 
 // rescheduleSubset will delete some unschedulable Pods that still in pending status. Some subsets have no
 // sufficient resource can lead to some Pods scheduled failed. WorkloadSpread has multiple subset, so these
@@ -67,7 +66,7 @@ func (r *ReconcileWorkloadSpread) rescheduleSubset(ws *appsv1alpha1.WorkloadSpre
 	} else {
 		// consider to recover
 		if oldCondition.Status == corev1.ConditionFalse {
-			expectReschedule := oldCondition.LastTransitionTime.Add(ScheduledFailedDuration)
+			expectReschedule := oldCondition.LastTransitionTime.Add(wsutil.MaxScheduledFailedDuration)
 			currentTime := time.Now()
 			// the duration of unschedule status more than 5 minutes, recover to schedulable.
 			if expectReschedule.Before(currentTime) {

--- a/pkg/webhook/workloadspread/validating/workloadspread_validation_test.go
+++ b/pkg/webhook/workloadspread/validating/workloadspread_validation_test.go
@@ -477,17 +477,17 @@ func TestValidateWorkloadSpreadCreate(t *testing.T) {
 			},
 			errorSuffix: "spec.subsets[1].name",
 		},
-		{
-			name: "subset[0]'s requiredNodeSelectorTerm, preferredNodeSelectorTerms and tolerations are all empty",
-			getWorkloadSpread: func() *appsv1alpha1.WorkloadSpread {
-				workloadSpread := workloadSpreadDemo.DeepCopy()
-				workloadSpread.Spec.Subsets[0].RequiredNodeSelectorTerm = nil
-				workloadSpread.Spec.Subsets[0].PreferredNodeSelectorTerms = nil
-				workloadSpread.Spec.Subsets[0].Tolerations = nil
-				return workloadSpread
-			},
-			errorSuffix: "spec.subsets[0].requiredNodeSelectorTerm",
-		},
+		//{
+		//	name: "subset[0]'s requiredNodeSelectorTerm, preferredNodeSelectorTerms and tolerations are all empty",
+		//	getWorkloadSpread: func() *appsv1alpha1.WorkloadSpread {
+		//		workloadSpread := workloadSpreadDemo.DeepCopy()
+		//		workloadSpread.Spec.Subsets[0].RequiredNodeSelectorTerm = nil
+		//		workloadSpread.Spec.Subsets[0].PreferredNodeSelectorTerms = nil
+		//		workloadSpread.Spec.Subsets[0].Tolerations = nil
+		//		return workloadSpread
+		//	},
+		//	errorSuffix: "spec.subsets[0].requiredNodeSelectorTerm",
+		//},
 		{
 			name: "requiredNodeSelectorTerm are not valid",
 			getWorkloadSpread: func() *appsv1alpha1.WorkloadSpread {
@@ -634,13 +634,13 @@ func TestValidateWorkloadSpreadCreate(t *testing.T) {
 			errorSuffix: "spec.scheduleStrategy.type",
 		},
 		{
-			name: "rescheduleCriticalSeconds = 0",
+			name: "rescheduleCriticalSeconds = -1",
 			getWorkloadSpread: func() *appsv1alpha1.WorkloadSpread {
 				workloadSpread := workloadSpreadDemo.DeepCopy()
 				workloadSpread.Spec.ScheduleStrategy = appsv1alpha1.WorkloadSpreadScheduleStrategy{
 					Type: appsv1alpha1.AdaptiveWorkloadSpreadScheduleStrategyType,
 					Adaptive: &appsv1alpha1.AdaptiveWorkloadSpreadStrategy{
-						RescheduleCriticalSeconds: pointer.Int32Ptr(0),
+						RescheduleCriticalSeconds: pointer.Int32Ptr(-1),
 						DisableSimulationSchedule: true,
 					},
 				}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Two things:
1. Relax webhook validating restriction about subset: No limit for name-only subset.
2. Improve the management for the pods that were created before workloadspread:
   - consider PreferredNodeSelectorTerms and Patch of subset when matching these pods and  subsets;
   - update the deletion cost of the pods that cannot match any subset to -100 * (len(subsets)+1), so that make sure these pods can be deleted preferentially.

### Ⅳ. Describe how to verify it
Unit Test & E2E Test



