### PR TITLE
Fix bugs for statefulset lifecycle and workloadspread e2e

### DIFF
--- a/pkg/controller/statefulset/stateful_set_control.go
+++ b/pkg/controller/statefulset/stateful_set_control.go
@@ -493,7 +493,7 @@ func (ssc *defaultStatefulSetControl) updateStatefulSet(
 				set.Namespace,
 				set.Name,
 				replicas[i].Name)
-			if err := ssc.podControl.DeleteStatefulPod(set, replicas[i]); err != nil {
+			if _, err := ssc.deletePod(set, replicas[i]); err != nil {
 				return &status, err
 			}
 			if getPodRevision(replicas[i]) == currentRevision.Name {
@@ -740,7 +740,7 @@ func (ssc *defaultStatefulSetControl) updateStatefulSet(
 					set.Namespace,
 					set.Name,
 					replicas[target].Name)
-				if err := ssc.podControl.DeleteStatefulPod(set, replicas[target]); err != nil {
+				if _, err := ssc.deletePod(set, replicas[target]); err != nil {
 					return &status, err
 				}
 			}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->
 
Signed-off-by: veophi <vec.g.sun@gmail.com>

### Ⅰ. Describe what this PR does
Fixes:
- StatefulSet preparingDelete lifecycle cannot be triggered in rebuilding update scene.
- WorkloadSpread e2e.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #950

Maybe also related with #951  