### PR TITLE
Fix error adding pod Webhook module comment

### DIFF
--- a/pkg/webhook/add_pod.go
+++ b/pkg/webhook/add_pod.go
@@ -45,7 +45,7 @@ func init() {
 			return false
 		}
 
-		// Currently, if SidecarSet is not installed, we can also disable pod webhook.
+		// Currently, if PodUnavailableBudget is not installed, we can also disable pod webhook.
 		if !utildiscovery.DiscoverObject(&policyv1alpha1.PodUnavailableBudget{}) {
 			return false
 		}


### PR DESCRIPTION
When I read the Add POD Webhook to HashMap module, I noticed a discrepancy between the comments and the code
```
// Currently, if **SidecarSet** is not installed, we can also disable pod webhook.
if !utildiscovery.DiscoverObject(&policyv1alpha1.**PodUnavailableBudget**{}) {
	return false
}
```
It confused me, so I changed it。

@furykerry 
