### PR TITLE
pub support pod unvailable label

### DIFF
--- a/apis/apps/pub/pod_unavailable_label.go
+++ b/apis/apps/pub/pod_unavailable_label.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2022 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pub
+
+import (
+	"strings"
+)
+
+const (
+	// PubUnavailablePodLabelPrefix indicates if the pod has this label, both kruise workload and
+	// pub will determine that the pod is unavailable, even if pod.status.ready=true.
+	// Main users non-destructive offline and other scenarios
+	PubUnavailablePodLabelPrefix = "unavailable-pod.kruise.io/"
+)
+
+func HasUnavailableLabel(labels map[string]string) bool {
+	if len(labels) == 0 {
+		return false
+	}
+	for key := range labels {
+		if strings.HasPrefix(key, PubUnavailablePodLabelPrefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/apis/policy/v1alpha1/podunavailablebudget_types.go
+++ b/apis/policy/v1alpha1/podunavailablebudget_types.go
@@ -24,12 +24,17 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
+type PubOperation string
+
 const (
 	// PubProtectOperationAnnotation indicates the pub protected Operation[DELETE,UPDATE]
 	// the following indicates the pub only protect DELETE,UPDATE Operation
 	// annotations[kruise.io/pub-protect-operations]=DELETE,UPDATE
 	// if the annotations do not exist, the default DELETE and UPDATE are protected
 	PubProtectOperationAnnotation = "kruise.io/pub-protect-operations"
+	// pod webhook operation
+	PubUpdateOperation PubOperation = "UPDATE"
+	PubDeleteOperation PubOperation = "DELETE"
 )
 
 // PodUnavailableBudgetSpec defines the desired state of PodUnavailableBudget

--- a/pkg/control/pubcontrol/pub_control_test.go
+++ b/pkg/control/pubcontrol/pub_control_test.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2021 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pubcontrol
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/openkruise/kruise/apis/apps/pub"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestIsPodUnavailableChanged(t *testing.T) {
+	cases := []struct {
+		name      string
+		getOldPod func() *corev1.Pod
+		getNewPod func() *corev1.Pod
+		expect    bool
+	}{
+		{
+			name: "only annotations change",
+			getOldPod: func() *corev1.Pod {
+				demo := podDemo.DeepCopy()
+				return demo
+			},
+			getNewPod: func() *corev1.Pod {
+				demo := podDemo.DeepCopy()
+				demo.Annotations["add"] = "annotations"
+				return demo
+			},
+			expect: false,
+		},
+		{
+			name: "add unvailable label",
+			getOldPod: func() *corev1.Pod {
+				demo := podDemo.DeepCopy()
+				return demo
+			},
+			getNewPod: func() *corev1.Pod {
+				demo := podDemo.DeepCopy()
+				demo.Labels[fmt.Sprintf("%sdata", pub.PubUnavailablePodLabelPrefix)] = "true"
+				return demo
+			},
+			expect: true,
+		},
+		{
+			name: "image changed",
+			getOldPod: func() *corev1.Pod {
+				demo := podDemo.DeepCopy()
+				return demo
+			},
+			getNewPod: func() *corev1.Pod {
+				demo := podDemo.DeepCopy()
+				demo.Spec.Containers[0].Image = "nginx:v2"
+				return demo
+			},
+			expect: true,
+		},
+	}
+
+	for _, cs := range cases {
+		t.Run(cs.name, func(t *testing.T) {
+			control := commonControl{}
+			is := control.IsPodUnavailableChanged(cs.getOldPod(), cs.getNewPod())
+			if cs.expect != is {
+				t.Fatalf("IsPodUnavailableChanged failed")
+			}
+		})
+	}
+}
+
+func TestIsPodReady(t *testing.T) {
+	cases := []struct {
+		name   string
+		getPod func() *corev1.Pod
+		expect bool
+	}{
+		{
+			name: "pod ready",
+			getPod: func() *corev1.Pod {
+				demo := podDemo.DeepCopy()
+				return demo
+			},
+			expect: true,
+		},
+		{
+			name: "pod not ready",
+			getPod: func() *corev1.Pod {
+				demo := podDemo.DeepCopy()
+				demo.Status.Conditions[0].Status = corev1.ConditionFalse
+				return demo
+			},
+			expect: false,
+		},
+		{
+			name: "pod contains unavailable label",
+			getPod: func() *corev1.Pod {
+				demo := podDemo.DeepCopy()
+				demo.Labels[fmt.Sprintf("%sdata", pub.PubUnavailablePodLabelPrefix)] = "true"
+				return demo
+			},
+			expect: false,
+		},
+	}
+
+	for _, cs := range cases {
+		t.Run(cs.name, func(t *testing.T) {
+			control := commonControl{}
+			is := control.IsPodReady(cs.getPod())
+			if cs.expect != is {
+				t.Fatalf("IsPodReady failed")
+			}
+		})
+	}
+}

--- a/pkg/controller/cloneset/sync/cloneset_update.go
+++ b/pkg/controller/cloneset/sync/cloneset_update.go
@@ -129,21 +129,12 @@ func (c *realControl) Update(cs *appsv1alpha1.CloneSet,
 	// 5. limit max count of pods can update
 	waitUpdateIndexes = limitUpdateIndexes(coreControl, cs.Spec.MinReadySeconds, diffRes, waitUpdateIndexes, pods, targetRevision.Name)
 
-	// Determine the pub before updating the pod
-	var pub *policyv1alpha1.PodUnavailableBudget
-	var err error
-	if utilfeature.DefaultFeatureGate.Enabled(features.PodUnavailableBudgetUpdateGate) && len(waitUpdateIndexes) > 0 {
-		pub, err = c.pubControl.GetPubForPod(pods[waitUpdateIndexes[0]])
-		if err != nil {
-			return err
-		}
-	}
 	// 6. update pods
 	for _, idx := range waitUpdateIndexes {
 		pod := pods[idx]
 		// Determine the pub before updating the pod
-		if pub != nil {
-			allowed, _, err := pubcontrol.PodUnavailableBudgetValidatePod(c.Client, c.pubControl, pub, pod, pubcontrol.UpdateOperation, false)
+		if utilfeature.DefaultFeatureGate.Enabled(features.PodUnavailableBudgetUpdateGate) {
+			allowed, _, err := pubcontrol.PodUnavailableBudgetValidatePod(c.Client, c.pubControl, pod, policyv1alpha1.PubUpdateOperation, false)
 			if err != nil {
 				return err
 				// pub check does not pass, try again in seconds

--- a/pkg/util/pods.go
+++ b/pkg/util/pods.go
@@ -201,7 +201,7 @@ func GetPodVolume(pod *v1.Pod, volumeName string) *v1.Volume {
 }
 
 func IsRunningAndReady(pod *v1.Pod) bool {
-	return pod.Status.Phase == v1.PodRunning && podutil.IsPodReady(pod)
+	return pod.Status.Phase == v1.PodRunning && podutil.IsPodReady(pod) && pod.DeletionTimestamp.IsZero()
 }
 
 func GetPodContainerImageIDs(pod *v1.Pod) map[string]string {


### PR DESCRIPTION
Signed-off-by: liheng.zms <liheng.zms@alibaba-inc.com>
### Ⅰ. Describe what this PR does

// PubUnavailablePodLabelPrefix indicates if the pod has this label, both kruise workload and
// pub will determine that the pod is unavailable, even if pod.status.ready=true.
// Main users non-destructive offline and other scenarios
PubUnavailablePodLabelPrefix = "unavailable-pod.kruise.io"
