### PR TITLE
CloneSet refresh pod states before skipping update when paused

### DIFF
--- a/pkg/controller/cloneset/sync/cloneset_update.go
+++ b/pkg/controller/cloneset/sync/cloneset_update.go
@@ -48,10 +48,6 @@ func (c *realControl) Update(cs *appsv1alpha1.CloneSet,
 	requeueDuration := requeueduration.Duration{}
 	coreControl := clonesetcore.New(cs)
 
-	if cs.Spec.UpdateStrategy.Paused {
-		return requeueDuration.Get(), nil
-	}
-
 	// 1. refresh states for all pods
 	var modified bool
 	for _, pod := range pods {
@@ -66,6 +62,10 @@ func (c *realControl) Update(cs *appsv1alpha1.CloneSet,
 		}
 	}
 	if modified {
+		return requeueDuration.Get(), nil
+	}
+
+	if cs.Spec.UpdateStrategy.Paused {
 		return requeueDuration.Get(), nil
 	}
 


### PR DESCRIPTION
Signed-off-by: FillZpp <FillZpp.pub@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
CloneSet refresh pod states before skipping update when paused

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

fixes #892 
