### PR TITLE
Optimize inplace update and support pod-template-hash label for cloneset

### DIFF
--- a/pkg/controller/cloneset/cloneset_event_handler.go
+++ b/pkg/controller/cloneset/cloneset_event_handler.go
@@ -164,7 +164,6 @@ func (e *podEventHandler) Delete(evt event.DeleteEvent, q workqueue.RateLimiting
 
 	klog.V(4).Infof("Pod %s/%s deleted, owner: %s", pod.Namespace, pod.Name, req.Name)
 	clonesetutils.ScaleExpectations.ObserveScale(req.String(), expectations.Delete, pod.Name)
-	clonesetutils.UpdateExpectations.DeleteObject(req.String(), pod)
 	q.Add(*req)
 }
 

--- a/pkg/controller/cloneset/sync/api.go
+++ b/pkg/controller/cloneset/sync/api.go
@@ -17,8 +17,6 @@ limitations under the License.
 package sync
 
 import (
-	"time"
-
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
 	clonesetutils "github.com/openkruise/kruise/pkg/controller/cloneset/utils"
 	"github.com/openkruise/kruise/pkg/util/controllerfinder"
@@ -41,7 +39,7 @@ type Interface interface {
 	Update(cs *appsv1alpha1.CloneSet,
 		currentRevision, updateRevision *apps.ControllerRevision, revisions []*apps.ControllerRevision,
 		pods []*v1.Pod, pvcs []*v1.PersistentVolumeClaim,
-	) (time.Duration, error)
+	) error
 }
 
 type realControl struct {

--- a/pkg/controller/cloneset/sync/cloneset_scale_test.go
+++ b/pkg/controller/cloneset/sync/cloneset_scale_test.go
@@ -80,10 +80,11 @@ func TestCreatePods(t *testing.T) {
 				Name:         "foo-id1",
 				GenerateName: "foo-",
 				Labels: map[string]string{
-					appsv1alpha1.CloneSetInstanceID:     "id1",
-					apps.ControllerRevisionHashLabelKey: "revision_abc",
-					"foo":                               "bar",
-					appspub.LifecycleStateKey:           string(appspub.LifecycleStateNormal),
+					appsv1alpha1.CloneSetInstanceID:      "id1",
+					apps.ControllerRevisionHashLabelKey:  "revision_abc",
+					apps.DefaultDeploymentUniqueLabelKey: "revision_abc",
+					"foo":                                "bar",
+					appspub.LifecycleStateKey:            string(appspub.LifecycleStateNormal),
 				},
 				OwnerReferences: []metav1.OwnerReference{
 					{
@@ -136,10 +137,11 @@ func TestCreatePods(t *testing.T) {
 				Name:         "foo-id3",
 				GenerateName: "foo-",
 				Labels: map[string]string{
-					appsv1alpha1.CloneSetInstanceID:     "id3",
-					apps.ControllerRevisionHashLabelKey: "revision_xyz",
-					"foo":                               "bar",
-					appspub.LifecycleStateKey:           string(appspub.LifecycleStateNormal),
+					appsv1alpha1.CloneSetInstanceID:      "id3",
+					apps.ControllerRevisionHashLabelKey:  "revision_xyz",
+					apps.DefaultDeploymentUniqueLabelKey: "revision_xyz",
+					"foo":                                "bar",
+					appspub.LifecycleStateKey:            string(appspub.LifecycleStateNormal),
 				},
 				OwnerReferences: []metav1.OwnerReference{
 					{
@@ -193,10 +195,11 @@ func TestCreatePods(t *testing.T) {
 				Name:         "foo-id4",
 				GenerateName: "foo-",
 				Labels: map[string]string{
-					appsv1alpha1.CloneSetInstanceID:     "id4",
-					apps.ControllerRevisionHashLabelKey: "revision_xyz",
-					"foo":                               "bar",
-					appspub.LifecycleStateKey:           string(appspub.LifecycleStateNormal),
+					appsv1alpha1.CloneSetInstanceID:      "id4",
+					apps.ControllerRevisionHashLabelKey:  "revision_xyz",
+					apps.DefaultDeploymentUniqueLabelKey: "revision_xyz",
+					"foo":                                "bar",
+					appspub.LifecycleStateKey:            string(appspub.LifecycleStateNormal),
 				},
 				OwnerReferences: []metav1.OwnerReference{
 					{

--- a/pkg/controller/cloneset/sync/cloneset_update_test.go
+++ b/pkg/controller/cloneset/sync/cloneset_update_test.go
@@ -99,7 +99,7 @@ func TestUpdate(t *testing.T) {
 			},
 			expectedPods: []*v1.Pod{
 				{
-					ObjectMeta: metav1.ObjectMeta{Name: "pod-0", Labels: map[string]string{apps.ControllerRevisionHashLabelKey: "rev_new"}},
+					ObjectMeta: metav1.ObjectMeta{Name: "pod-0", Labels: map[string]string{apps.ControllerRevisionHashLabelKey: "rev_new", apps.DefaultDeploymentUniqueLabelKey: "rev_new"}},
 					Spec:       v1.PodSpec{ReadinessGates: []v1.PodReadinessGate{{ConditionType: appspub.InPlaceUpdateReady}}},
 					Status: v1.PodStatus{Phase: v1.PodRunning, Conditions: []v1.PodCondition{
 						{Type: v1.PodReady, Status: v1.ConditionTrue},
@@ -123,7 +123,7 @@ func TestUpdate(t *testing.T) {
 			},
 			expectedPods: []*v1.Pod{
 				{
-					ObjectMeta: metav1.ObjectMeta{Name: "pod-0", Labels: map[string]string{apps.ControllerRevisionHashLabelKey: "rev_new"}, ResourceVersion: "1"},
+					ObjectMeta: metav1.ObjectMeta{Name: "pod-0", Labels: map[string]string{apps.ControllerRevisionHashLabelKey: "rev_new", apps.DefaultDeploymentUniqueLabelKey: "rev_new"}, ResourceVersion: "1"},
 					Spec:       v1.PodSpec{ReadinessGates: []v1.PodReadinessGate{{ConditionType: appspub.InPlaceUpdateReady}}},
 					Status: v1.PodStatus{Phase: v1.PodRunning, Conditions: []v1.PodCondition{
 						{Type: v1.PodReady, Status: v1.ConditionTrue},
@@ -142,8 +142,9 @@ func TestUpdate(t *testing.T) {
 			pods: []*v1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "pod-0", Labels: map[string]string{
-						apps.ControllerRevisionHashLabelKey: "rev_old",
-						appsv1alpha1.CloneSetInstanceID:     "id-0",
+						apps.ControllerRevisionHashLabelKey:  "rev_old",
+						apps.DefaultDeploymentUniqueLabelKey: "rev_old",
+						appsv1alpha1.CloneSetInstanceID:      "id-0",
 					}},
 					Spec: v1.PodSpec{ReadinessGates: []v1.PodReadinessGate{{ConditionType: appspub.InPlaceUpdateReady}}},
 					Status: v1.PodStatus{Phase: v1.PodRunning, Conditions: []v1.PodCondition{
@@ -160,9 +161,10 @@ func TestUpdate(t *testing.T) {
 			expectedPods: []*v1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "pod-0", ResourceVersion: "1", Labels: map[string]string{
-						apps.ControllerRevisionHashLabelKey: "rev_old",
-						appsv1alpha1.CloneSetInstanceID:     "id-0",
-						appsv1alpha1.SpecifiedDeleteKey:     "true",
+						apps.ControllerRevisionHashLabelKey:  "rev_old",
+						apps.DefaultDeploymentUniqueLabelKey: "rev_old",
+						appsv1alpha1.CloneSetInstanceID:      "id-0",
+						appsv1alpha1.SpecifiedDeleteKey:      "true",
 					}},
 					Spec: v1.PodSpec{ReadinessGates: []v1.PodReadinessGate{{ConditionType: appspub.InPlaceUpdateReady}}},
 					Status: v1.PodStatus{Phase: v1.PodRunning, Conditions: []v1.PodCondition{
@@ -196,8 +198,9 @@ func TestUpdate(t *testing.T) {
 			pods: []*v1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "pod-0", Labels: map[string]string{
-						apps.ControllerRevisionHashLabelKey: "rev_old",
-						appsv1alpha1.CloneSetInstanceID:     "id-0",
+						apps.ControllerRevisionHashLabelKey:  "rev_old",
+						apps.DefaultDeploymentUniqueLabelKey: "rev_old",
+						appsv1alpha1.CloneSetInstanceID:      "id-0",
 					}},
 					Spec: v1.PodSpec{
 						ReadinessGates: []v1.PodReadinessGate{{ConditionType: appspub.InPlaceUpdateReady}},
@@ -221,9 +224,10 @@ func TestUpdate(t *testing.T) {
 			expectedPods: []*v1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "pod-0", ResourceVersion: "1", Labels: map[string]string{
-						apps.ControllerRevisionHashLabelKey: "rev_old",
-						appsv1alpha1.CloneSetInstanceID:     "id-0",
-						appsv1alpha1.SpecifiedDeleteKey:     "true",
+						apps.ControllerRevisionHashLabelKey:  "rev_old",
+						apps.DefaultDeploymentUniqueLabelKey: "rev_old",
+						appsv1alpha1.CloneSetInstanceID:      "id-0",
+						appsv1alpha1.SpecifiedDeleteKey:      "true",
 					}},
 					Spec: v1.PodSpec{
 						ReadinessGates: []v1.PodReadinessGate{{ConditionType: appspub.InPlaceUpdateReady}},
@@ -264,8 +268,9 @@ func TestUpdate(t *testing.T) {
 			pods: []*v1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "pod-0", Labels: map[string]string{
-						apps.ControllerRevisionHashLabelKey: "rev_old",
-						appsv1alpha1.CloneSetInstanceID:     "id-0",
+						apps.ControllerRevisionHashLabelKey:  "rev_old",
+						apps.DefaultDeploymentUniqueLabelKey: "rev_old",
+						appsv1alpha1.CloneSetInstanceID:      "id-0",
 					}},
 					Spec: v1.PodSpec{
 						ReadinessGates: []v1.PodReadinessGate{{ConditionType: appspub.InPlaceUpdateReady}},
@@ -290,9 +295,10 @@ func TestUpdate(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "pod-0",
 						Labels: map[string]string{
-							apps.ControllerRevisionHashLabelKey: "rev_new",
-							appsv1alpha1.CloneSetInstanceID:     "id-0",
-							appspub.LifecycleStateKey:           string(appspub.LifecycleStateUpdating),
+							apps.ControllerRevisionHashLabelKey:  "rev_new",
+							apps.DefaultDeploymentUniqueLabelKey: "rev_new",
+							appsv1alpha1.CloneSetInstanceID:      "id-0",
+							appspub.LifecycleStateKey:            string(appspub.LifecycleStateUpdating),
 						},
 						Annotations: map[string]string{appspub.InPlaceUpdateStateKey: util.DumpJSON(appspub.InPlaceUpdateState{
 							Revision:               "rev_new",
@@ -341,8 +347,9 @@ func TestUpdate(t *testing.T) {
 			pods: []*v1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "pod-0", Labels: map[string]string{
-						apps.ControllerRevisionHashLabelKey: "rev_old",
-						appsv1alpha1.CloneSetInstanceID:     "id-0",
+						apps.ControllerRevisionHashLabelKey:  "rev_old",
+						apps.DefaultDeploymentUniqueLabelKey: "rev_old",
+						appsv1alpha1.CloneSetInstanceID:      "id-0",
 					}},
 					Spec: v1.PodSpec{
 						ReadinessGates: []v1.PodReadinessGate{{ConditionType: appspub.InPlaceUpdateReady}},
@@ -367,9 +374,10 @@ func TestUpdate(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "pod-0",
 						Labels: map[string]string{
-							apps.ControllerRevisionHashLabelKey: "rev_new",
-							appsv1alpha1.CloneSetInstanceID:     "id-0",
-							appspub.LifecycleStateKey:           string(appspub.LifecycleStateUpdating),
+							apps.ControllerRevisionHashLabelKey:  "rev_new",
+							apps.DefaultDeploymentUniqueLabelKey: "rev_new",
+							appsv1alpha1.CloneSetInstanceID:      "id-0",
+							appspub.LifecycleStateKey:            string(appspub.LifecycleStateUpdating),
 						},
 						Annotations: map[string]string{
 							appspub.InPlaceUpdateStateKey: util.DumpJSON(appspub.InPlaceUpdateState{
@@ -451,8 +459,9 @@ func TestUpdate(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "pod-0",
 						Labels: map[string]string{
-							apps.ControllerRevisionHashLabelKey: "rev_new",
-							appsv1alpha1.CloneSetInstanceID:     "id-0",
+							apps.ControllerRevisionHashLabelKey:  "rev_new",
+							apps.DefaultDeploymentUniqueLabelKey: "rev_new",
+							appsv1alpha1.CloneSetInstanceID:      "id-0",
 						},
 						Annotations: map[string]string{
 							appspub.InPlaceUpdateStateKey: util.DumpJSON(appspub.InPlaceUpdateState{
@@ -533,8 +542,9 @@ func TestUpdate(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "pod-0",
 						Labels: map[string]string{
-							apps.ControllerRevisionHashLabelKey: "rev_new",
-							appsv1alpha1.CloneSetInstanceID:     "id-0",
+							apps.ControllerRevisionHashLabelKey:  "rev_new",
+							apps.DefaultDeploymentUniqueLabelKey: "rev_new",
+							appsv1alpha1.CloneSetInstanceID:      "id-0",
 						},
 						Annotations: map[string]string{
 							appspub.InPlaceUpdateStateKey: util.DumpJSON(appspub.InPlaceUpdateState{
@@ -583,7 +593,7 @@ func TestUpdate(t *testing.T) {
 		if len(mc.revisions) > 0 {
 			currentRevision = mc.revisions[0]
 		}
-		if _, err := ctrl.Update(mc.cs, currentRevision, mc.updateRevision, mc.revisions, mc.pods, mc.pvcs); err != nil {
+		if err := ctrl.Update(mc.cs, currentRevision, mc.updateRevision, mc.revisions, mc.pods, mc.pvcs); err != nil {
 			t.Fatalf("Failed to test %s, manage error: %v", mc.name, err)
 		}
 		podList := v1.PodList{}

--- a/pkg/controller/cloneset/utils/cloneset_utils.go
+++ b/pkg/controller/cloneset/utils/cloneset_utils.go
@@ -27,6 +27,7 @@ import (
 	utilclient "github.com/openkruise/kruise/pkg/util/client"
 	"github.com/openkruise/kruise/pkg/util/expectations"
 	utilfeature "github.com/openkruise/kruise/pkg/util/feature"
+	"github.com/openkruise/kruise/pkg/util/requeueduration"
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -45,8 +46,10 @@ var (
 	WriteRevisionHash   = RevisionAdapterImpl.WriteRevisionHash
 
 	ScaleExpectations           = expectations.NewScaleExpectations()
-	UpdateExpectations          = expectations.NewUpdateExpectations(RevisionAdapterImpl)
 	ResourceVersionExpectations = expectations.NewResourceVersionExpectation()
+
+	// DurationStore is a short cut for any sub-functions to notify the reconcile how long to wait to requeue
+	DurationStore = requeueduration.DurationStore{}
 )
 
 type revisionAdapterImpl struct {
@@ -57,20 +60,26 @@ func (r *revisionAdapterImpl) EqualToRevisionHash(_ string, obj metav1.Object, h
 	if objHash == hash {
 		return true
 	}
-	return r.getShortHash(hash) == r.getShortHash(objHash)
+	return GetShortHash(hash) == GetShortHash(objHash)
 }
 
 func (r *revisionAdapterImpl) WriteRevisionHash(obj metav1.Object, hash string) {
 	if obj.GetLabels() == nil {
 		obj.SetLabels(make(map[string]string, 1))
 	}
+	// Note that controller-revision-hash defaults to be "{CLONESET_NAME}-{HASH}",
+	// and it will be "{HASH}" if CloneSetShortHash feature-gate has been enabled.
+	// But pod-template-hash should always be the short format.
+	shortHash := GetShortHash(hash)
 	if utilfeature.DefaultFeatureGate.Enabled(features.CloneSetShortHash) {
-		hash = r.getShortHash(hash)
+		obj.GetLabels()[apps.ControllerRevisionHashLabelKey] = shortHash
+	} else {
+		obj.GetLabels()[apps.ControllerRevisionHashLabelKey] = hash
 	}
-	obj.GetLabels()[apps.ControllerRevisionHashLabelKey] = hash
+	obj.GetLabels()[apps.DefaultDeploymentUniqueLabelKey] = shortHash
 }
 
-func (r *revisionAdapterImpl) getShortHash(hash string) string {
+func GetShortHash(hash string) string {
 	// This makes sure the real hash must be the last '-' substring of revision name
 	// vendor/k8s.io/kubernetes/pkg/controller/history/controller_history.go#82
 	list := strings.Split(hash, "-")

--- a/test/e2e/framework/podunavailablebudget_util.go
+++ b/test/e2e/framework/podunavailablebudget_util.go
@@ -290,7 +290,8 @@ func (t *PodUnavailableBudgetTester) WaitForCloneSetMinReadyAndRunning(cloneSets
 				}
 				readyReplicas += inner.Status.ReadyReplicas
 				count := *inner.Spec.Replicas
-				if inner.Status.UpdatedReplicas == count && count == inner.Status.ReadyReplicas && count == inner.Status.Replicas {
+				if inner.Generation == inner.Status.ObservedGeneration && inner.Status.UpdatedReplicas == count &&
+					count == inner.Status.ReadyReplicas && count == inner.Status.Replicas {
 					completed++
 				}
 			}

--- a/test/e2e/framework/workloadspread_util.go
+++ b/test/e2e/framework/workloadspread_util.go
@@ -255,7 +255,7 @@ func (t *WorkloadSpreadTester) WaitForCloneSetRunning(cloneSet *appsv1alpha1.Clo
 				return false, err
 			}
 			if inner.Generation == inner.Status.ObservedGeneration && *inner.Spec.Replicas == inner.Status.ReadyReplicas &&
-				*inner.Spec.Replicas == inner.Status.Replicas {
+				*inner.Spec.Replicas == inner.Status.Replicas && *inner.Spec.Replicas == inner.Status.UpdatedReplicas {
 				return true, nil
 			}
 			return false, nil


### PR DESCRIPTION
Signed-off-by: FillZpp <FillZpp.pub@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Optimize inplace update and support `pod-template-hash` label for cloneset.

Now there are two hash labels in pods that managed by cloneset:
- `controller-revision-hash` is still the important one that indicates the pod version. It defaults to be `"{CLONESET_NAME}-{HASH}"`, and it will be `"{HASH}"` if user enabled the `CloneSetShortHash` feature-gate.
- `pod-template-hash` should always be the short format `"{HASH}"`. cloneset-controller will not rely on it, but some other controllers, such as kruise-rollout, may use it to be the service selector.
