### PR TITLE
Improve Lifecycle

### DIFF
--- a/apis/apps/pub/lifecycle.go
+++ b/apis/apps/pub/lifecycle.go
@@ -40,4 +40,9 @@ type Lifecycle struct {
 type LifecycleHook struct {
 	LabelsHandler     map[string]string `json:"labelsHandler,omitempty"`
 	FinalizersHandler []string          `json:"finalizersHandler,omitempty"`
+	// MarkPodNotReady = true means:
+	// - Pod will be set to 'NotReady' at preparingDelete/preparingUpdate state.
+	// - Pod will be restored to 'Ready' at Updated state if it was set to 'NotReady' at preparingUpdate state.
+	// Default to false.
+	MarkPodNotReady bool `json:"markPodNotReady,omitempty"`
 }

--- a/config/crd/bases/apps.kruise.io_clonesets.yaml
+++ b/config/crd/bases/apps.kruise.io_clonesets.yaml
@@ -97,6 +97,13 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
+                      markPodNotReady:
+                        description: 'MarkPodNotReady = true means: - Pod will be
+                          set to ''NotReady'' at preparingDelete/preparingUpdate state.
+                          - Pod will be restored to ''Ready'' at Updated state if
+                          it was set to ''NotReady'' at preparingUpdate state. Default
+                          to false.'
+                        type: boolean
                     type: object
                   preDelete:
                     description: PreDelete is the hook before Pod to be deleted.
@@ -109,6 +116,13 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
+                      markPodNotReady:
+                        description: 'MarkPodNotReady = true means: - Pod will be
+                          set to ''NotReady'' at preparingDelete/preparingUpdate state.
+                          - Pod will be restored to ''Ready'' at Updated state if
+                          it was set to ''NotReady'' at preparingUpdate state. Default
+                          to false.'
+                        type: boolean
                     type: object
                 type: object
               minReadySeconds:

--- a/config/crd/bases/apps.kruise.io_daemonsets.yaml
+++ b/config/crd/bases/apps.kruise.io_daemonsets.yaml
@@ -93,6 +93,13 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
+                      markPodNotReady:
+                        description: 'MarkPodNotReady = true means: - Pod will be
+                          set to ''NotReady'' at preparingDelete/preparingUpdate state.
+                          - Pod will be restored to ''Ready'' at Updated state if
+                          it was set to ''NotReady'' at preparingUpdate state. Default
+                          to false.'
+                        type: boolean
                     type: object
                   preDelete:
                     description: PreDelete is the hook before Pod to be deleted.
@@ -105,6 +112,13 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
+                      markPodNotReady:
+                        description: 'MarkPodNotReady = true means: - Pod will be
+                          set to ''NotReady'' at preparingDelete/preparingUpdate state.
+                          - Pod will be restored to ''Ready'' at Updated state if
+                          it was set to ''NotReady'' at preparingUpdate state. Default
+                          to false.'
+                        type: boolean
                     type: object
                 type: object
               minReadySeconds:

--- a/config/crd/bases/apps.kruise.io_statefulsets.yaml
+++ b/config/crd/bases/apps.kruise.io_statefulsets.yaml
@@ -514,6 +514,13 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
+                      markPodNotReady:
+                        description: 'MarkPodNotReady = true means: - Pod will be
+                          set to ''NotReady'' at preparingDelete/preparingUpdate state.
+                          - Pod will be restored to ''Ready'' at Updated state if
+                          it was set to ''NotReady'' at preparingUpdate state. Default
+                          to false.'
+                        type: boolean
                     type: object
                   preDelete:
                     description: PreDelete is the hook before Pod to be deleted.
@@ -526,6 +533,13 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
+                      markPodNotReady:
+                        description: 'MarkPodNotReady = true means: - Pod will be
+                          set to ''NotReady'' at preparingDelete/preparingUpdate state.
+                          - Pod will be restored to ''Ready'' at Updated state if
+                          it was set to ''NotReady'' at preparingUpdate state. Default
+                          to false.'
+                        type: boolean
                     type: object
                 type: object
               persistentVolumeClaimRetentionPolicy:

--- a/config/crd/bases/apps.kruise.io_uniteddeployments.yaml
+++ b/config/crd/bases/apps.kruise.io_uniteddeployments.yaml
@@ -145,6 +145,13 @@ spec:
                                     additionalProperties:
                                       type: string
                                     type: object
+                                  markPodNotReady:
+                                    description: 'MarkPodNotReady = true means: -
+                                      Pod will be set to ''NotReady'' at preparingDelete/preparingUpdate
+                                      state. - Pod will be restored to ''Ready'' at
+                                      Updated state if it was set to ''NotReady''
+                                      at preparingUpdate state. Default to false.'
+                                    type: boolean
                                 type: object
                               preDelete:
                                 description: PreDelete is the hook before Pod to be
@@ -158,6 +165,13 @@ spec:
                                     additionalProperties:
                                       type: string
                                     type: object
+                                  markPodNotReady:
+                                    description: 'MarkPodNotReady = true means: -
+                                      Pod will be set to ''NotReady'' at preparingDelete/preparingUpdate
+                                      state. - Pod will be restored to ''Ready'' at
+                                      Updated state if it was set to ''NotReady''
+                                      at preparingUpdate state. Default to false.'
+                                    type: boolean
                                 type: object
                             type: object
                           persistentVolumeClaimRetentionPolicy:
@@ -546,6 +560,13 @@ spec:
                                     additionalProperties:
                                       type: string
                                     type: object
+                                  markPodNotReady:
+                                    description: 'MarkPodNotReady = true means: -
+                                      Pod will be set to ''NotReady'' at preparingDelete/preparingUpdate
+                                      state. - Pod will be restored to ''Ready'' at
+                                      Updated state if it was set to ''NotReady''
+                                      at preparingUpdate state. Default to false.'
+                                    type: boolean
                                 type: object
                               preDelete:
                                 description: PreDelete is the hook before Pod to be
@@ -559,6 +580,13 @@ spec:
                                     additionalProperties:
                                       type: string
                                     type: object
+                                  markPodNotReady:
+                                    description: 'MarkPodNotReady = true means: -
+                                      Pod will be set to ''NotReady'' at preparingDelete/preparingUpdate
+                                      state. - Pod will be restored to ''Ready'' at
+                                      Updated state if it was set to ''NotReady''
+                                      at preparingUpdate state. Default to false.'
+                                    type: boolean
                                 type: object
                             type: object
                           minReadySeconds:

--- a/pkg/controller/containerrecreaterequest/crr_controller.go
+++ b/pkg/controller/containerrecreaterequest/crr_controller.go
@@ -273,7 +273,7 @@ func (r *ReconcileContainerRecreateRequest) acquirePodNotReady(crr *appsv1alpha1
 			}
 		}
 
-		err := utilpodreadiness.AddNotReadyKey(r.Client, pod, getReadinessMessage(crr))
+		err := utilpodreadiness.NewCommon(r.Client).AddNotReadyKey(pod, getReadinessMessage(crr))
 		if err != nil {
 			return fmt.Errorf("add Pod not ready error: %v", err)
 		}
@@ -287,7 +287,7 @@ func (r *ReconcileContainerRecreateRequest) acquirePodNotReady(crr *appsv1alpha1
 
 func (r *ReconcileContainerRecreateRequest) releasePodNotReady(crr *appsv1alpha1.ContainerRecreateRequest, pod *v1.Pod) error {
 	if pod != nil && pod.DeletionTimestamp == nil && utilpodreadiness.ContainsReadinessGate(pod) {
-		err := utilpodreadiness.RemoveNotReadyKey(r.Client, pod, getReadinessMessage(crr))
+		err := utilpodreadiness.NewCommon(r.Client).RemoveNotReadyKey(pod, getReadinessMessage(crr))
 		if err != nil {
 			return fmt.Errorf("remove Pod not ready error: %v", err)
 		}

--- a/pkg/controller/daemonset/daemonset_controller.go
+++ b/pkg/controller/daemonset/daemonset_controller.go
@@ -755,7 +755,8 @@ func (dsc *ReconcileDaemonSet) syncWithPreparingDelete(ds *appsv1alpha1.DaemonSe
 			podsCanDelete = append(podsCanDelete, podName)
 			continue
 		}
-		if updated, gotPod, err := dsc.lifecycleControl.UpdatePodLifecycle(pod, appspub.LifecycleStatePreparingDelete); err != nil {
+		requiredPodNotReady := ds.Spec.Lifecycle.PreDelete.MarkPodNotReady
+		if updated, gotPod, err := dsc.lifecycleControl.UpdatePodLifecycle(pod, appspub.LifecycleStatePreparingDelete, requiredPodNotReady); err != nil {
 			return nil, err
 		} else if updated {
 			klog.V(3).Infof("DaemonSet %s/%s has marked Pod %s as PreparingDelete", ds.Namespace, ds.Name, podName)

--- a/pkg/controller/statefulset/stateful_set_control.go
+++ b/pkg/controller/statefulset/stateful_set_control.go
@@ -493,7 +493,7 @@ func (ssc *defaultStatefulSetControl) updateStatefulSet(
 				set.Namespace,
 				set.Name,
 				replicas[i].Name)
-			if err := ssc.podControl.DeleteStatefulPod(set, replicas[i]); err != nil {
+			if _, err := ssc.deletePod(set, replicas[i]); err != nil {
 				return &status, err
 			}
 			if getPodRevision(replicas[i]) == currentRevision.Name {
@@ -740,7 +740,7 @@ func (ssc *defaultStatefulSetControl) updateStatefulSet(
 					set.Namespace,
 					set.Name,
 					replicas[target].Name)
-				if err := ssc.podControl.DeleteStatefulPod(set, replicas[target]); err != nil {
+				if _, err := ssc.deletePod(set, replicas[target]); err != nil {
 					return &status, err
 				}
 			}

--- a/pkg/util/podreadiness/pod_readiness_control.go
+++ b/pkg/util/podreadiness/pod_readiness_control.go
@@ -1,0 +1,59 @@
+package podreadiness
+
+import (
+	"sort"
+
+	appspub "github.com/openkruise/kruise/apis/apps/pub"
+	"github.com/openkruise/kruise/pkg/util"
+	"github.com/openkruise/kruise/pkg/util/podadapter"
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type Interface interface {
+	AddNotReadyKey(pod *v1.Pod, msg Message) error
+	RemoveNotReadyKey(pod *v1.Pod, msg Message) error
+}
+
+type realCommonControl struct {
+	adp podadapter.Adapter
+}
+
+func NewCommon(c client.Client) Interface {
+	return &realCommonControl{adp: &podadapter.AdapterRuntimeClient{Client: c}}
+}
+
+func NewCommonForAdapter(adp podadapter.Adapter) Interface {
+	return &realCommonControl{adp: adp}
+}
+
+func (c *realCommonControl) AddNotReadyKey(pod *v1.Pod, msg Message) error {
+	_, err := addNotReadyKey(c.adp, pod, msg, appspub.KruisePodReadyConditionType)
+	return err
+}
+
+func (c *realCommonControl) RemoveNotReadyKey(pod *v1.Pod, msg Message) error {
+	_, err := removeNotReadyKey(c.adp, pod, msg, appspub.KruisePodReadyConditionType)
+	return err
+}
+
+type Message struct {
+	UserAgent string `json:"userAgent"`
+	Key       string `json:"key"`
+}
+
+type messageList []Message
+
+func (c messageList) Len() int      { return len(c) }
+func (c messageList) Swap(i, j int) { c[i], c[j] = c[j], c[i] }
+func (c messageList) Less(i, j int) bool {
+	if c[i].UserAgent == c[j].UserAgent {
+		return c[i].Key < c[j].Key
+	}
+	return c[i].UserAgent < c[j].UserAgent
+}
+
+func (c messageList) dump() string {
+	sort.Sort(c)
+	return util.DumpJSON(c)
+}

--- a/pkg/util/podreadiness/pod_readiness_utils.go
+++ b/pkg/util/podreadiness/pod_readiness_utils.go
@@ -17,33 +17,32 @@ limitations under the License.
 package podreadiness
 
 import (
-	"context"
 	"encoding/json"
-	"sort"
 
 	appspub "github.com/openkruise/kruise/apis/apps/pub"
-	"github.com/openkruise/kruise/pkg/util"
+	"github.com/openkruise/kruise/pkg/util/podadapter"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func AddNotReadyKey(c client.Client, pod *v1.Pod, msg Message) error {
-	if alreadyHasKey(pod, msg) {
-		return nil
+func addNotReadyKey(adp podadapter.Adapter, pod *v1.Pod, msg Message, condType v1.PodConditionType) (bool, error) {
+	if alreadyHasKey(pod, msg, condType) {
+		return true, nil
 	}
-	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		newPod := &v1.Pod{}
-		if err := c.Get(context.TODO(), types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}, newPod); err != nil {
+
+	conditionExists := false
+	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		newPod, err := adp.GetPod(pod.Namespace, pod.Name)
+		if err != nil {
 			return err
 		}
-		if !ContainsReadinessGate(pod) {
+		if !containsReadinessGate(newPod, condType) {
 			return nil
 		}
 
-		condition := GetReadinessCondition(newPod)
+		conditionExists = true
+		condition := getReadinessCondition(newPod, condType)
 		if condition == nil {
 			_, messages := addMessage("", msg)
 			newPod.Status.Conditions = append(newPod.Status.Conditions, v1.PodCondition{
@@ -61,21 +60,24 @@ func AddNotReadyKey(c client.Client, pod *v1.Pod, msg Message) error {
 			condition.LastTransitionTime = metav1.Now()
 		}
 
-		return c.Status().Update(context.TODO(), newPod)
+		return adp.UpdatePodStatus(newPod)
 	})
+	return conditionExists, err
 }
 
-func RemoveNotReadyKey(c client.Client, pod *v1.Pod, msg Message) error {
-	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		newPod := &v1.Pod{}
-		if err := c.Get(context.TODO(), types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}, newPod); err != nil {
+func removeNotReadyKey(adp podadapter.Adapter, pod *v1.Pod, msg Message, condType v1.PodConditionType) (bool, error) {
+	conditionExists := false
+	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		newPod, err := adp.GetPod(pod.Namespace, pod.Name)
+		if err != nil {
 			return err
 		}
-		if !ContainsReadinessGate(pod) {
+		if !containsReadinessGate(newPod, condType) {
 			return nil
 		}
 
-		condition := GetReadinessCondition(newPod)
+		conditionExists = true
+		condition := getReadinessCondition(newPod, condType)
 		if condition == nil {
 			return nil
 		}
@@ -89,29 +91,9 @@ func RemoveNotReadyKey(c client.Client, pod *v1.Pod, msg Message) error {
 		condition.Message = messages.dump()
 		condition.LastTransitionTime = metav1.Now()
 
-		return c.Status().Update(context.TODO(), newPod)
+		return adp.UpdatePodStatus(newPod)
 	})
-}
-
-type Message struct {
-	UserAgent string `json:"userAgent"`
-	Key       string `json:"key"`
-}
-
-type messageList []Message
-
-func (c messageList) Len() int      { return len(c) }
-func (c messageList) Swap(i, j int) { c[i], c[j] = c[j], c[i] }
-func (c messageList) Less(i, j int) bool {
-	if c[i].UserAgent == c[j].UserAgent {
-		return c[i].Key < c[j].Key
-	}
-	return c[i].UserAgent < c[j].UserAgent
-}
-
-func (c messageList) dump() string {
-	sort.Sort(c)
-	return util.DumpJSON(c)
+	return conditionExists, err
 }
 
 func addMessage(base string, msg Message) (bool, messageList) {
@@ -146,29 +128,37 @@ func removeMessage(base string, msg Message) (bool, messageList) {
 }
 
 func GetReadinessCondition(pod *v1.Pod) *v1.PodCondition {
+	return getReadinessCondition(pod, appspub.KruisePodReadyConditionType)
+}
+
+func ContainsReadinessGate(pod *v1.Pod) bool {
+	return containsReadinessGate(pod, appspub.KruisePodReadyConditionType)
+}
+
+func getReadinessCondition(pod *v1.Pod, condType v1.PodConditionType) *v1.PodCondition {
 	if pod == nil {
 		return nil
 	}
 	for i := range pod.Status.Conditions {
 		c := &pod.Status.Conditions[i]
-		if c.Type == appspub.KruisePodReadyConditionType {
+		if c.Type == condType {
 			return c
 		}
 	}
 	return nil
 }
 
-func ContainsReadinessGate(pod *v1.Pod) bool {
+func containsReadinessGate(pod *v1.Pod, condType v1.PodConditionType) bool {
 	for _, g := range pod.Spec.ReadinessGates {
-		if g.ConditionType == appspub.KruisePodReadyConditionType {
+		if g.ConditionType == condType {
 			return true
 		}
 	}
 	return false
 }
 
-func alreadyHasKey(pod *v1.Pod, msg Message) bool {
-	condition := GetReadinessCondition(pod)
+func alreadyHasKey(pod *v1.Pod, msg Message, condType v1.PodConditionType) bool {
+	condition := getReadinessCondition(pod, condType)
 	if condition == nil {
 		return false
 	}

--- a/pkg/util/podreadiness/pod_readiness_utils_test.go
+++ b/pkg/util/podreadiness/pod_readiness_utils_test.go
@@ -46,16 +46,20 @@ func TestPodReadiness(t *testing.T) {
 	msg0 := Message{UserAgent: "ua1", Key: "foo"}
 	msg1 := Message{UserAgent: "ua1", Key: "bar"}
 
-	if err := AddNotReadyKey(fakeClient, pod0, msg0); err != nil {
+	controller := NewCommon(fakeClient)
+	AddNotReadyKey := controller.AddNotReadyKey
+	RemoveNotReadyKey := controller.RemoveNotReadyKey
+
+	if err := AddNotReadyKey(pod0, msg0); err != nil {
 		t.Fatal(err)
 	}
-	if err := AddNotReadyKey(fakeClient, pod0, msg1); err != nil {
+	if err := AddNotReadyKey(pod0, msg1); err != nil {
 		t.Fatal(err)
 	}
-	if err := AddNotReadyKey(fakeClient, pod1, msg0); err != nil {
+	if err := AddNotReadyKey(pod1, msg0); err != nil {
 		t.Fatal(err)
 	}
-	if err := AddNotReadyKey(fakeClient, pod1, msg1); err != nil {
+	if err := AddNotReadyKey(pod1, msg1); err != nil {
 		t.Fatal(err)
 	}
 
@@ -63,7 +67,7 @@ func TestPodReadiness(t *testing.T) {
 	if err := fakeClient.Get(context.TODO(), types.NamespacedName{Namespace: pod0.Namespace, Name: pod0.Name}, newPod0); err != nil {
 		t.Fatal(err)
 	}
-	if !alreadyHasKey(newPod0, msg0) || !alreadyHasKey(newPod0, msg1) {
+	if !alreadyHasKey(newPod0, msg0, appspub.KruisePodReadyConditionType) || !alreadyHasKey(newPod0, msg1, appspub.KruisePodReadyConditionType) {
 		t.Fatalf("expect already has key, but not")
 	}
 	condition := GetReadinessCondition(newPod0)
@@ -75,24 +79,24 @@ func TestPodReadiness(t *testing.T) {
 	if err := fakeClient.Get(context.TODO(), types.NamespacedName{Namespace: pod1.Namespace, Name: pod1.Name}, newPod1); err != nil {
 		t.Fatal(err)
 	}
-	if alreadyHasKey(newPod1, msg0) || alreadyHasKey(newPod1, msg1) {
+	if alreadyHasKey(newPod1, msg0, appspub.KruisePodReadyConditionType) || alreadyHasKey(newPod1, msg1, appspub.KruisePodReadyConditionType) {
 		t.Fatalf("expect not have key, but it does")
 	}
 	if condition = GetReadinessCondition(newPod1); condition != nil {
 		t.Fatalf("expect condition nil, but exists: %v", condition)
 	}
 
-	if err := RemoveNotReadyKey(fakeClient, newPod0, msg0); err != nil {
+	if err := RemoveNotReadyKey(newPod0, msg0); err != nil {
 		t.Fatal(err)
 	}
 	newPod0 = &v1.Pod{}
 	if err := fakeClient.Get(context.TODO(), types.NamespacedName{Namespace: pod0.Namespace, Name: pod0.Name}, newPod0); err != nil {
 		t.Fatal(err)
 	}
-	if !alreadyHasKey(newPod0, msg1) {
+	if !alreadyHasKey(newPod0, msg1, appspub.KruisePodReadyConditionType) {
 		t.Fatalf("expect already has key, but not")
 	}
-	if alreadyHasKey(newPod0, msg0) {
+	if alreadyHasKey(newPod0, msg0, appspub.KruisePodReadyConditionType) {
 		t.Fatalf("expect not have key, but it does")
 	}
 	condition = GetReadinessCondition(newPod0)
@@ -100,14 +104,14 @@ func TestPodReadiness(t *testing.T) {
 		t.Fatalf("expect condition false, but not")
 	}
 
-	if err := RemoveNotReadyKey(fakeClient, newPod0, msg1); err != nil {
+	if err := RemoveNotReadyKey(newPod0, msg1); err != nil {
 		t.Fatal(err)
 	}
 	newPod0 = &v1.Pod{}
 	if err := fakeClient.Get(context.TODO(), types.NamespacedName{Namespace: pod0.Namespace, Name: pod0.Name}, newPod0); err != nil {
 		t.Fatal(err)
 	}
-	if alreadyHasKey(newPod0, msg0) || alreadyHasKey(newPod0, msg1) {
+	if alreadyHasKey(newPod0, msg0, appspub.KruisePodReadyConditionType) || alreadyHasKey(newPod0, msg1, appspub.KruisePodReadyConditionType) {
 		t.Fatalf("expect not have key, but it does")
 	}
 	condition = GetReadinessCondition(newPod0)


### PR DESCRIPTION
Signed-off-by: veophi <vec.g.sun@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
- Fix invalid lifecycle PreDelete hook for StatefulSet.
- Add `RequiredPodNotReady` lifecycle policy for CloneSet/StatefulSet/DaemonSet.

---
**Explanation:** `RequiredPodNotReady = true` means:
- Pod will be set to 'NotReady' at preparingDelete/preparingUpdate state.
- Pod will be restored to 'Ready' at Updated state if it was set to 'NotReady' at preparingUpdate state.

---
### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
#944 
#950 