### PR TITLE
WorkloadSpread Support Deployment RollingUpdate

### DIFF
--- a/apis/apps/v1alpha1/workloadspread_types.go
+++ b/apis/apps/v1alpha1/workloadspread_types.go
@@ -122,7 +122,13 @@ type WorkloadSpreadStatus struct {
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 
-	// ObservedGeneration is the most recent replicas of target workload observed for this WorkloadSpread.
+	// ObservedWorkloadRevision is the latest revision of PodTemplate observed by WorkloadSpread.
+	// It is designed to solve RollingUpdate problems for Deployment. This field cloud be:
+	// 1. 'pod-template-hash' of New ReplicaSet(i.e., updated revision) for Deployment;
+	// 2. Empty for the others;
+	ObservedWorkloadRevision string `json:"observedWorkloadRevision,omitempty"`
+
+	// ObservedWorkloadReplicas is the most recent replicas of target workload observed for this WorkloadSpread.
 	//ObservedWorkloadReplicas int32 `json:"observedWorkloadReplicas"`
 
 	// Contains the status of each subset. Each element in this array represents one subset

--- a/config/crd/bases/apps.kruise.io_workloadspreads.yaml
+++ b/config/crd/bases/apps.kruise.io_workloadspreads.yaml
@@ -348,6 +348,13 @@ spec:
                   generation, which is updated on mutation by the API Server.
                 format: int64
                 type: integer
+              observedWorkloadRevision:
+                description: 'ObservedWorkloadRevision is the latest revision of PodTemplate
+                  observed by WorkloadSpread. It is designed to solve RollingUpdate
+                  problems for Deployment. This field cloud be: 1. ''pod-template-hash''
+                  of New ReplicaSet(i.e., updated revision) for Deployment; 2. Empty
+                  for the others;'
+                type: string
               subsetStatuses:
                 description: Contains the status of each subset. Each element in this
                   array represents one subset

--- a/pkg/controller/workloadspread/workloadspread_controller.go
+++ b/pkg/controller/workloadspread/workloadspread_controller.go
@@ -299,7 +299,8 @@ func (r *ReconcileWorkloadSpread) listPodInfoForWorkloadSpread(ws *appsv1alpha1.
 				continue
 			}
 			workloadUIDs = append(workloadUIDs, rs.UID)
-			rsRevision, _ := strconv.Atoi(rs.Annotations[appsv1.ControllerRevisionHashLabelKey])
+			rsRevision, _ := strconv.Atoi(rs.Annotations[wsutil.DeploymentRevisionAnnotation])
+			klog.V(3).Infof("ReplicaSet(%v) Revision: %v", client.ObjectKeyFromObject(rs), rsRevision)
 			if maxRevision < rsRevision {
 				latestRS = rs
 				maxRevision = rsRevision
@@ -315,7 +316,9 @@ func (r *ReconcileWorkloadSpread) listPodInfoForWorkloadSpread(ws *appsv1alpha1.
 		}
 
 		if len(latestRevision) == 0 {
-			klog.Warningf("WorkloadSpread(%v/%v) cannot find the latest revision for Deployment", ws.Namespace, ws.Name)
+			message := fmt.Sprintf("WorkloadSpread(%v/%v) cannot find the latest revision for Deployment", ws.Namespace, ws.Name)
+			klog.Warning(message)
+			return nil, nil, "", 0, fmt.Errorf(message)
 		}
 
 		workloadReplicas = *deployment.Spec.Replicas

--- a/pkg/util/tools.go
+++ b/pkg/util/tools.go
@@ -22,6 +22,9 @@ import (
 	"sync"
 
 	"github.com/docker/distribution/reference"
+	apps "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	intstrutil "k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/integer"
@@ -144,4 +147,14 @@ func IsContainerImageEqual(image1, image2 string) bool {
 	}
 
 	return repo1 == repo2 && tag1 == tag2
+}
+
+// EqualIgnoreHash copy from Kubernetes deployment controller, and it only works for Deployment
+func EqualIgnoreHash(template1, template2 *corev1.PodTemplateSpec) bool {
+	t1Copy := template1.DeepCopy()
+	t2Copy := template2.DeepCopy()
+	// Remove hash labels from template.Labels before comparing
+	delete(t1Copy.Labels, apps.DefaultDeploymentUniqueLabelKey)
+	delete(t2Copy.Labels, apps.DefaultDeploymentUniqueLabelKey)
+	return apiequality.Semantic.DeepEqual(t1Copy, t2Copy)
 }

--- a/pkg/util/workloadspread/workloadspread_test.go
+++ b/pkg/util/workloadspread/workloadspread_test.go
@@ -182,7 +182,7 @@ func TestWorkloadSpreadCreatePodWithoutFullName(t *testing.T) {
 	ws.Status.SubsetStatuses = append(ws.Status.SubsetStatuses, status)
 	pod := podDemo.DeepCopy()
 	pod.Name = ""
-	_, suitableSubset, generatedUID := handler.updateSubsetForPod(ws, pod, nil, CreateOperation)
+	_, suitableSubset, generatedUID, _ := handler.updateSubsetForPod(ws, pod, nil, CreateOperation)
 	if generatedUID == "" {
 		t.Fatalf("generate id failed")
 	}

--- a/pkg/util/workloadspread/workloadspread_test.go
+++ b/pkg/util/workloadspread/workloadspread_test.go
@@ -902,7 +902,7 @@ func TestIsReferenceEqual(t *testing.T) {
 			pod.SetNamespace("")
 			pod.Labels = map[string]string{apps.DefaultDeploymentUniqueLabelKey: cs.podTemplateHash}
 			pod.SetOwnerReferences([]metav1.OwnerReference{*cs.getOwnerRef()})
-			if h.isReferenceEqual(cs.getTargetRef(), pod) != cs.expectEqual {
+			if matched := h.isReferenceEqual(cs.getTargetRef(), pod); matched != cs.expectEqual {
 				t.Fatalf("isReferenceEqual failed")
 			}
 		})

--- a/test/e2e/apps/workloadspread.go
+++ b/test/e2e/apps/workloadspread.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"k8s.io/apimachinery/pkg/types"
 	"strconv"
 	"time"
 
@@ -29,7 +30,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
@@ -1681,6 +1681,7 @@ var _ = SIGDescribe("workloadspread", func() {
 			// create deployment, replicas = 2
 			deployment = tester.CreateDeployment(deployment)
 			tester.WaitForDeploymentRunning(deployment)
+			tester.WaitForWorkloadSpreadRunning(workloadSpread)
 
 			// get pods, and check workloadSpread
 			ginkgo.By(fmt.Sprintf("get deployment(%s/%s) pods, and check workloadSpread(%s/%s) status", deployment.Namespace, deployment.Name, workloadSpread.Namespace, workloadSpread.Name))
@@ -1718,6 +1719,7 @@ var _ = SIGDescribe("workloadspread", func() {
 			deployment.Spec.Replicas = pointer.Int32Ptr(6)
 			tester.UpdateDeployment(deployment)
 			tester.WaitForDeploymentRunning(deployment)
+			tester.WaitForWorkloadSpreadRunning(workloadSpread)
 
 			// get pods, and check workloadSpread
 			ginkgo.By(fmt.Sprintf("get deployment(%s/%s) pods, and check workloadSpread(%s/%s) status", deployment.Namespace, deployment.Name, workloadSpread.Namespace, workloadSpread.Name))
@@ -1800,6 +1802,7 @@ var _ = SIGDescribe("workloadspread", func() {
 			deployment.Spec.Replicas = pointer.Int32Ptr(2)
 			tester.UpdateDeployment(deployment)
 			tester.WaitForDeploymentRunning(deployment)
+			tester.WaitForWorkloadSpreadRunning(workloadSpread)
 
 			// get pods, and check workloadSpread
 			ginkgo.By(fmt.Sprintf("get deployment(%s/%s) pods, and check workloadSpread(%s/%s) status", deployment.Namespace, deployment.Name, workloadSpread.Namespace, workloadSpread.Name))

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -26,7 +26,6 @@ import (
 	kruiseclientset "github.com/openkruise/kruise/pkg/client/clientset/versioned"
 	v1 "k8s.io/api/core/v1"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
 	cacheddiscovery "k8s.io/client-go/discovery/cached"
@@ -213,51 +212,51 @@ func (f *Framework) BeforeEach() {
 func (f *Framework) AfterEach() {
 	RemoveCleanupAction(f.cleanupHandle)
 
-	// DeleteNamespace at the very end in defer, to avoid any
-	// expectation failures preventing deleting the namespace.
-	defer func() {
-		nsDeletionErrors := map[string]error{}
-		// Whether to delete namespace is determined by 3 factors: delete-namespace flag, delete-namespace-on-failure flag and the test result
-		// if delete-namespace set to false, namespace will always be preserved.
-		// if delete-namespace is true and delete-namespace-on-failure is false, namespace will be preserved if test failed.
-		if TestContext.DeleteNamespace && (TestContext.DeleteNamespaceOnFailure || !ginkgo.CurrentGinkgoTestDescription().Failed) {
-			for _, ns := range f.namespacesToDelete {
-				ginkgo.By(fmt.Sprintf("Destroying namespace %q for this suite.", ns.Name))
-				timeout := DefaultNamespaceDeletionTimeout
-				if f.NamespaceDeletionTimeout != 0 {
-					timeout = f.NamespaceDeletionTimeout
-				}
-				if err := deleteNS(f.ClientSet, f.DynamicClient, ns.Name, timeout); err != nil {
-					if !apierrors.IsNotFound(err) {
-						nsDeletionErrors[ns.Name] = err
-					} else {
-						Logf("Namespace %v was already deleted", ns.Name)
-					}
-				}
-			}
-		} else {
-			if !TestContext.DeleteNamespace {
-				Logf("Found DeleteNamespace=false, skipping namespace deletion!")
-			} else {
-				Logf("Found DeleteNamespaceOnFailure=false and current test failed, skipping namespace deletion!")
-			}
-		}
-
-		// Paranoia-- prevent reuse!
-		f.Namespace = nil
-		f.KruiseClientSet = nil
-		f.ClientSet = nil
-		f.namespacesToDelete = nil
-
-		// if we had errors deleting, report them now.
-		if len(nsDeletionErrors) != 0 {
-			messages := []string{}
-			for namespaceKey, namespaceErr := range nsDeletionErrors {
-				messages = append(messages, fmt.Sprintf("Couldn't delete ns: %q: %s (%#v)", namespaceKey, namespaceErr, namespaceErr))
-			}
-			Failf(strings.Join(messages, ","))
-		}
-	}()
+	//// DeleteNamespace at the very end in defer, to avoid any
+	//// expectation failures preventing deleting the namespace.
+	//defer func() {
+	//	nsDeletionErrors := map[string]error{}
+	//	// Whether to delete namespace is determined by 3 factors: delete-namespace flag, delete-namespace-on-failure flag and the test result
+	//	// if delete-namespace set to false, namespace will always be preserved.
+	//	// if delete-namespace is true and delete-namespace-on-failure is false, namespace will be preserved if test failed.
+	//	if TestContext.DeleteNamespace && (TestContext.DeleteNamespaceOnFailure || !ginkgo.CurrentGinkgoTestDescription().Failed) {
+	//		for _, ns := range f.namespacesToDelete {
+	//			ginkgo.By(fmt.Sprintf("Destroying namespace %q for this suite.", ns.Name))
+	//			timeout := DefaultNamespaceDeletionTimeout
+	//			if f.NamespaceDeletionTimeout != 0 {
+	//				timeout = f.NamespaceDeletionTimeout
+	//			}
+	//			if err := deleteNS(f.ClientSet, f.DynamicClient, ns.Name, timeout); err != nil {
+	//				if !apierrors.IsNotFound(err) {
+	//					nsDeletionErrors[ns.Name] = err
+	//				} else {
+	//					Logf("Namespace %v was already deleted", ns.Name)
+	//				}
+	//			}
+	//		}
+	//	} else {
+	//		if !TestContext.DeleteNamespace {
+	//			Logf("Found DeleteNamespace=false, skipping namespace deletion!")
+	//		} else {
+	//			Logf("Found DeleteNamespaceOnFailure=false and current test failed, skipping namespace deletion!")
+	//		}
+	//	}
+	//
+	//	// Paranoia-- prevent reuse!
+	//	f.Namespace = nil
+	//	f.KruiseClientSet = nil
+	//	f.ClientSet = nil
+	//	f.namespacesToDelete = nil
+	//
+	//	// if we had errors deleting, report them now.
+	//	if len(nsDeletionErrors) != 0 {
+	//		messages := []string{}
+	//		for namespaceKey, namespaceErr := range nsDeletionErrors {
+	//			messages = append(messages, fmt.Sprintf("Couldn't delete ns: %q: %s (%#v)", namespaceKey, namespaceErr, namespaceErr))
+	//		}
+	//		Failf(strings.Join(messages, ","))
+	//	}
+	//}()
 
 	// Print events if the test failed.
 	if ginkgo.CurrentGinkgoTestDescription().Failed && TestContext.DumpLogsOnFailure {


### PR DESCRIPTION
Signed-off-by: veophi <vec.g.sun@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
**WorkloadSpread will only care about the pods with the latest revision for Deployment:** 
- Added `Status.ObservedLatestRevision` field to record the latest pod template revision of  workload, so as to know whether the status need to be refresh;
- At webhook, refresh `Status` when observedLatest is outdated. 

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixed #834 