### PR TITLE
fix bug: allow optional filed maxunavilable to be nil in ads, and set default …

### DIFF
--- a/pkg/controller/daemonset/daemonset_util.go
+++ b/pkg/controller/daemonset/daemonset_util.go
@@ -254,7 +254,10 @@ func unavailableCount(ds *appsv1alpha1.DaemonSet, numberToSchedule int) (int, er
 	}
 	r := ds.Spec.UpdateStrategy.RollingUpdate
 	if r == nil {
-		return 0, nil
+		return 1, nil
+	}
+	if r.MaxUnavailable == nil {
+		return 1, nil
 	}
 	return intstrutil.GetScaledValueFromIntOrPercent(r.MaxUnavailable, numberToSchedule, true)
 }

--- a/pkg/controller/daemonset/daemonset_util.go
+++ b/pkg/controller/daemonset/daemonset_util.go
@@ -254,10 +254,10 @@ func unavailableCount(ds *appsv1alpha1.DaemonSet, numberToSchedule int) (int, er
 	}
 	r := ds.Spec.UpdateStrategy.RollingUpdate
 	if r == nil {
-		return 1, nil
+		return 0, nil
 	}
 	if r.MaxUnavailable == nil {
-		return 1, nil
+		return 0, nil
 	}
 	return intstrutil.GetScaledValueFromIntOrPercent(r.MaxUnavailable, numberToSchedule, true)
 }


### PR DESCRIPTION
fix bug: allow optional filed max unavilable in ads, and set default value 1

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

1. allow optional filed max unavilable to be nil in ads
2. set max unavilable default value to 1

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #1006

### Ⅲ. Describe how to verify it
update ads with nil MaxUnavailable.

### Ⅳ. Special notes for reviews

