### PR TITLE
Add mark pod not ready feature to Lifecycle hooks

### DIFF
--- a/apis/apps/pub/lifecycle.go
+++ b/apis/apps/pub/lifecycle.go
@@ -40,4 +40,9 @@ type Lifecycle struct {
 type LifecycleHook struct {
 	LabelsHandler     map[string]string `json:"labelsHandler,omitempty"`
 	FinalizersHandler []string          `json:"finalizersHandler,omitempty"`
+	// MarkPodNotReady = true means:
+	// - Pod will be set to 'NotReady' at preparingDelete/preparingUpdate state.
+	// - Pod will be restored to 'Ready' at Updated state if it was set to 'NotReady' at preparingUpdate state.
+	// Default to false.
+	MarkPodNotReady bool `json:"markPodNotReady,omitempty"`
 }

--- a/apis/apps/pub/pod_readiness_gate.go
+++ b/apis/apps/pub/pod_readiness_gate.go
@@ -19,5 +19,12 @@ package pub
 import v1 "k8s.io/api/core/v1"
 
 const (
+	// KruisePodReadyConditionType can support multiple writers, such as:
+	// - ContainerRecreateRequest;
+	// - Workload controller, including CloneSet, Advanced StatefulSet, Advanced Daemonset.
+	//
+	// If its corresponding condition status was set to "False" by multiple writers,
+	// the condition status will be considered as "True" only when all these writers
+	// set it to "True".
 	KruisePodReadyConditionType v1.PodConditionType = "KruisePodReady"
 )

--- a/config/crd/bases/apps.kruise.io_clonesets.yaml
+++ b/config/crd/bases/apps.kruise.io_clonesets.yaml
@@ -97,6 +97,13 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
+                      markPodNotReady:
+                        description: 'MarkPodNotReady = true means: - Pod will be
+                          set to ''NotReady'' at preparingDelete/preparingUpdate state.
+                          - Pod will be restored to ''Ready'' at Updated state if
+                          it was set to ''NotReady'' at preparingUpdate state. Default
+                          to false.'
+                        type: boolean
                     type: object
                   preDelete:
                     description: PreDelete is the hook before Pod to be deleted.
@@ -109,6 +116,13 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
+                      markPodNotReady:
+                        description: 'MarkPodNotReady = true means: - Pod will be
+                          set to ''NotReady'' at preparingDelete/preparingUpdate state.
+                          - Pod will be restored to ''Ready'' at Updated state if
+                          it was set to ''NotReady'' at preparingUpdate state. Default
+                          to false.'
+                        type: boolean
                     type: object
                 type: object
               minReadySeconds:

--- a/config/crd/bases/apps.kruise.io_daemonsets.yaml
+++ b/config/crd/bases/apps.kruise.io_daemonsets.yaml
@@ -93,6 +93,13 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
+                      markPodNotReady:
+                        description: 'MarkPodNotReady = true means: - Pod will be
+                          set to ''NotReady'' at preparingDelete/preparingUpdate state.
+                          - Pod will be restored to ''Ready'' at Updated state if
+                          it was set to ''NotReady'' at preparingUpdate state. Default
+                          to false.'
+                        type: boolean
                     type: object
                   preDelete:
                     description: PreDelete is the hook before Pod to be deleted.
@@ -105,6 +112,13 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
+                      markPodNotReady:
+                        description: 'MarkPodNotReady = true means: - Pod will be
+                          set to ''NotReady'' at preparingDelete/preparingUpdate state.
+                          - Pod will be restored to ''Ready'' at Updated state if
+                          it was set to ''NotReady'' at preparingUpdate state. Default
+                          to false.'
+                        type: boolean
                     type: object
                 type: object
               minReadySeconds:

--- a/config/crd/bases/apps.kruise.io_statefulsets.yaml
+++ b/config/crd/bases/apps.kruise.io_statefulsets.yaml
@@ -514,6 +514,13 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
+                      markPodNotReady:
+                        description: 'MarkPodNotReady = true means: - Pod will be
+                          set to ''NotReady'' at preparingDelete/preparingUpdate state.
+                          - Pod will be restored to ''Ready'' at Updated state if
+                          it was set to ''NotReady'' at preparingUpdate state. Default
+                          to false.'
+                        type: boolean
                     type: object
                   preDelete:
                     description: PreDelete is the hook before Pod to be deleted.
@@ -526,6 +533,13 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
+                      markPodNotReady:
+                        description: 'MarkPodNotReady = true means: - Pod will be
+                          set to ''NotReady'' at preparingDelete/preparingUpdate state.
+                          - Pod will be restored to ''Ready'' at Updated state if
+                          it was set to ''NotReady'' at preparingUpdate state. Default
+                          to false.'
+                        type: boolean
                     type: object
                 type: object
               persistentVolumeClaimRetentionPolicy:

--- a/config/crd/bases/apps.kruise.io_uniteddeployments.yaml
+++ b/config/crd/bases/apps.kruise.io_uniteddeployments.yaml
@@ -145,6 +145,13 @@ spec:
                                     additionalProperties:
                                       type: string
                                     type: object
+                                  markPodNotReady:
+                                    description: 'MarkPodNotReady = true means: -
+                                      Pod will be set to ''NotReady'' at preparingDelete/preparingUpdate
+                                      state. - Pod will be restored to ''Ready'' at
+                                      Updated state if it was set to ''NotReady''
+                                      at preparingUpdate state. Default to false.'
+                                    type: boolean
                                 type: object
                               preDelete:
                                 description: PreDelete is the hook before Pod to be
@@ -158,6 +165,13 @@ spec:
                                     additionalProperties:
                                       type: string
                                     type: object
+                                  markPodNotReady:
+                                    description: 'MarkPodNotReady = true means: -
+                                      Pod will be set to ''NotReady'' at preparingDelete/preparingUpdate
+                                      state. - Pod will be restored to ''Ready'' at
+                                      Updated state if it was set to ''NotReady''
+                                      at preparingUpdate state. Default to false.'
+                                    type: boolean
                                 type: object
                             type: object
                           persistentVolumeClaimRetentionPolicy:
@@ -546,6 +560,13 @@ spec:
                                     additionalProperties:
                                       type: string
                                     type: object
+                                  markPodNotReady:
+                                    description: 'MarkPodNotReady = true means: -
+                                      Pod will be set to ''NotReady'' at preparingDelete/preparingUpdate
+                                      state. - Pod will be restored to ''Ready'' at
+                                      Updated state if it was set to ''NotReady''
+                                      at preparingUpdate state. Default to false.'
+                                    type: boolean
                                 type: object
                               preDelete:
                                 description: PreDelete is the hook before Pod to be
@@ -559,6 +580,13 @@ spec:
                                     additionalProperties:
                                       type: string
                                     type: object
+                                  markPodNotReady:
+                                    description: 'MarkPodNotReady = true means: -
+                                      Pod will be set to ''NotReady'' at preparingDelete/preparingUpdate
+                                      state. - Pod will be restored to ''Ready'' at
+                                      Updated state if it was set to ''NotReady''
+                                      at preparingUpdate state. Default to false.'
+                                    type: boolean
                                 type: object
                             type: object
                           minReadySeconds:

--- a/pkg/controller/cloneset/cloneset_status.go
+++ b/pkg/controller/cloneset/cloneset_status.go
@@ -21,6 +21,7 @@ import (
 
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
 	clonesetcore "github.com/openkruise/kruise/pkg/controller/cloneset/core"
+	"github.com/openkruise/kruise/pkg/controller/cloneset/sync"
 	clonesetutils "github.com/openkruise/kruise/pkg/controller/cloneset/utils"
 	"github.com/openkruise/kruise/pkg/util"
 	v1 "k8s.io/api/core/v1"
@@ -88,7 +89,7 @@ func (r *realStatusUpdater) calculateStatus(cs *appsv1alpha1.CloneSet, newStatus
 		if coreControl.IsPodUpdateReady(pod, 0) {
 			newStatus.ReadyReplicas++
 		}
-		if coreControl.IsPodUpdateReady(pod, cs.Spec.MinReadySeconds) {
+		if sync.IsPodAvailable(coreControl, pod, cs.Spec.MinReadySeconds) {
 			newStatus.AvailableReplicas++
 		}
 		if clonesetutils.EqualToRevisionHash("", pod, newStatus.UpdateRevision) {

--- a/pkg/controller/cloneset/sync/cloneset_scale.go
+++ b/pkg/controller/cloneset/sync/cloneset_scale.go
@@ -165,6 +165,14 @@ func (r *realControl) Scale(
 }
 
 func (r *realControl) managePreparingDelete(cs *appsv1alpha1.CloneSet, pods, podsInPreDelete []*v1.Pod, numToDelete int) (bool, error) {
+	//  We do not allow regret once the pod enter PreparingDelete state if MarkPodNotReady is set.
+	// Actually, there is a bug cased by this transformation from PreparingDelete to Normal,
+	// i.e., Lifecycle Updated Hook may be lost if the pod was transformed from Updating state
+	// to PreparingDelete.
+	if lifecycle.IsLifecycleMarkPodNotReady(cs.Spec.Lifecycle) {
+		return false, nil
+	}
+
 	diff := int(*cs.Spec.Replicas) - len(pods) + numToDelete
 	var modified bool
 	for _, pod := range podsInPreDelete {
@@ -177,7 +185,7 @@ func (r *realControl) managePreparingDelete(cs *appsv1alpha1.CloneSet, pods, pod
 
 		klog.V(3).Infof("CloneSet %s patch pod %s lifecycle from PreparingDelete to Normal",
 			clonesetutils.GetControllerKey(cs), pod.Name)
-		if updated, gotPod, err := r.lifecycleControl.UpdatePodLifecycle(pod, appspub.LifecycleStateNormal); err != nil {
+		if updated, gotPod, err := r.lifecycleControl.UpdatePodLifecycle(pod, appspub.LifecycleStateNormal, false); err != nil {
 			return modified, err
 		} else if updated {
 			modified = true
@@ -270,7 +278,8 @@ func (r *realControl) deletePods(cs *appsv1alpha1.CloneSet, podsToDelete []*v1.P
 	var modified bool
 	for _, pod := range podsToDelete {
 		if cs.Spec.Lifecycle != nil && lifecycle.IsPodHooked(cs.Spec.Lifecycle.PreDelete, pod) {
-			if updated, gotPod, err := r.lifecycleControl.UpdatePodLifecycle(pod, appspub.LifecycleStatePreparingDelete); err != nil {
+			markPodNotReady := cs.Spec.Lifecycle.PreDelete.MarkPodNotReady
+			if updated, gotPod, err := r.lifecycleControl.UpdatePodLifecycle(pod, appspub.LifecycleStatePreparingDelete, markPodNotReady); err != nil {
 				return false, err
 			} else if updated {
 				klog.V(3).Infof("CloneSet %s scaling update pod %s lifecycle to PreparingDelete",
@@ -383,7 +392,7 @@ func (r *realControl) choosePodsToDelete(cs *appsv1alpha1.CloneSet, totalDiff in
 				Pods:   pods,
 				Ranker: ranker,
 				AvailableFunc: func(pod *v1.Pod) bool {
-					return isPodAvailable(coreControl, pod, cs.Spec.MinReadySeconds)
+					return IsPodAvailable(coreControl, pod, cs.Spec.MinReadySeconds)
 				},
 			})
 		} else if diff > len(pods) {

--- a/pkg/controller/cloneset/sync/cloneset_sync_utils.go
+++ b/pkg/controller/cloneset/sync/cloneset_sync_utils.go
@@ -122,7 +122,7 @@ func calculateDiffsWithExpectation(cs *appsv1alpha1.CloneSet, pods []*v1.Pod, cu
 
 				if isSpecifiedDelete(cs, p) {
 					toDeleteNewRevisionCount++
-				} else if !isPodAvailable(coreControl, p, cs.Spec.MinReadySeconds) {
+				} else if !IsPodAvailable(coreControl, p, cs.Spec.MinReadySeconds) {
 					unavailableNewRevisionCount++
 				}
 			}
@@ -138,7 +138,7 @@ func calculateDiffsWithExpectation(cs *appsv1alpha1.CloneSet, pods []*v1.Pod, cu
 
 				if isSpecifiedDelete(cs, p) {
 					toDeleteOldRevisionCount++
-				} else if !isPodAvailable(coreControl, p, cs.Spec.MinReadySeconds) {
+				} else if !IsPodAvailable(coreControl, p, cs.Spec.MinReadySeconds) {
 					unavailableOldRevisionCount++
 				}
 			}
@@ -235,10 +235,10 @@ func isSpecifiedDelete(cs *appsv1alpha1.CloneSet, pod *v1.Pod) bool {
 }
 
 func isPodReady(coreControl clonesetcore.Control, pod *v1.Pod) bool {
-	return isPodAvailable(coreControl, pod, 0)
+	return IsPodAvailable(coreControl, pod, 0)
 }
 
-func isPodAvailable(coreControl clonesetcore.Control, pod *v1.Pod, minReadySeconds int32) bool {
+func IsPodAvailable(coreControl clonesetcore.Control, pod *v1.Pod, minReadySeconds int32) bool {
 	state := lifecycle.GetPodLifecycleState(pod)
 	if state != "" && state != appspub.LifecycleStateNormal {
 		return false

--- a/pkg/controller/daemonset/daemonset_controller.go
+++ b/pkg/controller/daemonset/daemonset_controller.go
@@ -755,7 +755,8 @@ func (dsc *ReconcileDaemonSet) syncWithPreparingDelete(ds *appsv1alpha1.DaemonSe
 			podsCanDelete = append(podsCanDelete, podName)
 			continue
 		}
-		if updated, gotPod, err := dsc.lifecycleControl.UpdatePodLifecycle(pod, appspub.LifecycleStatePreparingDelete); err != nil {
+		markPodNotReady := ds.Spec.Lifecycle.PreDelete.MarkPodNotReady
+		if updated, gotPod, err := dsc.lifecycleControl.UpdatePodLifecycle(pod, appspub.LifecycleStatePreparingDelete, markPodNotReady); err != nil {
 			return nil, err
 		} else if updated {
 			klog.V(3).Infof("DaemonSet %s/%s has marked Pod %s as PreparingDelete", ds.Namespace, ds.Name, podName)
@@ -989,7 +990,6 @@ func (dsc *ReconcileDaemonSet) refreshUpdateStates(ds *appsv1alpha1.DaemonSet) e
 
 	opts := &inplaceupdate.UpdateOptions{}
 	opts = inplaceupdate.SetOptionsDefaults(opts)
-
 	for _, pod := range pods {
 		if dsc.inplaceControl == nil {
 			continue

--- a/pkg/util/podreadiness/pod_readiness.go
+++ b/pkg/util/podreadiness/pod_readiness.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2022 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package podreadiness
+
+import (
+	"sort"
+
+	appspub "github.com/openkruise/kruise/apis/apps/pub"
+	"github.com/openkruise/kruise/pkg/util"
+	"github.com/openkruise/kruise/pkg/util/podadapter"
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type Interface interface {
+	AddNotReadyKey(pod *v1.Pod, msg Message) error
+	RemoveNotReadyKey(pod *v1.Pod, msg Message) error
+}
+
+func New(c client.Client) Interface {
+	return &commonControl{adp: &podadapter.AdapterRuntimeClient{Client: c}}
+}
+
+func NewForAdapter(adp podadapter.Adapter) Interface {
+	return &commonControl{adp: adp}
+}
+
+type commonControl struct {
+	adp podadapter.Adapter
+}
+
+func (c *commonControl) AddNotReadyKey(pod *v1.Pod, msg Message) error {
+	_, err := addNotReadyKey(c.adp, pod, msg, appspub.KruisePodReadyConditionType)
+	return err
+}
+
+func (c *commonControl) RemoveNotReadyKey(pod *v1.Pod, msg Message) error {
+	_, err := removeNotReadyKey(c.adp, pod, msg, appspub.KruisePodReadyConditionType)
+	return err
+}
+
+type Message struct {
+	UserAgent string `json:"userAgent"`
+	Key       string `json:"key"`
+}
+
+type messageList []Message
+
+func (c messageList) Len() int      { return len(c) }
+func (c messageList) Swap(i, j int) { c[i], c[j] = c[j], c[i] }
+func (c messageList) Less(i, j int) bool {
+	if c[i].UserAgent == c[j].UserAgent {
+		return c[i].Key < c[j].Key
+	}
+	return c[i].UserAgent < c[j].UserAgent
+}
+
+func (c messageList) dump() string {
+	sort.Sort(c)
+	return util.DumpJSON(c)
+}

--- a/pkg/util/podreadiness/pod_readiness_utils.go
+++ b/pkg/util/podreadiness/pod_readiness_utils.go
@@ -17,33 +17,32 @@ limitations under the License.
 package podreadiness
 
 import (
-	"context"
 	"encoding/json"
-	"sort"
 
 	appspub "github.com/openkruise/kruise/apis/apps/pub"
-	"github.com/openkruise/kruise/pkg/util"
+	"github.com/openkruise/kruise/pkg/util/podadapter"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func AddNotReadyKey(c client.Client, pod *v1.Pod, msg Message) error {
-	if alreadyHasKey(pod, msg) {
-		return nil
+func addNotReadyKey(adp podadapter.Adapter, pod *v1.Pod, msg Message, condType v1.PodConditionType) (bool, error) {
+	if alreadyHasKey(pod, msg, condType) {
+		return true, nil
 	}
-	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		newPod := &v1.Pod{}
-		if err := c.Get(context.TODO(), types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}, newPod); err != nil {
+
+	readinessGateExists := false
+	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		newPod, err := adp.GetPod(pod.Namespace, pod.Name)
+		if err != nil {
 			return err
 		}
-		if !ContainsReadinessGate(pod) {
+		if !containsReadinessGate(newPod, condType) {
 			return nil
 		}
 
-		condition := GetReadinessCondition(newPod)
+		readinessGateExists = true
+		condition := getReadinessCondition(newPod, condType)
 		if condition == nil {
 			_, messages := addMessage("", msg)
 			newPod.Status.Conditions = append(newPod.Status.Conditions, v1.PodCondition{
@@ -61,21 +60,24 @@ func AddNotReadyKey(c client.Client, pod *v1.Pod, msg Message) error {
 			condition.LastTransitionTime = metav1.Now()
 		}
 
-		return c.Status().Update(context.TODO(), newPod)
+		return adp.UpdatePodStatus(newPod)
 	})
+	return readinessGateExists, err
 }
 
-func RemoveNotReadyKey(c client.Client, pod *v1.Pod, msg Message) error {
-	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		newPod := &v1.Pod{}
-		if err := c.Get(context.TODO(), types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}, newPod); err != nil {
+func removeNotReadyKey(adp podadapter.Adapter, pod *v1.Pod, msg Message, condType v1.PodConditionType) (bool, error) {
+	readinessGateExists := false
+	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		newPod, err := adp.GetPod(pod.Namespace, pod.Name)
+		if err != nil {
 			return err
 		}
-		if !ContainsReadinessGate(pod) {
+		if !containsReadinessGate(newPod, condType) {
 			return nil
 		}
 
-		condition := GetReadinessCondition(newPod)
+		readinessGateExists = true
+		condition := getReadinessCondition(newPod, condType)
 		if condition == nil {
 			return nil
 		}
@@ -89,29 +91,9 @@ func RemoveNotReadyKey(c client.Client, pod *v1.Pod, msg Message) error {
 		condition.Message = messages.dump()
 		condition.LastTransitionTime = metav1.Now()
 
-		return c.Status().Update(context.TODO(), newPod)
+		return adp.UpdatePodStatus(newPod)
 	})
-}
-
-type Message struct {
-	UserAgent string `json:"userAgent"`
-	Key       string `json:"key"`
-}
-
-type messageList []Message
-
-func (c messageList) Len() int      { return len(c) }
-func (c messageList) Swap(i, j int) { c[i], c[j] = c[j], c[i] }
-func (c messageList) Less(i, j int) bool {
-	if c[i].UserAgent == c[j].UserAgent {
-		return c[i].Key < c[j].Key
-	}
-	return c[i].UserAgent < c[j].UserAgent
-}
-
-func (c messageList) dump() string {
-	sort.Sort(c)
-	return util.DumpJSON(c)
+	return readinessGateExists, err
 }
 
 func addMessage(base string, msg Message) (bool, messageList) {
@@ -146,29 +128,37 @@ func removeMessage(base string, msg Message) (bool, messageList) {
 }
 
 func GetReadinessCondition(pod *v1.Pod) *v1.PodCondition {
+	return getReadinessCondition(pod, appspub.KruisePodReadyConditionType)
+}
+
+func ContainsReadinessGate(pod *v1.Pod) bool {
+	return containsReadinessGate(pod, appspub.KruisePodReadyConditionType)
+}
+
+func getReadinessCondition(pod *v1.Pod, condType v1.PodConditionType) *v1.PodCondition {
 	if pod == nil {
 		return nil
 	}
 	for i := range pod.Status.Conditions {
 		c := &pod.Status.Conditions[i]
-		if c.Type == appspub.KruisePodReadyConditionType {
+		if c.Type == condType {
 			return c
 		}
 	}
 	return nil
 }
 
-func ContainsReadinessGate(pod *v1.Pod) bool {
+func containsReadinessGate(pod *v1.Pod, condType v1.PodConditionType) bool {
 	for _, g := range pod.Spec.ReadinessGates {
-		if g.ConditionType == appspub.KruisePodReadyConditionType {
+		if g.ConditionType == condType {
 			return true
 		}
 	}
 	return false
 }
 
-func alreadyHasKey(pod *v1.Pod, msg Message) bool {
-	condition := GetReadinessCondition(pod)
+func alreadyHasKey(pod *v1.Pod, msg Message, condType v1.PodConditionType) bool {
+	condition := getReadinessCondition(pod, condType)
 	if condition == nil {
 		return false
 	}

--- a/pkg/util/podreadiness/pod_readiness_utils_test.go
+++ b/pkg/util/podreadiness/pod_readiness_utils_test.go
@@ -46,16 +46,20 @@ func TestPodReadiness(t *testing.T) {
 	msg0 := Message{UserAgent: "ua1", Key: "foo"}
 	msg1 := Message{UserAgent: "ua1", Key: "bar"}
 
-	if err := AddNotReadyKey(fakeClient, pod0, msg0); err != nil {
+	controller := New(fakeClient)
+	AddNotReadyKey := controller.AddNotReadyKey
+	RemoveNotReadyKey := controller.RemoveNotReadyKey
+
+	if err := AddNotReadyKey(pod0, msg0); err != nil {
 		t.Fatal(err)
 	}
-	if err := AddNotReadyKey(fakeClient, pod0, msg1); err != nil {
+	if err := AddNotReadyKey(pod0, msg1); err != nil {
 		t.Fatal(err)
 	}
-	if err := AddNotReadyKey(fakeClient, pod1, msg0); err != nil {
+	if err := AddNotReadyKey(pod1, msg0); err != nil {
 		t.Fatal(err)
 	}
-	if err := AddNotReadyKey(fakeClient, pod1, msg1); err != nil {
+	if err := AddNotReadyKey(pod1, msg1); err != nil {
 		t.Fatal(err)
 	}
 
@@ -63,7 +67,7 @@ func TestPodReadiness(t *testing.T) {
 	if err := fakeClient.Get(context.TODO(), types.NamespacedName{Namespace: pod0.Namespace, Name: pod0.Name}, newPod0); err != nil {
 		t.Fatal(err)
 	}
-	if !alreadyHasKey(newPod0, msg0) || !alreadyHasKey(newPod0, msg1) {
+	if !alreadyHasKey(newPod0, msg0, appspub.KruisePodReadyConditionType) || !alreadyHasKey(newPod0, msg1, appspub.KruisePodReadyConditionType) {
 		t.Fatalf("expect already has key, but not")
 	}
 	condition := GetReadinessCondition(newPod0)
@@ -75,24 +79,24 @@ func TestPodReadiness(t *testing.T) {
 	if err := fakeClient.Get(context.TODO(), types.NamespacedName{Namespace: pod1.Namespace, Name: pod1.Name}, newPod1); err != nil {
 		t.Fatal(err)
 	}
-	if alreadyHasKey(newPod1, msg0) || alreadyHasKey(newPod1, msg1) {
+	if alreadyHasKey(newPod1, msg0, appspub.KruisePodReadyConditionType) || alreadyHasKey(newPod1, msg1, appspub.KruisePodReadyConditionType) {
 		t.Fatalf("expect not have key, but it does")
 	}
 	if condition = GetReadinessCondition(newPod1); condition != nil {
 		t.Fatalf("expect condition nil, but exists: %v", condition)
 	}
 
-	if err := RemoveNotReadyKey(fakeClient, newPod0, msg0); err != nil {
+	if err := RemoveNotReadyKey(newPod0, msg0); err != nil {
 		t.Fatal(err)
 	}
 	newPod0 = &v1.Pod{}
 	if err := fakeClient.Get(context.TODO(), types.NamespacedName{Namespace: pod0.Namespace, Name: pod0.Name}, newPod0); err != nil {
 		t.Fatal(err)
 	}
-	if !alreadyHasKey(newPod0, msg1) {
+	if !alreadyHasKey(newPod0, msg1, appspub.KruisePodReadyConditionType) {
 		t.Fatalf("expect already has key, but not")
 	}
-	if alreadyHasKey(newPod0, msg0) {
+	if alreadyHasKey(newPod0, msg0, appspub.KruisePodReadyConditionType) {
 		t.Fatalf("expect not have key, but it does")
 	}
 	condition = GetReadinessCondition(newPod0)
@@ -100,14 +104,14 @@ func TestPodReadiness(t *testing.T) {
 		t.Fatalf("expect condition false, but not")
 	}
 
-	if err := RemoveNotReadyKey(fakeClient, newPod0, msg1); err != nil {
+	if err := RemoveNotReadyKey(newPod0, msg1); err != nil {
 		t.Fatal(err)
 	}
 	newPod0 = &v1.Pod{}
 	if err := fakeClient.Get(context.TODO(), types.NamespacedName{Namespace: pod0.Namespace, Name: pod0.Name}, newPod0); err != nil {
 		t.Fatal(err)
 	}
-	if alreadyHasKey(newPod0, msg0) || alreadyHasKey(newPod0, msg1) {
+	if alreadyHasKey(newPod0, msg0, appspub.KruisePodReadyConditionType) || alreadyHasKey(newPod0, msg1, appspub.KruisePodReadyConditionType) {
 		t.Fatalf("expect not have key, but it does")
 	}
 	condition = GetReadinessCondition(newPod0)


### PR DESCRIPTION
Signed-off-by: mingzhou.swx <mingzhou.swx@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
- Add mark pod not ready feature to Lifecycle hooks;
- CloneSet status.availableReplicas consider lifecycle state, only the pods at normal state are available.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
#944 
