### PR TITLE
Remove pod name label from CRR

### DIFF
--- a/apis/apps/v1alpha1/containerrecreaterequest_types.go
+++ b/apis/apps/v1alpha1/containerrecreaterequest_types.go
@@ -22,8 +22,6 @@ import (
 )
 
 const (
-	// [Immutable] Pod name of this ContainerRecreateRequest.
-	ContainerRecreateRequestPodNameKey = "crr.apps.kruise.io/pod-name"
 	// [Immutable] Pod UID of this ContainerRecreateRequest.
 	ContainerRecreateRequestPodUIDKey = "crr.apps.kruise.io/pod-uid"
 	// [Immutable] Node name of this ContainerRecreateRequest.

--- a/pkg/controller/containerrecreaterequest/crr_event_handler.go
+++ b/pkg/controller/containerrecreaterequest/crr_event_handler.go
@@ -65,7 +65,7 @@ func (e *podEventHandler) Generic(evt event.GenericEvent, q workqueue.RateLimiti
 
 func (e *podEventHandler) handle(pod *v1.Pod, q workqueue.RateLimitingInterface) {
 	crrList := &appsv1alpha1.ContainerRecreateRequestList{}
-	err := e.List(context.TODO(), crrList, client.InNamespace(pod.Namespace), client.MatchingLabels{appsv1alpha1.ContainerRecreateRequestPodNameKey: pod.Name})
+	err := e.List(context.TODO(), crrList, client.InNamespace(pod.Namespace), client.MatchingLabels{appsv1alpha1.ContainerRecreateRequestPodUIDKey: string(pod.UID)})
 	if err != nil {
 		klog.Errorf("Failed to get CRR List for Pod %s/%s: %v", pod.Namespace, pod.Name, err)
 		return

--- a/pkg/daemon/containerrecreate/crr_daemon_util.go
+++ b/pkg/daemon/containerrecreate/crr_daemon_util.go
@@ -18,6 +18,7 @@ package containerrecreate
 
 import (
 	"encoding/json"
+	"fmt"
 	"time"
 
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
@@ -27,6 +28,11 @@ import (
 	"k8s.io/klog/v2"
 	kubeletcontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	utilpointer "k8s.io/utils/pointer"
+)
+
+const (
+	// CRRPodNameIndex is the lookup name for the most comment index function, which is to index by the crr.spec.podName field.
+	CRRPodNameIndex = "podName"
 )
 
 type crrListByPhaseAndCreated []*appsv1alpha1.ContainerRecreateRequest
@@ -187,4 +193,13 @@ func convertCRRToPod(crr *appsv1alpha1.ContainerRecreateRequest) *v1.Pod {
 	}
 
 	return pod
+}
+
+// SpecPodNameIndexFunc is a default index function that indexes based on crr.spec.podName
+func SpecPodNameIndexFunc(obj interface{}) ([]string, error) {
+	crr, ok := obj.(*appsv1alpha1.ContainerRecreateRequest)
+	if !ok {
+		return []string{""}, fmt.Errorf("object cannot be convert to CRR")
+	}
+	return []string{crr.Spec.PodName}, nil
 }

--- a/pkg/webhook/containerrecreaterequest/mutating/crr_mutating_handler.go
+++ b/pkg/webhook/containerrecreaterequest/mutating/crr_mutating_handler.go
@@ -70,9 +70,6 @@ func (h *ContainerRecreateRequestHandler) Handle(ctx context.Context, req admiss
 		if !reflect.DeepEqual(obj.Spec, oldObj.Spec) {
 			return admission.Errored(http.StatusForbidden, fmt.Errorf("spec of ContainerRecreateRequest is immutable"))
 		}
-		if obj.Labels[appsv1alpha1.ContainerRecreateRequestPodNameKey] != oldObj.Labels[appsv1alpha1.ContainerRecreateRequestPodNameKey] {
-			return admission.Errored(http.StatusForbidden, fmt.Errorf("not allowed to update immutable label %s", appsv1alpha1.ContainerRecreateRequestPodNameKey))
-		}
 		if obj.Labels[appsv1alpha1.ContainerRecreateRequestPodUIDKey] != oldObj.Labels[appsv1alpha1.ContainerRecreateRequestPodUIDKey] {
 			return admission.Errored(http.StatusForbidden, fmt.Errorf("not allowed to update immutable label %s", appsv1alpha1.ContainerRecreateRequestPodUIDKey))
 		}
@@ -96,7 +93,6 @@ func (h *ContainerRecreateRequestHandler) Handle(ctx context.Context, req admiss
 	if obj.Spec.Strategy == nil {
 		obj.Spec.Strategy = &appsv1alpha1.ContainerRecreateRequestStrategy{}
 	}
-	obj.Labels[appsv1alpha1.ContainerRecreateRequestPodNameKey] = obj.Spec.PodName
 	obj.Labels[appsv1alpha1.ContainerRecreateRequestActiveKey] = "true"
 	if len(obj.Spec.Containers) == 0 {
 		return admission.Errored(http.StatusBadRequest, fmt.Errorf("containers list can not be null"))


### PR DESCRIPTION
Signed-off-by: mingzhou.swx <mingzhou.swx@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
If pod name is more than 63 chars, the CRR creation will fail due to its pod name label. Hence, we remove this label from CRR.


