### PR TITLE
Fix go get in Makefile with go 1.18

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ endif
 
 KUSTOMIZE = $(shell pwd)/bin/kustomize
 kustomize: ## Download kustomize locally if necessary.
-	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v3@v3.8.7)
+	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v4@v4.5.5)
 
 GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
 golangci-lint: ## Download golangci-lint locally if necessary.
@@ -110,7 +110,7 @@ TMP_DIR=$$(mktemp -d) ;\
 cd $$TMP_DIR ;\
 go mod init tmp ;\
 echo "Downloading $(2)" ;\
-GOBIN=$(PROJECT_DIR)/bin go get $(2) ;\
+GOBIN=$(PROJECT_DIR)/bin go install $(2) ;\
 rm -rf $$TMP_DIR ;\
 }
 endef


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
From the Go 1.18 [release notes](https://tip.golang.org/doc/go1.18), we know that the `go get -d` is enabled by default,
then the target package binary will not install.

So this PR fix it to work well both below or above go 1.18 by using `go install` instead of `go get`.

### Ⅱ. Does this pull request fix one issue?
fixes #1035

### Ⅲ. Describe how to verify it
Change to defferent go version, like go 1.17 and go 1.18, `make manifests` will both work ok.

### Ⅳ. Special notes for reviews
Updated `kustomize` version to make the `go install` work ok on go 1.18.