### PR TITLE
Fix expectedUpdatedReplicas logic when CloneSet rolling back

### DIFF
--- a/pkg/controller/cloneset/cloneset_status.go
+++ b/pkg/controller/cloneset/cloneset_status.go
@@ -105,11 +105,7 @@ func (r *realStatusUpdater) calculateStatus(cs *appsv1alpha1.CloneSet, newStatus
 		newStatus.CurrentRevision = newStatus.UpdateRevision
 	}
 
-	if newStatus.UpdateRevision == newStatus.CurrentRevision {
-		newStatus.ExpectedUpdatedReplicas = *cs.Spec.Replicas
-	} else {
-		if partition, err := util.CalculatePartitionReplicas(cs.Spec.UpdateStrategy.Partition, cs.Spec.Replicas); err == nil {
-			newStatus.ExpectedUpdatedReplicas = *cs.Spec.Replicas - int32(partition)
-		}
+	if partition, err := util.CalculatePartitionReplicas(cs.Spec.UpdateStrategy.Partition, cs.Spec.Replicas); err == nil {
+		newStatus.ExpectedUpdatedReplicas = *cs.Spec.Replicas - int32(partition)
 	}
 }


### PR DESCRIPTION
Signed-off-by: mingzhou.swx <mingzhou.swx@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
`ExpectedUpdatedReplicas` just is calculated based on `Partition`.