### PR TITLE
pub support custom workload

### DIFF
--- a/apis/policy/v1alpha1/podunavailablebudget_types.go
+++ b/apis/policy/v1alpha1/podunavailablebudget_types.go
@@ -24,6 +24,14 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
+const (
+	// PubProtectOperationAnnotation indicates the pub protected Operation[DELETE,UPDATE]
+	// the following indicates the pub only protect DELETE,UPDATE Operation
+	// annotations[kruise.io/pub-protect-operations]=DELETE,UPDATE
+	// if the annotations do not exist, the default DELETE and UPDATE are protected
+	PubProtectOperationAnnotation = "kruise.io/pub-protect-operations"
+)
+
 // PodUnavailableBudgetSpec defines the desired state of PodUnavailableBudget
 type PodUnavailableBudgetSpec struct {
 	// Selector label query over pods managed by the budget

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -43,6 +43,14 @@ rules:
   verbs:
   - list
 - apiGroups:
+  - '*'
+  resources:
+  - '*/scale'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - admissionregistration.k8s.io
   resources:
   - mutatingwebhookconfigurations

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/openkruise/kruise/pkg/util/controllerfinder"
 	"github.com/spf13/pflag"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -147,6 +148,11 @@ func main() {
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
+		os.Exit(1)
+	}
+	err = controllerfinder.InitControllerFinder(mgr)
+	if err != nil {
+		setupLog.Error(err, "unable to start ControllerFinder")
 		os.Exit(1)
 	}
 

--- a/pkg/control/pubcontrol/api.go
+++ b/pkg/control/pubcontrol/api.go
@@ -44,6 +44,6 @@ type PubControl interface {
 }
 
 func NewPubControl(client client.Client) PubControl {
-	controllerFinder := controllerfinder.NewControllerFinder(client)
+	controllerFinder := controllerfinder.Finder
 	return &commonControl{controllerFinder: controllerFinder, Client: client}
 }

--- a/pkg/controller/cloneset/sync/api.go
+++ b/pkg/controller/cloneset/sync/api.go
@@ -58,7 +58,7 @@ func New(c client.Client, recorder record.EventRecorder) Interface {
 		inplaceControl:   inplaceupdate.New(c, clonesetutils.RevisionAdapterImpl),
 		lifecycleControl: lifecycle.New(c),
 		recorder:         recorder,
-		controllerFinder: controllerfinder.NewControllerFinder(c),
+		controllerFinder: controllerfinder.Finder,
 		pubControl:       pubcontrol.NewPubControl(c),
 	}
 }

--- a/pkg/controller/cloneset/sync/cloneset_update_test.go
+++ b/pkg/controller/cloneset/sync/cloneset_update_test.go
@@ -588,7 +588,7 @@ func TestUpdate(t *testing.T) {
 			lifecycle.New(fakeClient),
 			inplaceupdate.New(fakeClient, clonesetutils.RevisionAdapterImpl),
 			record.NewFakeRecorder(10),
-			controllerfinder.NewControllerFinder(fakeClient),
+			&controllerfinder.ControllerFinder{Client: fakeClient},
 			pubcontrol.NewPubControl(fakeClient),
 		}
 		currentRevision := mc.updateRevision

--- a/pkg/controller/persistentpodstate/persistent_pod_state_controller.go
+++ b/pkg/controller/persistentpodstate/persistent_pod_state_controller.go
@@ -79,7 +79,7 @@ func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 	return &ReconcilePersistentPodState{
 		Client: cli,
 		scheme: mgr.GetScheme(),
-		finder: controllerfinder.NewControllerFinder(cli),
+		finder: controllerfinder.Finder,
 	}
 }
 

--- a/pkg/controller/persistentpodstate/persistent_pod_state_controller_test.go
+++ b/pkg/controller/persistentpodstate/persistent_pod_state_controller_test.go
@@ -519,7 +519,7 @@ func TestReconcilePersistentPodState(t *testing.T) {
 			fakeClient := clientBuilder.Build()
 			reconciler := ReconcilePersistentPodState{
 				Client: fakeClient,
-				finder: controllerfinder.NewControllerFinder(fakeClient),
+				finder: &controllerfinder.ControllerFinder{Client: fakeClient},
 			}
 			if _, err := reconciler.Reconcile(context.TODO(), request); err != nil {
 				t.Fatalf("reconcile failed, err: %v", err)

--- a/pkg/controller/podunavailablebudget/podunavailablebudget_controller.go
+++ b/pkg/controller/podunavailablebudget/podunavailablebudget_controller.go
@@ -103,7 +103,7 @@ func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 		Client:           mgr.GetClient(),
 		Scheme:           mgr.GetScheme(),
 		recorder:         mgr.GetEventRecorderFor("podunavailablebudget-controller"),
-		controllerFinder: controllerfinder.NewControllerFinder(mgr.GetClient()),
+		controllerFinder: controllerfinder.Finder,
 		pubControl:       pubcontrol.NewPubControl(mgr.GetClient()),
 	}
 }
@@ -208,6 +208,7 @@ type ReconcilePodUnavailableBudget struct {
 
 // +kubebuilder:rbac:groups=policy.kruise.io,resources=podunavailablebudgets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=policy.kruise.io,resources=podunavailablebudgets/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=*,resources=*/scale,verbs=get;list;watch
 
 // pkg/controller/cloneset/cloneset_controller.go Watch for changes to CloneSet
 func (r *ReconcilePodUnavailableBudget) Reconcile(_ context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/pkg/controller/podunavailablebudget/pub_controller_test.go
+++ b/pkg/controller/podunavailablebudget/pub_controller_test.go
@@ -767,10 +767,11 @@ func TestPubReconcile(t *testing.T) {
 					t.Fatalf("create pod failed: %s", err.Error())
 				}
 			}
+			controllerfinder.Finder = &controllerfinder.ControllerFinder{Client: fakeClient}
 			reconciler := ReconcilePodUnavailableBudget{
 				Client:           fakeClient,
 				recorder:         record.NewFakeRecorder(10),
-				controllerFinder: controllerfinder.NewControllerFinder(fakeClient),
+				controllerFinder: &controllerfinder.ControllerFinder{Client: fakeClient},
 				pubControl:       pubcontrol.NewPubControl(fakeClient),
 			}
 

--- a/pkg/controller/workloadspread/reschedule_test.go
+++ b/pkg/controller/workloadspread/reschedule_test.go
@@ -268,9 +268,11 @@ func TestRescheduleSubset(t *testing.T) {
 			}
 
 			reconciler := ReconcileWorkloadSpread{
-				Client:           fakeClient,
-				recorder:         record.NewFakeRecorder(10),
-				controllerFinder: controllerfinder.NewControllerFinder(fakeClient),
+				Client:   fakeClient,
+				recorder: record.NewFakeRecorder(10),
+				controllerFinder: &controllerfinder.ControllerFinder{
+					Client: fakeClient,
+				},
 			}
 
 			err := reconciler.syncWorkloadSpread(workloadSpread)

--- a/pkg/controller/workloadspread/workloadspread_controller.go
+++ b/pkg/controller/workloadspread/workloadspread_controller.go
@@ -154,7 +154,7 @@ func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 		Client:           cli,
 		scheme:           mgr.GetScheme(),
 		recorder:         mgr.GetEventRecorderFor(controllerName),
-		controllerFinder: controllerfinder.NewControllerFinder(mgr.GetClient()),
+		controllerFinder: controllerfinder.Finder,
 	}
 }
 

--- a/pkg/controller/workloadspread/workloadspread_controller_test.go
+++ b/pkg/controller/workloadspread/workloadspread_controller_test.go
@@ -1409,7 +1409,7 @@ func TestWorkloadSpreadReconcile(t *testing.T) {
 			reconciler := ReconcileWorkloadSpread{
 				Client:           fakeClient,
 				recorder:         record.NewFakeRecorder(10),
-				controllerFinder: controllerfinder.NewControllerFinder(fakeClient),
+				controllerFinder: &controllerfinder.ControllerFinder{Client: fakeClient},
 			}
 
 			err := reconciler.syncWorkloadSpread(workloadSpread)
@@ -1609,7 +1609,7 @@ func TestDelayReconcile(t *testing.T) {
 			reconciler := ReconcileWorkloadSpread{
 				Client:           fakeClient,
 				recorder:         record.NewFakeRecorder(10),
-				controllerFinder: controllerfinder.NewControllerFinder(fakeClient),
+				controllerFinder: &controllerfinder.ControllerFinder{Client: fakeClient},
 			}
 
 			durationStore = requeueduration.DurationStore{}
@@ -2031,7 +2031,7 @@ func TestManagerExistingPods(t *testing.T) {
 			reconciler := ReconcileWorkloadSpread{
 				Client:           fakeClient,
 				recorder:         record.NewFakeRecorder(10),
-				controllerFinder: controllerfinder.NewControllerFinder(fakeClient),
+				controllerFinder: &controllerfinder.ControllerFinder{Client: fakeClient},
 			}
 
 			durationStore = requeueduration.DurationStore{}

--- a/pkg/webhook/pod/mutating/pod_create_update_handler.go
+++ b/pkg/webhook/pod/mutating/pod_create_update_handler.go
@@ -111,7 +111,7 @@ var _ inject.Client = &PodCreateHandler{}
 // InjectClient injects the client into the PodCreateHandler
 func (h *PodCreateHandler) InjectClient(c client.Client) error {
 	h.Client = c
-	h.finder = controllerfinder.NewControllerFinder(c)
+	h.finder = controllerfinder.Finder
 	return nil
 }
 

--- a/pkg/webhook/pod/mutating/pod_unavailable_budget.go
+++ b/pkg/webhook/pod/mutating/pod_unavailable_budget.go
@@ -20,9 +20,9 @@ import (
 	"context"
 
 	"github.com/openkruise/kruise/pkg/control/pubcontrol"
+	"github.com/openkruise/kruise/pkg/controller/podunavailablebudget"
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
@@ -33,18 +33,7 @@ func (h *PodCreateHandler) pubMutatingPod(ctx context.Context, req admission.Req
 		req.AdmissionRequest.Resource.Resource != "pods" {
 		return nil
 	}
-	ref := metav1.GetControllerOf(pod)
-	if ref == nil {
-		return nil
-	}
-	workload, err := h.finder.GetScaleAndSelectorForRef(ref.APIVersion, ref.Kind, pod.Namespace, ref.Name, "")
-	if err != nil {
-		return err
-	} else if workload == nil {
-		return nil
-	}
-	// fetch pub for workload
-	pub, err := pubcontrol.GetPubForWorkload(h.Client, workload)
+	pub, err := podunavailablebudget.GetPubForPod(h.Client, pod)
 	if err != nil {
 		return err
 	} else if pub == nil {

--- a/pkg/webhook/pod/validating/pod_create_update_handler.go
+++ b/pkg/webhook/pod/validating/pod_create_update_handler.go
@@ -90,7 +90,7 @@ var _ inject.Client = &PodCreateHandler{}
 // InjectClient injects the client into the PodCreateHandler
 func (h *PodCreateHandler) InjectClient(c client.Client) error {
 	h.Client = c
-	h.finders = controllerfinder.NewControllerFinder(c)
+	h.finders = controllerfinder.Finder
 	h.pubControl = pubcontrol.NewPubControl(c)
 	return nil
 }

--- a/pkg/webhook/podunavailablebudget/validating/pub_validating_test.go
+++ b/pkg/webhook/podunavailablebudget/validating/pub_validating_test.go
@@ -43,8 +43,9 @@ var (
 			Kind:       "PodUnavailableBudget",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "default",
-			Name:      "pub-test",
+			Namespace:   "default",
+			Name:        "pub-test",
+			Annotations: map[string]string{},
 		},
 		Spec: policyv1alpha1.PodUnavailableBudgetSpec{
 			Selector: &metav1.LabelSelector{
@@ -134,6 +135,28 @@ func TestValidatingPub(t *testing.T) {
 				return pub
 			},
 			expectErrList: 1,
+		},
+		{
+			name: "invalid pub feature-gate annotation",
+			pub: func() *policyv1alpha1.PodUnavailableBudget {
+				pub := pubDemo.DeepCopy()
+				pub.Spec.Selector = nil
+				pub.Spec.MinAvailable = nil
+				pub.Annotations[policyv1alpha1.PubProtectOperationAnnotation] = "xxxxx"
+				return pub
+			},
+			expectErrList: 1,
+		},
+		{
+			name: "valid pub feature-gate annotation",
+			pub: func() *policyv1alpha1.PodUnavailableBudget {
+				pub := pubDemo.DeepCopy()
+				pub.Spec.Selector = nil
+				pub.Spec.MinAvailable = nil
+				pub.Annotations[policyv1alpha1.PubProtectOperationAnnotation] = "DELETE"
+				return pub
+			},
+			expectErrList: 0,
 		},
 	}
 

--- a/test/e2e/apps/daemonset.go
+++ b/test/e2e/apps/daemonset.go
@@ -55,7 +55,6 @@ var _ = SIGDescribe("DaemonSet", func() {
 		*/
 		framework.ConformanceIt("should run and stop simple daemon", func() {
 			label := map[string]string{framework.DaemonSetNameLabel: dsName}
-
 			ginkgo.By(fmt.Sprintf("Creating simple DaemonSet %q", dsName))
 			ds, err := tester.CreateDaemonSet(tester.NewDaemonSet(dsName, label, WebserverImage, appsv1alpha1.DaemonSetUpdateStrategy{}))
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())


### PR DESCRIPTION
Signed-off-by: liheng.zms <liheng.zms@alibaba-inc.com>
### Ⅰ. Describe what this PR does
1. pub support custom workload, for example argo-rollouts. The custom workload must contain scale subresources.
2. add pub annotations[kruise.io/pub-feature-gate] to determine the feature of the protection for each pub object. the following indicates that delete protection is enabled and update protection is disabled
annotations[kruise.io/pub-feature-gate]='PodUnavailableBudgetUpdateGate=false,PodUnavailableBudgetDeleteGate=true'
