### PR TITLE
Fix bug: Read conditions from nil old subset status

### DIFF
--- a/pkg/controller/workloadspread/workloadspread_controller_utils.go
+++ b/pkg/controller/workloadspread/workloadspread_controller_utils.go
@@ -39,6 +39,9 @@ func NewWorkloadSpreadSubsetCondition(condType appsv1alpha1.WorkloadSpreadSubset
 
 // GetWorkloadSpreadSubsetCondition returns the condition with the provided type.
 func GetWorkloadSpreadSubsetCondition(status *appsv1alpha1.WorkloadSpreadSubsetStatus, condType appsv1alpha1.WorkloadSpreadSubsetConditionType) *appsv1alpha1.WorkloadSpreadSubsetCondition {
+	if status == nil {
+		return nil
+	}
 	for i := range status.Conditions {
 		c := status.Conditions[i]
 		if c.Type == condType {


### PR DESCRIPTION
Signed-off-by: veophi <vec.g.sun@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
When applying a workloadSpread with rescheduleStrategy and unschedulable subsets, workloadSpread may read `conditions` from nil. This PR fixed this bug.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #835 



