### PR TITLE
Optimize `spec.containers[x].statusContext` field injection method 

### DIFF
--- a/apis/apps/v1alpha1/containerrecreaterequest_types.go
+++ b/apis/apps/v1alpha1/containerrecreaterequest_types.go
@@ -68,9 +68,8 @@ type ContainerRecreateRequestContainer struct {
 	// Populated by the system.
 	// Read-only.
 	Ports []v1.ContainerPort `json:"ports,omitempty"`
-	// StatusContext is synced from the real Pod status during this ContainerRecreateRequest creating.
-	// Populated by the system.
-	// Read-only.
+	// StatusContext is synced from the real container status during this ContainerRecreateRequest creating.
+	// Populated by the kruise daemon.
 	StatusContext *ContainerRecreateRequestContainerContext `json:"statusContext,omitempty"`
 }
 

--- a/config/crd/bases/apps.kruise.io_containerrecreaterequests.yaml
+++ b/config/crd/bases/apps.kruise.io_containerrecreaterequests.yaml
@@ -202,9 +202,9 @@ spec:
                           type: object
                       type: object
                     statusContext:
-                      description: StatusContext is synced from the real Pod status
-                        during this ContainerRecreateRequest creating. Populated by
-                        the system. Read-only.
+                      description: StatusContext is synced from the real container
+                        status during this ContainerRecreateRequest creating. Populated
+                        by the kruise daemon.
                       properties:
                         containerID:
                           description: Container's ID in the format 'docker://<container_id>'.

--- a/config/rbac/daemon_role.yaml
+++ b/config/rbac/daemon_role.yaml
@@ -38,6 +38,7 @@ rules:
   - get
   - list
   - watch
+  - update
 - apiGroups:
   - apps.kruise.io
   resources:

--- a/pkg/daemon/containerrecreate/crr_daemon_util.go
+++ b/pkg/daemon/containerrecreate/crr_daemon_util.go
@@ -188,3 +188,12 @@ func convertCRRToPod(crr *appsv1alpha1.ContainerRecreateRequest) *v1.Pod {
 
 	return pod
 }
+
+func hasContainerContext(obj *appsv1alpha1.ContainerRecreateRequest) bool {
+	for _, c := range obj.Spec.Containers {
+		if c.StatusContext == nil {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/webhook/containerrecreaterequest/mutating/crr_mutating_handler.go
+++ b/pkg/webhook/containerrecreaterequest/mutating/crr_mutating_handler.go
@@ -67,8 +67,8 @@ func (h *ContainerRecreateRequestHandler) Handle(ctx context.Context, req admiss
 		if err := h.Decoder.DecodeRaw(req.OldObject, oldObj); err != nil {
 			return admission.Errored(http.StatusBadRequest, err)
 		}
-		if !reflect.DeepEqual(obj.Spec, oldObj.Spec) {
-			return admission.Errored(http.StatusForbidden, fmt.Errorf("spec of ContainerRecreateRequest is immutable"))
+		if !reflect.DeepEqual(obj.Spec, oldObj.Spec) && reflect.DeepEqual(obj.Spec.Containers, oldObj.Spec.Containers) {
+			return admission.Errored(http.StatusForbidden, fmt.Errorf("spec of ContainerRecreateRequest is immutable, except spec.containers"))
 		}
 		if obj.Labels[appsv1alpha1.ContainerRecreateRequestPodNameKey] != oldObj.Labels[appsv1alpha1.ContainerRecreateRequestPodNameKey] {
 			return admission.Errored(http.StatusForbidden, fmt.Errorf("not allowed to update immutable label %s", appsv1alpha1.ContainerRecreateRequestPodNameKey))
@@ -188,11 +188,6 @@ func injectPodIntoContainerRecreateRequest(obj *appsv1alpha1.ContainerRecreateRe
 
 		if c.PreStop != nil && c.PreStop.HTTPGet != nil {
 			c.Ports = podContainer.Ports
-		}
-
-		c.StatusContext = &appsv1alpha1.ContainerRecreateRequestContainerContext{
-			ContainerID:  podContainerStatus.ContainerID,
-			RestartCount: podContainerStatus.RestartCount,
 		}
 	}
 

--- a/test/e2e/apps/containerrecreate.go
+++ b/test/e2e/apps/containerrecreate.go
@@ -96,7 +96,6 @@ var _ = SIGDescribe("ContainerRecreateRequest", func() {
 				gomega.Expect(crr.Labels[appsv1alpha1.ContainerRecreateRequestNodeNameKey]).Should(gomega.Equal(pod.Spec.NodeName))
 				gomega.Expect(crr.Labels[appsv1alpha1.ContainerRecreateRequestActiveKey]).Should(gomega.Equal("true"))
 				gomega.Expect(crr.Spec.Strategy.FailurePolicy).Should(gomega.Equal(appsv1alpha1.ContainerRecreateRequestFailurePolicyFail))
-				gomega.Expect(crr.Spec.Containers[0].StatusContext.ContainerID).Should(gomega.Equal(util.GetContainerStatus("app", pod).ContainerID))
 				ginkgo.By("Wait CRR recreate completion")
 				gomega.Eventually(func() appsv1alpha1.ContainerRecreateRequestPhase {
 					crr, err = tester.GetCRR(crr.Name)
@@ -109,7 +108,11 @@ var _ = SIGDescribe("ContainerRecreateRequest", func() {
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 					return crr.Labels[appsv1alpha1.ContainerRecreateRequestActiveKey]
 				}, 5*time.Second, 1*time.Second).Should(gomega.Equal(""))
+
+				crr, err = tester.GetCRR(crr.Name)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				gomega.Expect(crr.Status.ContainerRecreateStates).Should(gomega.Equal([]appsv1alpha1.ContainerRecreateRequestContainerRecreateState{{Name: "app", Phase: appsv1alpha1.ContainerRecreateRequestSucceeded}}))
+				gomega.Expect(crr.Spec.Containers[0].StatusContext.ContainerID).Should(gomega.Equal(util.GetContainerStatus("app", pod).ContainerID))
 
 				ginkgo.By("Check Pod containers recreated and started for minStartedSeconds")
 				pod, err = tester.GetPod(pod.Name)
@@ -142,8 +145,6 @@ var _ = SIGDescribe("ContainerRecreateRequest", func() {
 				}
 				crr, err = tester.CreateCRR(crr)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				gomega.Expect(crr.Spec.Containers[0].StatusContext.ContainerID).Should(gomega.Equal(util.GetContainerStatus("app", pod).ContainerID))
-				gomega.Expect(crr.Spec.Containers[1].StatusContext.ContainerID).Should(gomega.Equal(util.GetContainerStatus("sidecar", pod).ContainerID))
 
 				ginkgo.By("Wait CRR recreate completion")
 				gomega.Eventually(func() appsv1alpha1.ContainerRecreateRequestPhase {
@@ -162,6 +163,10 @@ var _ = SIGDescribe("ContainerRecreateRequest", func() {
 					{Name: "sidecar", Phase: appsv1alpha1.ContainerRecreateRequestSucceeded},
 				}))
 
+				crr, err = tester.GetCRR(crr.Name)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(crr.Spec.Containers[0].StatusContext.ContainerID).Should(gomega.Equal(util.GetContainerStatus("app", pod).ContainerID))
+				gomega.Expect(crr.Spec.Containers[1].StatusContext.ContainerID).Should(gomega.Equal(util.GetContainerStatus("sidecar", pod).ContainerID))
 				ginkgo.By("Check Pod containers recreated")
 				pod, err = tester.GetPod(pod.Name)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -207,8 +212,6 @@ var _ = SIGDescribe("ContainerRecreateRequest", func() {
 				}
 				crr, err = tester.CreateCRR(crr)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				gomega.Expect(crr.Spec.Containers[0].StatusContext.ContainerID).Should(gomega.Equal(util.GetContainerStatus("app", pod).ContainerID))
-				gomega.Expect(crr.Spec.Containers[1].StatusContext.ContainerID).Should(gomega.Equal(util.GetContainerStatus("sidecar", pod).ContainerID))
 
 				ginkgo.By("Wait CRR recreate completion")
 				gomega.Eventually(func() appsv1alpha1.ContainerRecreateRequestPhase {
@@ -227,6 +230,10 @@ var _ = SIGDescribe("ContainerRecreateRequest", func() {
 					return crr.Labels[appsv1alpha1.ContainerRecreateRequestActiveKey]
 				}, 5*time.Second, time.Second).Should(gomega.Equal(""))
 
+				crr, err = tester.GetCRR(crr.Name)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(crr.Spec.Containers[0].StatusContext.ContainerID).Should(gomega.Equal(util.GetContainerStatus("app", pod).ContainerID))
+				gomega.Expect(crr.Spec.Containers[1].StatusContext.ContainerID).Should(gomega.Equal(util.GetContainerStatus("sidecar", pod).ContainerID))
 				ginkgo.By("Check Pod containers recreated")
 				pod, err = tester.GetPod(pod.Name)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -261,8 +268,6 @@ var _ = SIGDescribe("ContainerRecreateRequest", func() {
 				}
 				crr, err = tester.CreateCRR(crr)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				gomega.Expect(crr.Spec.Containers[0].StatusContext.ContainerID).Should(gomega.Equal(util.GetContainerStatus("app", pod).ContainerID))
-				gomega.Expect(crr.Spec.Containers[1].StatusContext.ContainerID).Should(gomega.Equal(util.GetContainerStatus("sidecar", pod).ContainerID))
 
 				ginkgo.By("Wait CRR recreate completion")
 				gomega.Eventually(func() appsv1alpha1.ContainerRecreateRequestPhase {
@@ -281,6 +286,10 @@ var _ = SIGDescribe("ContainerRecreateRequest", func() {
 					{Name: "sidecar", Phase: appsv1alpha1.ContainerRecreateRequestSucceeded},
 				}))
 
+				crr, err = tester.GetCRR(crr.Name)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(crr.Spec.Containers[0].StatusContext.ContainerID).Should(gomega.Equal(util.GetContainerStatus("app", pod).ContainerID))
+				gomega.Expect(crr.Spec.Containers[1].StatusContext.ContainerID).Should(gomega.Equal(util.GetContainerStatus("sidecar", pod).ContainerID))
 				ginkgo.By("Check Pod containers recreated")
 				pod, err = tester.GetPod(pod.Name)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -331,8 +340,6 @@ var _ = SIGDescribe("ContainerRecreateRequest", func() {
 				}
 				crr, err = tester.CreateCRR(crr)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				gomega.Expect(crr.Spec.Containers[0].StatusContext.ContainerID).Should(gomega.Equal(util.GetContainerStatus("app", pod).ContainerID))
-				gomega.Expect(crr.Spec.Containers[1].StatusContext.ContainerID).Should(gomega.Equal(util.GetContainerStatus("sidecar", pod).ContainerID))
 
 				ginkgo.By("Wait CRR recreate completion")
 				gomega.Eventually(func() appsv1alpha1.ContainerRecreateRequestPhase {
@@ -351,6 +358,10 @@ var _ = SIGDescribe("ContainerRecreateRequest", func() {
 					{Name: "sidecar", Phase: appsv1alpha1.ContainerRecreateRequestSucceeded},
 				}))
 
+				crr, err = tester.GetCRR(crr.Name)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(crr.Spec.Containers[0].StatusContext.ContainerID).Should(gomega.Equal(util.GetContainerStatus("app", pod).ContainerID))
+				gomega.Expect(crr.Spec.Containers[1].StatusContext.ContainerID).Should(gomega.Equal(util.GetContainerStatus("sidecar", pod).ContainerID))
 				ginkgo.By("Check Pod containers recreated")
 				pod, err = tester.GetPod(pod.Name)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -383,8 +394,6 @@ var _ = SIGDescribe("ContainerRecreateRequest", func() {
 				}
 				crr, err = tester.CreateCRR(crr)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				gomega.Expect(crr.Spec.Containers[0].StatusContext.ContainerID).Should(gomega.Equal(util.GetContainerStatus("app", pod).ContainerID))
-				gomega.Expect(crr.Spec.Containers[1].StatusContext.ContainerID).Should(gomega.Equal(util.GetContainerStatus("sidecar", pod).ContainerID))
 
 				ginkgo.By("Wait CRR recreate completion")
 				gomega.Eventually(func() appsv1alpha1.ContainerRecreateRequestPhase {
@@ -488,8 +497,6 @@ var _ = SIGDescribe("ContainerRecreateRequest", func() {
 				interval := util.GetContainerStatus("app", pod).LastTerminationState.Terminated.FinishedAt.Sub(crr.CreationTimestamp.Time)
 				gomega.Expect(interval < 8*time.Second).Should(gomega.Equal(true))
 			}
-
 		})
-
 	})
 })

--- a/test/e2e/apps/ephemeraljob.go
+++ b/test/e2e/apps/ephemeraljob.go
@@ -574,7 +574,6 @@ var _ = SIGDescribe("EphemeralJob", func() {
 				gomega.Expect(crr.Labels[appsv1alpha1.ContainerRecreateRequestNodeNameKey]).Should(gomega.Equal(pod.Spec.NodeName))
 				gomega.Expect(crr.Labels[appsv1alpha1.ContainerRecreateRequestActiveKey]).Should(gomega.Equal("true"))
 				gomega.Expect(crr.Spec.Strategy.FailurePolicy).Should(gomega.Equal(appsv1alpha1.ContainerRecreateRequestFailurePolicyFail))
-				gomega.Expect(crr.Spec.Containers[0].StatusContext.ContainerID).Should(gomega.Equal(pod.Status.ContainerStatuses[0].ContainerID))
 				ginkgo.By("Wait CRR recreate completion")
 				gomega.Eventually(func() appsv1alpha1.ContainerRecreateRequestPhase {
 					crr, err = resetartContainerTester.GetCRR(crr.Name)
@@ -593,7 +592,6 @@ var _ = SIGDescribe("EphemeralJob", func() {
 				pod, err = resetartContainerTester.GetPod(pod.Name)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				gomega.Expect(podutil.IsPodReady(pod)).Should(gomega.Equal(true))
-				gomega.Expect(pod.Status.ContainerStatuses[0].ContainerID).ShouldNot(gomega.Equal(crr.Spec.Containers[0].StatusContext.ContainerID))
 				gomega.Expect(pod.Status.ContainerStatuses[0].RestartCount).Should(gomega.Equal(int32(1)))
 				gomega.Expect(crr.Status.CompletionTime.Sub(pod.Status.ContainerStatuses[0].State.Running.StartedAt.Time)).Should(gomega.BeNumerically(">", 4*time.Second))
 			}


### PR DESCRIPTION
Signed-off-by: JunjunLi <junjunli666@gmail.com>
the `spec.containers[x].statusContext`  is synced from the real Pod status during this ContainerRecreateRequest creating.  but in some case, pod status is not real container status. 

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

Optimize `spec.containers[x].statusContext` field injection method.   `spec.containers[x].statusContext` value inject by kruise daemon.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

no

### Ⅲ. Describe how to verify it

e2e test.

### Ⅳ. Special notes for reviews

