### PR TITLE
[Feat]: Make sure at least one pod is upgraded if CloneSet Partition != 100% 

### DIFF
--- a/apis/apps/v1alpha1/cloneset_types.go
+++ b/apis/apps/v1alpha1/cloneset_types.go
@@ -168,6 +168,10 @@ type CloneSetStatus struct {
 	// indicated by updateRevision and have a Ready Condition.
 	UpdatedReadyReplicas int32 `json:"updatedReadyReplicas"`
 
+	// ExpectedUpdatedReplicas is the number of Pods that should be updated by CloneSet controller.
+	// This field is calculated via Replicas - Partition.
+	ExpectedUpdatedReplicas int32 `json:"expectUpdatedReplicas,omitempty"`
+
 	// UpdateRevision, if not empty, indicates the latest revision of the CloneSet.
 	UpdateRevision string `json:"updateRevision,omitempty"`
 

--- a/config/crd/bases/apps.kruise.io_clonesets.yaml
+++ b/config/crd/bases/apps.kruise.io_clonesets.yaml
@@ -427,6 +427,12 @@ spec:
                 description: currentRevision, if not empty, indicates the current
                   revision version of the CloneSet.
                 type: string
+              expectUpdatedReplicas:
+                description: ExpectedUpdatedReplicas is the number of Pods that should
+                  be updated by CloneSet controller. This field is calculated via
+                  Replicas - Partition.
+                format: int32
+                type: integer
               labelSelector:
                 description: LabelSelector is label selectors for query over pods
                   that should match the replica count used by HPA.

--- a/pkg/controller/cloneset/sync/cloneset_sync_utils.go
+++ b/pkg/controller/cloneset/sync/cloneset_sync_utils.go
@@ -76,8 +76,12 @@ func calculateDiffsWithExpectation(cs *appsv1alpha1.CloneSet, pods []*v1.Pod, cu
 	replicas := int(*cs.Spec.Replicas)
 	var partition, maxSurge, maxUnavailable, scaleMaxUnavailable int
 	if cs.Spec.UpdateStrategy.Partition != nil {
-		partition, _ = intstrutil.GetValueFromIntOrPercent(cs.Spec.UpdateStrategy.Partition, replicas, true)
-		partition = integer.IntMin(partition, replicas)
+		if pValue, err := util.CalculatePartitionReplicas(cs.Spec.UpdateStrategy.Partition, cs.Spec.Replicas); err != nil {
+			// TODO: maybe, we should block pod update if partition settings is wrong
+			klog.Errorf("CloneSet %s/%s partition value is illegal", cs.Namespace, cs.Name)
+		} else {
+			partition = pValue
+		}
 	}
 	if cs.Spec.UpdateStrategy.MaxSurge != nil {
 		maxSurge, _ = intstrutil.GetValueFromIntOrPercent(cs.Spec.UpdateStrategy.MaxSurge, replicas, true)

--- a/pkg/controller/cloneset/sync/cloneset_sync_utils_test.go
+++ b/pkg/controller/cloneset/sync/cloneset_sync_utils_test.go
@@ -467,6 +467,117 @@ func TestCalculateDiffsWithExpectation(t *testing.T) {
 			expectResult: expectationDiffs{},
 		},
 		{
+			name: "update recreate partition=99% with maxUnavailable=3, maxSurge=2 (step 1/3)",
+			set:  createTestCloneSet(5, intstr.FromString("99%"), intstr.FromInt(3), intstr.FromInt(2)),
+			pods: []*v1.Pod{
+				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
+				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
+				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
+				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
+				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
+			},
+			expectResult: expectationDiffs{scaleNum: 1, useSurge: 1, updateNum: 1, updateMaxUnavailable: 3, scaleUpLimit: 1},
+		},
+		{
+			name: "update recreate partition=99% with maxUnavailable=3, maxSurge=2 (step 2/3)",
+			set:  createTestCloneSet(5, intstr.FromString("99%"), intstr.FromInt(3), intstr.FromInt(2)),
+			pods: []*v1.Pod{
+				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
+				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
+				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
+				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
+				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
+				createTestPod(newRevision, appspub.LifecycleStateNormal, false, false), // new creation
+			},
+			expectResult: expectationDiffs{scaleNum: -1, scaleNumOldRevision: -1, deleteReadyLimit: 3},
+		},
+		{
+			name: "update recreate partition=99% with maxUnavailable=3, maxSurge=2 (step 3/3)",
+			set:  createTestCloneSet(5, intstr.FromString("99%"), intstr.FromInt(3), intstr.FromInt(2)),
+			pods: []*v1.Pod{
+				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
+				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
+				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
+				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
+				createTestPod(newRevision, appspub.LifecycleStateNormal, false, false), // new creation
+			},
+			expectResult: expectationDiffs{},
+		},
+		{
+			name: "update recreate partition=99% with maxUnavailable=40%, maxSurge=30% (step 1/3)",
+			set:  createTestCloneSet(5, intstr.FromString("99%"), intstr.FromString("40%"), intstr.FromString("30%")),
+			pods: []*v1.Pod{
+				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
+				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
+				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
+				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
+				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
+			},
+			expectResult: expectationDiffs{scaleNum: 1, useSurge: 1, updateNum: 1, updateMaxUnavailable: 2, scaleUpLimit: 1},
+		},
+		{
+			name: "update recreate partition=99% with maxUnavailable=40%, maxSurge=30% (step 2/3)",
+			set:  createTestCloneSet(5, intstr.FromString("99%"), intstr.FromString("40%"), intstr.FromString("30%")),
+			pods: []*v1.Pod{
+				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
+				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
+				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
+				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
+				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
+				createTestPod(newRevision, appspub.LifecycleStateNormal, false, false), // new creation
+			},
+			expectResult: expectationDiffs{scaleNum: -1, scaleNumOldRevision: -1, deleteReadyLimit: 2},
+		},
+		{
+			name: "update recreate partition=99% with maxUnavailable=40%, maxSurge=30% (step 3/3)",
+			set:  createTestCloneSet(5, intstr.FromString("99%"), intstr.FromString("40%"), intstr.FromString("30%")),
+			pods: []*v1.Pod{
+				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
+				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
+				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
+				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
+				createTestPod(newRevision, appspub.LifecycleStateNormal, false, false), // new creation
+			},
+			expectResult: expectationDiffs{},
+		},
+		{
+			name: "update recreate partition=99% with maxUnavailable=30%, maxSurge=30% (step 1/3)",
+			set:  createTestCloneSet(5, intstr.FromString("99%"), intstr.FromString("30%"), intstr.FromString("30%")),
+			pods: []*v1.Pod{
+				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
+				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
+				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
+				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
+				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
+			},
+			expectResult: expectationDiffs{scaleNum: 1, useSurge: 1, updateNum: 1, updateMaxUnavailable: 1, scaleUpLimit: 1},
+		},
+		{
+			name: "update recreate partition=99% with maxUnavailable=30%, maxSurge=30% (step 2/3)",
+			set:  createTestCloneSet(5, intstr.FromString("99%"), intstr.FromString("30%"), intstr.FromString("30%")),
+			pods: []*v1.Pod{
+				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
+				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
+				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
+				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
+				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
+				createTestPod(newRevision, appspub.LifecycleStateNormal, false, false), // new creation
+			},
+			expectResult: expectationDiffs{scaleNum: -1, scaleNumOldRevision: -1, deleteReadyLimit: 1},
+		},
+		{
+			name: "update recreate partition=99% with maxUnavailable=30%, maxSurge=30% (step 3/3)",
+			set:  createTestCloneSet(5, intstr.FromString("99%"), intstr.FromString("30%"), intstr.FromString("30%")),
+			pods: []*v1.Pod{
+				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
+				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
+				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
+				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
+				createTestPod(newRevision, appspub.LifecycleStateNormal, false, false), // new creation
+			},
+			expectResult: expectationDiffs{},
+		},
+		{
 			name: "revision consistent 1",
 			set:  createTestCloneSet(5, intstr.FromInt(0), intstr.FromInt(1), intstr.FromInt(0)),
 			pods: []*v1.Pod{


### PR DESCRIPTION
Signed-off-by: veophi <vec.g.sun@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Make sure at least one pod is upgraded if CloneSet Partition != 100%:
- If `replicas >= 2 && partition != 100%`, at least ONE pod will be upgraded;
- If `replicas >= 1` && partition != 0%, at least ONE pod will keep old revision (same behaviors as before);

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #953
fixes #926
