### PR TITLE
fix ejob nil pointer bug

### DIFF
--- a/apis/apps/v1alpha1/ephemeraljob_types.go
+++ b/apis/apps/v1alpha1/ephemeraljob_types.go
@@ -37,7 +37,7 @@ type EphemeralJobSpec struct {
 
 	// Replicas indicates a part of the quantity from matched pods by selector.
 	// Usually it is used for gray scale working.
-	// if Replicas exceeded the matched number by selector, replicas will not work.
+	// if Replicas exceeded the matched number by selector or not be set, replicas will not work.
 	Replicas *int32 `json:"replicas,omitempty"`
 
 	// Parallelism specifies the maximum desired number of pods which matches running ephemeral containers.

--- a/config/crd/bases/apps.kruise.io_ephemeraljobs.yaml
+++ b/config/crd/bases/apps.kruise.io_ephemeraljobs.yaml
@@ -88,8 +88,8 @@ spec:
               replicas:
                 description: Replicas indicates a part of the quantity from matched
                   pods by selector. Usually it is used for gray scale working. if
-                  Replicas exceeded the matched number by selector, replicas will
-                  not work.
+                  Replicas exceeded the matched number by selector or not be set,
+                  replicas will not work.
                 format: int32
                 type: integer
               selector:


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

fix ejob nil pointer. 

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

ejob controller will not panic if `ejob.spec.replicas` not set.

```
E0706 15:49:38.652110 655 runtime.go:78] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference) goroutine 1837 [running]: k8s.io/apimachinery/pkg/util/runtime.logPanic({0x1a206c0, 0x2e57b80}) /home/admin/204_20220705195047156_295115616_code/kruise/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:74 +0x85 k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0xc0262d7fe0}) /home/admin/204_20220705195047156_295115616_code/kruise/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:48 +0x75 panic({0x1a206c0, 0x2e57b80}) /usr/local/go/src/runtime/panic.go:1038 +0x215 github.com/openkruise/kruise/pkg/controller/ephemeraljob.(*ReconcileEphemeralJob).filterPods(0xc0160c2e40, 0xc01f1e5880) /home/admin/204_20220705195047156_295115616_code/kruise/pkg/controller/ephemeraljob/ephemeraljob_controller.go:258 +0x31e
```



### Ⅳ. Special notes for reviews

