### PR TITLE
Feature: krusie daemon crr record restarCount by deamon.

### DIFF
--- a/apis/apps/v1alpha1/containerrecreaterequest_types.go
+++ b/apis/apps/v1alpha1/containerrecreaterequest_types.go
@@ -160,6 +160,8 @@ type ContainerRecreateRequestContainerRecreateState struct {
 	Phase ContainerRecreateRequestPhase `json:"phase"`
 	// A human readable message indicating details about this state.
 	Message string `json:"message,omitempty"`
+	// The number of times the container has been restarted by krusie-daemon
+	RestartCount int `json:"restartCount,omitempty"`
 }
 
 // ContainerRecreateRequestSyncContainerStatus only uses in the annotation `crr.apps.kruise.io/sync-container-statuses`.

--- a/pkg/daemon/containerrecreate/crr_daemon_controller.go
+++ b/pkg/daemon/containerrecreate/crr_daemon_controller.go
@@ -337,6 +337,8 @@ func (c *Controller) manage(crr *appsv1alpha1.ContainerRecreateRequest) error {
 			if crr.Spec.Strategy.OrderedRecreate {
 				break
 			}
+		}
+		if state.RestartCount != 0 {
 			continue
 		}
 
@@ -357,6 +359,7 @@ func (c *Controller) manage(crr *appsv1alpha1.ContainerRecreateRequest) error {
 			return c.patchCRRContainerRecreateStates(crr, newCRRContainerRecreateStates)
 		}
 		state.Phase = appsv1alpha1.ContainerRecreateRequestRecreating
+		state.RestartCount += 1
 		break
 	}
 

--- a/pkg/daemon/containerrecreate/crr_daemon_util.go
+++ b/pkg/daemon/containerrecreate/crr_daemon_util.go
@@ -115,7 +115,9 @@ func getCurrentCRRContainersRecreateStates(
 				Phase: appsv1alpha1.ContainerRecreateRequestPending,
 			}
 		}
-
+		if previousContainerRecreateState != nil {
+			currentState.RestartCount = previousContainerRecreateState.RestartCount
+		}
 		statuses = append(statuses, currentState)
 	}
 


### PR DESCRIPTION
Signed-off-by: JunjunLi <junjunli666@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### 0. Backgroud

`kruise crr`  can restart containers by container runtime interface.  but if container is not running, kruise deamon will not work. so i hop kruise deamon will restart container compulsorily.

### Ⅰ. Describe what this PR does

1. record  container restartCount by kruise-daemon crr. 
2. krusie daemon restart container compulsorily.



### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

todo: add test case in e2e tests.


### Ⅳ. Special notes for reviews

