### PR TITLE
fix #879 Statefulset should consider non-available pods when deleting…

### DIFF
--- a/pkg/controller/statefulset/stateful_set_control.go
+++ b/pkg/controller/statefulset/stateful_set_control.go
@@ -581,12 +581,15 @@ func (ssc *defaultStatefulSetControl) updateStatefulSet(
 			continue
 		}
 		// if we are in monotonic mode and the condemned target is not the first unhealthy Pod block
-		if avail, _ := isRunningAndAvailable(condemned[target], minReadySeconds); !avail && monotonic && condemned[target] != firstUnhealthyPod {
+		if avail, waitTime := isRunningAndAvailable(condemned[target], minReadySeconds); !avail && monotonic && condemned[target] != firstUnhealthyPod {
 			klog.V(4).Infof(
 				"StatefulSet %s/%s is waiting for Pod %s to be Running and Available prior to scale down",
 				set.Namespace,
 				set.Name,
 				firstUnhealthyPod.Name)
+			if waitTime > 0 {
+				durationStore.Push(getStatefulSetKey(condemned[target]), waitTime)
+			}
 			return &status, nil
 		}
 		klog.V(2).Infof("StatefulSet %s/%s terminating Pod %s for scale down",

--- a/pkg/controller/statefulset/stateful_set_control.go
+++ b/pkg/controller/statefulset/stateful_set_control.go
@@ -581,9 +581,9 @@ func (ssc *defaultStatefulSetControl) updateStatefulSet(
 			continue
 		}
 		// if we are in monotonic mode and the condemned target is not the first unhealthy Pod block
-		if !isRunningAndReady(condemned[target]) && monotonic && condemned[target] != firstUnhealthyPod {
+		if avail, _ := isRunningAndAvailable(condemned[target], minReadySeconds); !avail && monotonic && condemned[target] != firstUnhealthyPod {
 			klog.V(4).Infof(
-				"StatefulSet %s/%s is waiting for Pod %s to be Running and Ready prior to scale down",
+				"StatefulSet %s/%s is waiting for Pod %s to be Running and Available prior to scale down",
 				set.Namespace,
 				set.Name,
 				firstUnhealthyPod.Name)


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
fixes #879 , use `isRunningAndAvailable` to instead of `isRunningAndReady`

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #879 

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

