### PR TITLE
fix:add volumes that initcontainers used in sidecarset

### DIFF
--- a/pkg/webhook/pod/mutating/sidecarset.go
+++ b/pkg/webhook/pod/mutating/sidecarset.go
@@ -79,12 +79,6 @@ func (h *PodCreateHandler) sidecarsetMutatingPod(ctx context.Context, req admiss
 		} else if !matched {
 			continue
 		}
-		// if the sidecarSet has been injected to the pod,
-		// check whether the pod is consistent with the sidecarSet.
-		if sidecarcontrol.IsPodInjectedSidecarSet(pod, &sidecarSet) &&
-			!sidecarcontrol.IsPodConsistentWithSidecarSet(pod, &sidecarSet) {
-			continue
-		}
 		// check whether sidecarSet is active
 		// when sidecarSet is not active, it will not perform injections and upgrades process.
 		control := sidecarcontrol.New(sidecarSet.DeepCopy())

--- a/pkg/webhook/pod/mutating/sidecarset.go
+++ b/pkg/webhook/pod/mutating/sidecarset.go
@@ -261,6 +261,10 @@ func buildSidecars(isUpdated bool, pod *corev1.Pod, oldPod *corev1.Pod, matchedS
 				transferEnvs := sidecarcontrol.GetSidecarTransferEnvs(initContainer, pod)
 				initContainer.Env = append(initContainer.Env, transferEnvs...)
 				sidecarInitContainers = append(sidecarInitContainers, initContainer)
+				// insert volumes that initContainers used
+				for _, mount := range initContainer.VolumeMounts {
+					volumesInSidecars = append(volumesInSidecars, *volumesMap[mount.Name])
+				}
 			}
 
 			//process imagePullSecrets


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
fix: sidecarset doesn't insert volumes used in volumeMounts of initContainers

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #934


