### PR TITLE
Add job sidecar terminator controller

### DIFF
--- a/apis/apps/v1alpha1/well_known_labels.go
+++ b/apis/apps/v1alpha1/well_known_labels.go
@@ -16,3 +16,15 @@ const (
 	// ImagePreDownloadIgnoredKey indicates the images of this revision have been ignored to pre-download
 	ImagePreDownloadIgnoredKey = "apps.kruise.io/image-predownload-ignored"
 )
+
+// Sidecar container environment variable definitions which are used to enable SidecarTerminator to take effect on the sidecar container.
+const (
+	// KruiseTerminateSidecarEnv is an env name, which represents a switch to enable sidecar terminator.
+	// The corresponding value is "true", which means apply a crr to kill sidecar using kruise-daemon.
+	KruiseTerminateSidecarEnv = "KRUISE_TERMINATE_SIDECAR_WHEN_JOB_EXIT"
+
+	// KruiseTerminateSidecarWithImageEnv is an env name, which refers to an image that will replace the original image
+	// using in-place update strategy to kill sidecar. This image must be given if you want to use in-place update
+	// strategy to terminate sidecar containers.
+	KruiseTerminateSidecarWithImageEnv = "KRUISE_TERMINATE_SIDECAR_WHEN_JOB_EXIT_WITH_IMAGE"
+)

--- a/pkg/controller/controllers.go
+++ b/pkg/controller/controllers.go
@@ -33,6 +33,7 @@ import (
 	"github.com/openkruise/kruise/pkg/controller/podunavailablebudget"
 	"github.com/openkruise/kruise/pkg/controller/resourcedistribution"
 	"github.com/openkruise/kruise/pkg/controller/sidecarset"
+	"github.com/openkruise/kruise/pkg/controller/sidecarterminator"
 	"github.com/openkruise/kruise/pkg/controller/statefulset"
 	"github.com/openkruise/kruise/pkg/controller/uniteddeployment"
 	"github.com/openkruise/kruise/pkg/controller/workloadspread"
@@ -61,6 +62,7 @@ func init() {
 	controllerAddFuncs = append(controllerAddFuncs, ephemeraljob.Add)
 	controllerAddFuncs = append(controllerAddFuncs, containerlauchpriority.Add)
 	controllerAddFuncs = append(controllerAddFuncs, persistentpodstate.Add)
+	controllerAddFuncs = append(controllerAddFuncs, sidecarterminator.Add)
 	controllerAddFuncs = append(controllerAddFuncs, podprobemarker.Add)
 	controllerAddFuncs = append(controllerAddFuncs, nodepodprobe.Add)
 }

--- a/pkg/controller/sidecarterminator/inplace_update_action.go
+++ b/pkg/controller/sidecarterminator/inplace_update_action.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2023 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sidecarterminator
+
+import (
+	"context"
+
+	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/klog/v2"
+)
+
+func (r *ReconcileSidecarTerminator) executeInPlaceUpdateAction(originalPod *corev1.Pod, sidecars sets.String) error {
+	uncompletedSidecars := filterUncompletedSidecars(originalPod, sidecars)
+	if uncompletedSidecars.Len() == 0 {
+		return nil
+	}
+
+	var changed bool
+	var pod *corev1.Pod
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		pod = &corev1.Pod{}
+		getErr := r.Client.Get(context.TODO(), types.NamespacedName{Name: originalPod.Name, Namespace: originalPod.Namespace}, pod)
+		if getErr != nil {
+			if errors.IsNotFound(getErr) {
+				return nil
+			}
+			return getErr
+		}
+
+		changed, pod = updateSidecarsForInPlaceUpdate(pod, uncompletedSidecars)
+		if !changed || pod == nil {
+			return nil
+		}
+
+		return r.Update(context.TODO(), pod)
+	})
+
+	if err != nil {
+		klog.Errorf("SidecarTerminator -- Error occurred when inPlace update pod(%v/%v), error %v",
+			originalPod.Namespace, originalPod.Name, err)
+	} else {
+		klog.V(3).Infof("SidecarTerminator -- InPlace update pod(%v/%v) successfully",
+			originalPod.Namespace, originalPod.Name)
+
+		r.recorder.Eventf(originalPod, corev1.EventTypeNormal, "SidecarTerminator",
+			"Kruise SidecarTerminator is trying to terminate sidecar %v using in-place update", uncompletedSidecars.List())
+	}
+
+	return err
+}
+
+// updateSidecarsForInPlaceUpdate replace sidecar image with KruiseTerminateSidecarWithImageEnv
+func updateSidecarsForInPlaceUpdate(pod *corev1.Pod, sidecars sets.String) (bool, *corev1.Pod) {
+	changed := false
+	for i := range pod.Spec.Containers {
+		container := &pod.Spec.Containers[i]
+		if !sidecars.Has(container.Name) {
+			continue
+		}
+		changed = true
+		container.Image = getImageFromEnv(container)
+	}
+	return changed, pod
+}
+
+// getImageFromEnv return the image set in sidecar env
+func getImageFromEnv(container *corev1.Container) string {
+	for i := range container.Env {
+		if container.Env[i].Name == appsv1alpha1.KruiseTerminateSidecarWithImageEnv {
+			return container.Env[i].Value
+		}
+	}
+	return ""
+}

--- a/pkg/controller/sidecarterminator/kill_container_action.go
+++ b/pkg/controller/sidecarterminator/kill_container_action.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2023 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sidecarterminator
+
+import (
+	"context"
+	"fmt"
+
+	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func (r *ReconcileSidecarTerminator) executeKillContainerAction(pod *corev1.Pod, sidecars sets.String) error {
+	uncompletedSidecars := filterUncompletedSidecars(pod, sidecars)
+	if uncompletedSidecars.Len() == 0 {
+		return nil
+	}
+
+	// if the CRR has been created, this func will do nothing
+	existingCRR := &appsv1alpha1.ContainerRecreateRequest{}
+	err := r.Get(context.TODO(), types.NamespacedName{Namespace: pod.Namespace, Name: getCRRName(pod)}, existingCRR)
+	if err == nil {
+		klog.V(3).Infof("SidecarTerminator -- CRR(%s/%s) exists, waiting for this CRR to complete", existingCRR.Namespace, existingCRR.Name)
+		return nil
+	} else if client.IgnoreNotFound(err) != nil {
+		klog.V(3).Infof("SidecarTerminator -- Error occurred when try to get CRR(%s/%s), error: %v", existingCRR.Namespace, existingCRR.Name, err)
+		return err
+	}
+
+	var sidecarContainers []appsv1alpha1.ContainerRecreateRequestContainer
+	for _, name := range uncompletedSidecars.List() {
+		sidecarContainers = append(sidecarContainers, appsv1alpha1.ContainerRecreateRequestContainer{
+			Name: name,
+		})
+	}
+
+	crr := &appsv1alpha1.ContainerRecreateRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: pod.Namespace,
+			Name:      getCRRName(pod),
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(pod, pod.GroupVersionKind()),
+			},
+		},
+		Spec: appsv1alpha1.ContainerRecreateRequestSpec{
+			PodName:    pod.Name,
+			Containers: sidecarContainers,
+			Strategy: &appsv1alpha1.ContainerRecreateRequestStrategy{
+				FailurePolicy: appsv1alpha1.ContainerRecreateRequestFailurePolicyIgnore,
+			},
+		},
+	}
+
+	err = r.Create(context.TODO(), crr)
+	if err != nil {
+		klog.V(3).Infof("SidecarTerminator -- Error occurred when creating CRR(%v/%v), error %v", crr.Namespace, crr.Name, err)
+	} else {
+		klog.V(3).Infof("SidecarTerminator -- Creating CRR(%v/%v) successfully", crr.Namespace, crr.Name)
+
+		r.recorder.Eventf(pod, corev1.EventTypeNormal, "SidecarTerminator",
+			"Kruise SidecarTerminator is trying to terminate sidecar %v using crr", uncompletedSidecars.List())
+	}
+
+	return err
+}
+
+func filterUncompletedSidecars(pod *corev1.Pod, sidecars sets.String) sets.String {
+	uncompletedSidecars := sets.NewString(sidecars.List()...)
+	for i := range pod.Status.ContainerStatuses {
+		status := &pod.Status.ContainerStatuses[i]
+		if sidecars.Has(status.Name) && status.State.Terminated != nil {
+			uncompletedSidecars.Delete(status.Name)
+		}
+	}
+	return uncompletedSidecars
+}
+
+func getCRRName(pod *corev1.Pod) string {
+	return fmt.Sprintf("sidecar-termination-%v", pod.UID)
+}

--- a/pkg/controller/sidecarterminator/sidecar_terminator_controller.go
+++ b/pkg/controller/sidecarterminator/sidecar_terminator_controller.go
@@ -1,0 +1,210 @@
+/*
+Copyright 2023 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sidecarterminator
+
+import (
+	"context"
+	"flag"
+	"strings"
+	"time"
+
+	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
+	"github.com/openkruise/kruise/pkg/features"
+	utilclient "github.com/openkruise/kruise/pkg/util/client"
+	utilfeature "github.com/openkruise/kruise/pkg/util/feature"
+	"github.com/openkruise/kruise/pkg/util/ratelimiter"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+func init() {
+	flag.IntVar(&concurrentReconciles, "sidecarterminator-workers", concurrentReconciles, "Max concurrent workers for SidecarTerminator controller.")
+}
+
+var (
+	concurrentReconciles = 3
+)
+
+/**
+* USER ACTION REQUIRED: This is a scaffold file intended for the user to modify with their own Controller
+* business logic.  Delete these comments after modifying this file.*
+ */
+
+// Add creates a new SidecarTerminator Controller and adds it to the Manager with default RBAC. The Manager will set fields on the Controller
+// and Start it when the Manager is Started.
+func Add(mgr manager.Manager) error {
+	if !utilfeature.DefaultFeatureGate.Enabled(features.SidecarTerminator) {
+		return nil
+	}
+	return add(mgr, newReconciler(mgr))
+}
+
+// newReconciler returns a new reconcile.Reconciler
+func newReconciler(mgr manager.Manager) reconcile.Reconciler {
+	cli := utilclient.NewClientFromManager(mgr, "sidecarterminator-controller")
+	recorder := mgr.GetEventRecorderFor("sidecarterminator-controller")
+	return &ReconcileSidecarTerminator{
+		Client:   cli,
+		recorder: recorder,
+		scheme:   mgr.GetScheme(),
+	}
+}
+
+// add adds a new Controller to mgr with r as the reconcile.Reconciler
+func add(mgr manager.Manager, r reconcile.Reconciler) error {
+	// Create a new controller
+	c, err := controller.New("sidecarterminator-controller", mgr, controller.Options{
+		Reconciler:              r,
+		MaxConcurrentReconciles: concurrentReconciles,
+		RateLimiter:             ratelimiter.DefaultControllerRateLimiter()})
+	if err != nil {
+		return err
+	}
+
+	// Watch for changes to Pod
+	if err = c.Watch(&source.Kind{Type: &corev1.Pod{}}, &enqueueRequestForPod{}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var _ reconcile.Reconciler = &ReconcileSidecarTerminator{}
+
+// ReconcileSidecarTerminator reconciles a SidecarTerminator object
+type ReconcileSidecarTerminator struct {
+	client.Client
+	recorder record.EventRecorder
+	scheme   *runtime.Scheme
+}
+
+// Reconcile get the pod whose sidecar containers should be stopped, and stop them.
+func (r *ReconcileSidecarTerminator) Reconcile(_ context.Context, request reconcile.Request) (reconcile.Result, error) {
+	pod := &corev1.Pod{}
+	err := r.Get(context.TODO(), request.NamespacedName, pod)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Object not found, return.  Created objects are automatically garbage collected.
+			// For additional cleanup logic use finalizers.
+			return reconcile.Result{}, nil
+		}
+		// Error reading the object - requeue the request.
+		return reconcile.Result{}, err
+	}
+
+	start := time.Now()
+	klog.V(3).Infof("SidecarTerminator -- begin to process pod %v for reconcile", request.NamespacedName)
+	defer func() {
+		klog.V(3).Infof("SidecarTerminator -- process pod %v done, cost: %v", request.NamespacedName, time.Since(start))
+	}()
+
+	return r.doReconcile(pod)
+}
+
+func (r *ReconcileSidecarTerminator) doReconcile(pod *corev1.Pod) (reconcile.Result, error) {
+	if !isInterestingPod(pod) {
+		return reconcile.Result{}, nil
+	}
+
+	if containersCompleted(pod, getSidecar(pod)) {
+		klog.V(3).Infof("SidecarTerminator -- all sidecars of pod(%v/%v) have been completed, no need to process", pod.Namespace, pod.Name)
+		return reconcile.Result{}, nil
+	}
+
+	if pod.Spec.RestartPolicy == corev1.RestartPolicyOnFailure && !containersSucceeded(pod, getMain(pod)) {
+		klog.V(3).Infof("SidecarTerminator -- pod(%v/%v) is trying to restart, no need to process", pod.Namespace, pod.Name)
+		return reconcile.Result{}, nil
+	}
+
+	sidecarNeedToExecuteKillContainer, sidecarNeedToExecuteInPlaceUpdate, err := r.groupSidecars(pod)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if err := r.executeInPlaceUpdateAction(pod, sidecarNeedToExecuteInPlaceUpdate); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if err := r.executeKillContainerAction(pod, sidecarNeedToExecuteKillContainer); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (r *ReconcileSidecarTerminator) groupSidecars(pod *corev1.Pod) (sets.String, sets.String, error) {
+	runningOnVK, err := IsPodRunningOnVirtualKubelet(pod, r.Client)
+	if err != nil {
+		return nil, nil, client.IgnoreNotFound(err)
+	}
+
+	inPlaceUpdate := sets.NewString()
+	killContainer := sets.NewString()
+	for i := range pod.Spec.Containers {
+		container := &pod.Spec.Containers[i]
+		for j := range container.Env {
+			if !runningOnVK && container.Env[j].Name == appsv1alpha1.KruiseTerminateSidecarEnv &&
+				strings.EqualFold(container.Env[j].Value, "true") {
+				killContainer.Insert(container.Name)
+				break
+			}
+			if container.Env[j].Name == appsv1alpha1.KruiseTerminateSidecarWithImageEnv &&
+				container.Env[j].Value != "" {
+				inPlaceUpdate.Insert(container.Name)
+			}
+		}
+	}
+	return killContainer, inPlaceUpdate, nil
+}
+
+func containersCompleted(pod *corev1.Pod, containers sets.String) bool {
+	if len(pod.Spec.Containers) != len(pod.Status.ContainerStatuses) {
+		return false
+	}
+
+	for i := range pod.Status.ContainerStatuses {
+		status := &pod.Status.ContainerStatuses[i]
+		if containers.Has(status.Name) && status.State.Terminated == nil {
+			return false
+		}
+	}
+	return true
+}
+
+func containersSucceeded(pod *corev1.Pod, containers sets.String) bool {
+	if len(pod.Spec.Containers) != len(pod.Status.ContainerStatuses) {
+		return false
+	}
+
+	for i := range pod.Status.ContainerStatuses {
+		status := &pod.Status.ContainerStatuses[i]
+		if containers.Has(status.Name) &&
+			(status.State.Terminated == nil || status.State.Terminated.ExitCode != int32(0)) {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/controller/sidecarterminator/sidecar_terminator_controller_test.go
+++ b/pkg/controller/sidecarterminator/sidecar_terminator_controller_test.go
@@ -1,0 +1,587 @@
+/*
+Copyright 2023 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sidecarterminator
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	ExitQuicklyImage = "exit-quickly:latest"
+)
+
+var (
+	scheme                       *runtime.Scheme
+	succeededMainContainerStatus = corev1.ContainerStatus{
+		Name: "main",
+		State: corev1.ContainerState{
+			Terminated: &corev1.ContainerStateTerminated{
+				ExitCode: int32(0),
+			},
+		},
+	}
+
+	failedMainContainerStatus = corev1.ContainerStatus{
+		Name: "main",
+		State: corev1.ContainerState{
+			Terminated: &corev1.ContainerStateTerminated{
+				ExitCode: int32(137),
+			},
+		},
+	}
+
+	uncompletedMainContainerStatus = corev1.ContainerStatus{
+		Name: "main",
+		State: corev1.ContainerState{
+			Terminated: nil,
+		},
+	}
+
+	completedSidecarContainerStatus = corev1.ContainerStatus{
+		Name: "sidecar",
+		State: corev1.ContainerState{
+			Terminated: &corev1.ContainerStateTerminated{
+				ExitCode: int32(0),
+			},
+		},
+	}
+
+	uncompletedSidecarContainerStatus = corev1.ContainerStatus{
+		Name: "sidecar",
+		State: corev1.ContainerState{
+			Terminated: nil,
+		},
+	}
+
+	podDemo = &corev1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: corev1.SchemeGroupVersion.String(),
+			Kind:       "Pod",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "test-sidecar-terminator",
+			UID:       "87076677",
+			Name:      "job-generate-rand-str",
+		},
+		Spec: corev1.PodSpec{
+			NodeName:      "normal-node",
+			RestartPolicy: corev1.RestartPolicyNever,
+			Containers: []corev1.Container{
+				{
+					Name:  "main",
+					Image: "main-container:latest",
+				},
+				{
+					Name:  "sidecar",
+					Image: "sidecar-container-images",
+					Env: []corev1.EnvVar{
+						{
+							Name:  appsv1alpha1.KruiseTerminateSidecarEnv,
+							Value: "true",
+						},
+						{
+							Name:  appsv1alpha1.KruiseTerminateSidecarWithImageEnv,
+							Value: ExitQuicklyImage,
+						},
+					},
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				succeededMainContainerStatus,
+				uncompletedSidecarContainerStatus,
+			},
+		},
+	}
+
+	crrDemo = &appsv1alpha1.ContainerRecreateRequest{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: appsv1alpha1.SchemeGroupVersion.String(),
+			Kind:       "ContainerRecreateRequest",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       podDemo.Namespace,
+			Name:            getCRRName(podDemo),
+			ResourceVersion: "1",
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(podDemo, podDemo.GroupVersionKind()),
+			},
+		},
+		Spec: appsv1alpha1.ContainerRecreateRequestSpec{
+			PodName: podDemo.Name,
+			Containers: []appsv1alpha1.ContainerRecreateRequestContainer{
+				{Name: "sidecar"},
+			},
+			Strategy: &appsv1alpha1.ContainerRecreateRequestStrategy{
+				FailurePolicy: appsv1alpha1.ContainerRecreateRequestFailurePolicyIgnore,
+			},
+		},
+	}
+
+	normalNode = &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "normal-node",
+		},
+	}
+	vkNode = &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "vk-node",
+			Labels: map[string]string{
+				DefaultVKLabelKey: DefaultVKLabelValue,
+			},
+		},
+		Spec: corev1.NodeSpec{
+			Taints: []corev1.Taint{
+				{
+					Effect: corev1.TaintEffectNoSchedule,
+					Key:    DefaultVKTaintKey,
+					Value:  "cloudProvider",
+				},
+			},
+		},
+	}
+)
+
+func init() {
+	scheme = runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = appsv1alpha1.AddToScheme(scheme)
+}
+
+func sidecarContainerFactory(name string, strategy string) corev1.Container {
+	return corev1.Container{
+		Name:  name,
+		Image: "sidecar-container-images",
+		Env: []corev1.EnvVar{
+			{
+				Name:  appsv1alpha1.KruiseTerminateSidecarEnv,
+				Value: strategy,
+			},
+			{
+				Name:  appsv1alpha1.KruiseTerminateSidecarWithImageEnv,
+				Value: ExitQuicklyImage,
+			},
+		},
+	}
+}
+
+func TestKruiseDaemonStrategy(t *testing.T) {
+	cases := []struct {
+		name   string
+		getIn  func() *corev1.Pod
+		getCRR func() *appsv1alpha1.ContainerRecreateRequest
+	}{
+		{
+			name: "normal pod with sidecar, restartPolicy=Never, main containers have not been completed",
+			getIn: func() *corev1.Pod {
+				podIn := podDemo.DeepCopy()
+				podIn.Status.ContainerStatuses[0] = uncompletedMainContainerStatus
+				return podIn
+			},
+			getCRR: func() *appsv1alpha1.ContainerRecreateRequest {
+				return nil
+			},
+		},
+		{
+			name: "normal pod with sidecar, restartPolicy=Never, main containers failed",
+			getIn: func() *corev1.Pod {
+				podIn := podDemo.DeepCopy()
+				podIn.Status.ContainerStatuses[0] = failedMainContainerStatus
+				return podIn
+			},
+			getCRR: func() *appsv1alpha1.ContainerRecreateRequest {
+				return crrDemo.DeepCopy()
+			},
+		},
+		{
+			name: "normal pod with sidecar, restartPolicy=Never, main containers succeeded",
+			getIn: func() *corev1.Pod {
+				podIn := podDemo.DeepCopy()
+				podIn.Status.ContainerStatuses[0] = succeededMainContainerStatus
+				return podIn
+			},
+			getCRR: func() *appsv1alpha1.ContainerRecreateRequest {
+				return crrDemo.DeepCopy()
+			},
+		},
+		{
+			name: "normal pod with sidecar, restartPolicy=OnFailure, main containers have not been completed",
+			getIn: func() *corev1.Pod {
+				podIn := podDemo.DeepCopy()
+				podIn.Spec.RestartPolicy = corev1.RestartPolicyOnFailure
+				podIn.Status.ContainerStatuses[0] = uncompletedMainContainerStatus
+				return podIn
+			},
+			getCRR: func() *appsv1alpha1.ContainerRecreateRequest {
+				return nil
+			},
+		},
+		{
+			name: "normal pod with sidecar, restartPolicy=OnFailure, main containers failed",
+			getIn: func() *corev1.Pod {
+				podIn := podDemo.DeepCopy()
+				podIn.Spec.RestartPolicy = corev1.RestartPolicyOnFailure
+				podIn.Status.ContainerStatuses[0] = failedMainContainerStatus
+				return podIn
+			},
+			getCRR: func() *appsv1alpha1.ContainerRecreateRequest {
+				return nil
+			},
+		},
+		{
+			name: "normal pod with sidecar, restartPolicy=OnFailure, main containers succeeded",
+			getIn: func() *corev1.Pod {
+				podIn := podDemo.DeepCopy()
+				podIn.Spec.RestartPolicy = corev1.RestartPolicyOnFailure
+				podIn.Status.ContainerStatuses[0] = succeededMainContainerStatus
+				return podIn
+			},
+			getCRR: func() *appsv1alpha1.ContainerRecreateRequest {
+				return crrDemo.DeepCopy()
+			},
+		},
+		{
+			name: "normal pod with sidecar, restartPolicy=OnFailure, 2 succeeded main containers, 2 sidecars",
+			getIn: func() *corev1.Pod {
+				podIn := podDemo.DeepCopy()
+				podIn.Spec.Containers = []corev1.Container{
+					mainContainerFactory("main-1"),
+					mainContainerFactory("main-2"),
+					sidecarContainerFactory("sidecar-1", "true"),
+					sidecarContainerFactory("sidecar-2", "true"),
+				}
+				podIn.Spec.RestartPolicy = corev1.RestartPolicyOnFailure
+				podIn.Status.ContainerStatuses = []corev1.ContainerStatus{
+					rename(succeededMainContainerStatus.DeepCopy(), "main-1"),
+					rename(succeededMainContainerStatus.DeepCopy(), "main-2"),
+					rename(uncompletedSidecarContainerStatus.DeepCopy(), "sidecar-1"),
+					rename(uncompletedSidecarContainerStatus.DeepCopy(), "sidecar-2"),
+				}
+				return podIn
+			},
+			getCRR: func() *appsv1alpha1.ContainerRecreateRequest {
+				crr := crrDemo.DeepCopy()
+				crr.Spec.Containers = []appsv1alpha1.ContainerRecreateRequestContainer{
+					{Name: "sidecar-1"}, {Name: "sidecar-2"},
+				}
+				return crr
+			},
+		},
+		{
+			name: "normal pod with sidecar, restartPolicy=OnFailure, 2 succeeded main containers, 2 sidecars but 1 completed",
+			getIn: func() *corev1.Pod {
+				podIn := podDemo.DeepCopy()
+				podIn.Spec.Containers = []corev1.Container{
+					mainContainerFactory("main-1"),
+					mainContainerFactory("main-2"),
+					sidecarContainerFactory("sidecar-1", "true"),
+					sidecarContainerFactory("sidecar-2", "true"),
+				}
+				podIn.Spec.RestartPolicy = corev1.RestartPolicyOnFailure
+				podIn.Status.ContainerStatuses = []corev1.ContainerStatus{
+					rename(succeededMainContainerStatus.DeepCopy(), "main-1"),
+					rename(succeededMainContainerStatus.DeepCopy(), "main-2"),
+					rename(completedSidecarContainerStatus.DeepCopy(), "sidecar-1"),
+					rename(uncompletedSidecarContainerStatus.DeepCopy(), "sidecar-2"),
+				}
+				return podIn
+			},
+			getCRR: func() *appsv1alpha1.ContainerRecreateRequest {
+				crr := crrDemo.DeepCopy()
+				crr.Spec.Containers = []appsv1alpha1.ContainerRecreateRequestContainer{
+					{Name: "sidecar-2"},
+				}
+				return crr
+			},
+		},
+		{
+			name: "normal pod with sidecar, restartPolicy=OnFailure, 2 main containers but 1 uncompleted, 2 sidecars but 1 completed",
+			getIn: func() *corev1.Pod {
+				podIn := podDemo.DeepCopy()
+				podIn.Spec.Containers = []corev1.Container{
+					mainContainerFactory("main-1"),
+					mainContainerFactory("main-2"),
+					sidecarContainerFactory("sidecar-1", "true"),
+					sidecarContainerFactory("sidecar-2", "true"),
+				}
+				podIn.Spec.RestartPolicy = corev1.RestartPolicyOnFailure
+				podIn.Status.ContainerStatuses = []corev1.ContainerStatus{
+					rename(succeededMainContainerStatus.DeepCopy(), "main-1"),
+					rename(uncompletedMainContainerStatus.DeepCopy(), "main-2"),
+					rename(completedSidecarContainerStatus.DeepCopy(), "sidecar-1"),
+					rename(uncompletedSidecarContainerStatus.DeepCopy(), "sidecar-2"),
+				}
+				return podIn
+			},
+			getCRR: func() *appsv1alpha1.ContainerRecreateRequest {
+				return nil
+			},
+		},
+	}
+
+	for _, cs := range cases {
+		t.Run(cs.name, func(t *testing.T) {
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+				WithObjects(normalNode, vkNode, cs.getIn()).Build()
+			fakeRecord := record.NewFakeRecorder(100)
+			r := ReconcileSidecarTerminator{
+				Client:   fakeClient,
+				recorder: fakeRecord,
+			}
+
+			_, err := r.Reconcile(context.Background(), reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      podDemo.Name,
+					Namespace: podDemo.Namespace,
+				},
+			})
+			if err != nil {
+				t.Fatalf("Failed to reconcile, error: %v", err)
+			}
+
+			realCRR := &appsv1alpha1.ContainerRecreateRequest{}
+			err = fakeClient.Get(context.TODO(), types.NamespacedName{
+				Name:      getCRRName(podDemo),
+				Namespace: podDemo.Namespace,
+			}, realCRR)
+			expectCRR := cs.getCRR()
+
+			realBy, _ := json.Marshal(realCRR)
+			expectBy, _ := json.Marshal(expectCRR)
+
+			if !(expectCRR == nil && errors.IsNotFound(err) || reflect.DeepEqual(realBy, expectBy)) {
+				t.Fatal("Get unexpected CRR")
+			}
+		})
+	}
+}
+
+func TestInPlaceUpdateStrategy(t *testing.T) {
+	cases := []struct {
+		name           string
+		getIn          func() *corev1.Pod
+		expectedNumber int
+	}{
+		{
+			name: "vk pod with sidecar, restartPolicy=Never, main containers have not been completed",
+			getIn: func() *corev1.Pod {
+				podIn := podDemo.DeepCopy()
+				podIn.Spec.NodeName = vkNode.Name
+				podIn.Status.ContainerStatuses[0] = uncompletedMainContainerStatus
+				return podIn
+			},
+			expectedNumber: 0,
+		},
+		{
+			name: "vk pod with sidecar, restartPolicy=Never, main containers failed, Strategy=InPlaceUpdateOnly",
+			getIn: func() *corev1.Pod {
+				podIn := podDemo.DeepCopy()
+				podIn.Status.ContainerStatuses[0] = failedMainContainerStatus
+				podIn.Spec.Containers[1].Env = []corev1.EnvVar{
+					{Name: appsv1alpha1.KruiseTerminateSidecarWithImageEnv, Value: ExitQuicklyImage},
+				}
+				return podIn
+			},
+			expectedNumber: 1,
+		},
+		{
+			name: "vk pod with sidecar, restartPolicy=Never, main containers succeeded",
+			getIn: func() *corev1.Pod {
+				podIn := podDemo.DeepCopy()
+				podIn.Spec.NodeName = vkNode.Name
+				podIn.Status.ContainerStatuses[0] = succeededMainContainerStatus
+				return podIn
+			},
+			expectedNumber: 1,
+		},
+		{
+			name: "vk pod with sidecar, restartPolicy=OnFailure, main containers have not been completed",
+			getIn: func() *corev1.Pod {
+				podIn := podDemo.DeepCopy()
+				podIn.Spec.NodeName = vkNode.Name
+				podIn.Spec.RestartPolicy = corev1.RestartPolicyOnFailure
+				podIn.Status.ContainerStatuses[0] = uncompletedMainContainerStatus
+				return podIn
+			},
+			expectedNumber: 0,
+		},
+		{
+			name: "vk pod with sidecar, restartPolicy=OnFailure, main containers failed",
+			getIn: func() *corev1.Pod {
+				podIn := podDemo.DeepCopy()
+				podIn.Spec.NodeName = vkNode.Name
+				podIn.Spec.RestartPolicy = corev1.RestartPolicyOnFailure
+				podIn.Status.ContainerStatuses[0] = failedMainContainerStatus
+				return podIn
+			},
+			expectedNumber: 0,
+		},
+		{
+			name: "vk pod with sidecar, restartPolicy=OnFailure, main containers succeeded",
+			getIn: func() *corev1.Pod {
+				podIn := podDemo.DeepCopy()
+				podIn.Spec.NodeName = vkNode.Name
+				podIn.Spec.RestartPolicy = corev1.RestartPolicyOnFailure
+				podIn.Status.ContainerStatuses[0] = succeededMainContainerStatus
+				return podIn
+			},
+			expectedNumber: 1,
+		},
+		{
+			name: "vk pod with sidecar, restartPolicy=OnFailure, 2 succeeded main containers, 2 sidecars",
+			getIn: func() *corev1.Pod {
+				podIn := podDemo.DeepCopy()
+				podIn.Spec.NodeName = vkNode.Name
+				podIn.Spec.Containers = []corev1.Container{
+					mainContainerFactory("main-1"),
+					mainContainerFactory("main-2"),
+					sidecarContainerFactory("sidecar-1", "true"),
+					sidecarContainerFactory("sidecar-2", "true"),
+				}
+				podIn.Spec.RestartPolicy = corev1.RestartPolicyOnFailure
+				podIn.Status.ContainerStatuses = []corev1.ContainerStatus{
+					rename(succeededMainContainerStatus.DeepCopy(), "main-1"),
+					rename(succeededMainContainerStatus.DeepCopy(), "main-2"),
+					rename(uncompletedSidecarContainerStatus.DeepCopy(), "sidecar-1"),
+					rename(uncompletedSidecarContainerStatus.DeepCopy(), "sidecar-2"),
+				}
+				return podIn
+			},
+			expectedNumber: 2,
+		},
+		{
+			name: "vk pod with sidecar, restartPolicy=OnFailure, 2 succeeded main containers, 2 sidecars but 1 completed",
+			getIn: func() *corev1.Pod {
+				podIn := podDemo.DeepCopy()
+				podIn.Spec.NodeName = vkNode.Name
+				podIn.Spec.Containers = []corev1.Container{
+					mainContainerFactory("main-1"),
+					mainContainerFactory("main-2"),
+					sidecarContainerFactory("sidecar-1", "true"),
+					sidecarContainerFactory("sidecar-2", "true"),
+				}
+				podIn.Spec.RestartPolicy = corev1.RestartPolicyOnFailure
+				podIn.Status.ContainerStatuses = []corev1.ContainerStatus{
+					rename(succeededMainContainerStatus.DeepCopy(), "main-1"),
+					rename(succeededMainContainerStatus.DeepCopy(), "main-2"),
+					rename(completedSidecarContainerStatus.DeepCopy(), "sidecar-1"),
+					rename(uncompletedSidecarContainerStatus.DeepCopy(), "sidecar-2"),
+				}
+				return podIn
+			},
+			expectedNumber: 1,
+		},
+		{
+			name: "vk pod with sidecar, restartPolicy=OnFailure, 2 main containers but 1 uncompleted, 2 sidecars but 1 completed",
+			getIn: func() *corev1.Pod {
+				podIn := podDemo.DeepCopy()
+				podIn.Spec.Containers = []corev1.Container{
+					mainContainerFactory("main-1"),
+					mainContainerFactory("main-2"),
+					sidecarContainerFactory("sidecar-1", "true"),
+					sidecarContainerFactory("sidecar-2", "true"),
+				}
+				podIn.Spec.RestartPolicy = corev1.RestartPolicyOnFailure
+				podIn.Status.ContainerStatuses = []corev1.ContainerStatus{
+					rename(succeededMainContainerStatus.DeepCopy(), "main-1"),
+					rename(uncompletedMainContainerStatus.DeepCopy(), "main-2"),
+					rename(completedSidecarContainerStatus.DeepCopy(), "sidecar-1"),
+					rename(uncompletedSidecarContainerStatus.DeepCopy(), "sidecar-2"),
+				}
+				return podIn
+			},
+			expectedNumber: 0,
+		},
+	}
+
+	for _, cs := range cases {
+		t.Run(cs.name, func(t *testing.T) {
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+				WithObjects(normalNode, vkNode, cs.getIn()).Build()
+			fakeRecord := record.NewFakeRecorder(100)
+			r := ReconcileSidecarTerminator{
+				Client:   fakeClient,
+				recorder: fakeRecord,
+			}
+
+			_, err := r.Reconcile(context.Background(), reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      podDemo.Name,
+					Namespace: podDemo.Namespace,
+				},
+			})
+			if err != nil {
+				t.Fatalf("Failed to reconcile, error: %v", err)
+			}
+
+			pod := &corev1.Pod{}
+			if err = fakeClient.Get(context.TODO(), types.NamespacedName{
+				Name:      podDemo.Name,
+				Namespace: podDemo.Namespace,
+			}, pod); err != nil {
+				t.Fatalf("Failed to get pod, error %v", err)
+			}
+
+			actualNumber := 0
+			for i := range pod.Spec.Containers {
+				if pod.Spec.Containers[i].Image == ExitQuicklyImage {
+					actualNumber++
+				}
+			}
+
+			if cs.expectedNumber != actualNumber {
+				t.Fatalf("get unexpected new sidecar image number, expected %v, actual %v", cs.expectedNumber, actualNumber)
+			}
+
+			crr := &appsv1alpha1.ContainerRecreateRequest{}
+			err = fakeClient.Get(context.TODO(), types.NamespacedName{
+				Name:      getCRRName(podDemo),
+				Namespace: podDemo.Namespace,
+			}, crr)
+			if err == nil || !errors.IsNotFound(err) {
+				t.Fatal("Get unexpected CRR")
+			}
+		})
+	}
+}
+
+func mainContainerFactory(name string) corev1.Container {
+	return corev1.Container{
+		Name:  name,
+		Image: "main-container:latest",
+	}
+}
+
+func rename(status *corev1.ContainerStatus, name string) corev1.ContainerStatus {
+	status.Name = name
+	return *status
+}

--- a/pkg/controller/sidecarterminator/sidecar_terminator_pod_event_handler.go
+++ b/pkg/controller/sidecarterminator/sidecar_terminator_pod_event_handler.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2023 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sidecarterminator
+
+import (
+	"strings"
+
+	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var _ handler.EventHandler = &enqueueRequestForPod{}
+
+type enqueueRequestForPod struct{}
+
+func (p *enqueueRequestForPod) Delete(evt event.DeleteEvent, q workqueue.RateLimitingInterface)   {}
+func (p *enqueueRequestForPod) Generic(evt event.GenericEvent, q workqueue.RateLimitingInterface) {}
+func (p *enqueueRequestForPod) Create(evt event.CreateEvent, q workqueue.RateLimitingInterface) {
+	p.handlePodCreate(q, evt.Object)
+}
+func (p *enqueueRequestForPod) Update(evt event.UpdateEvent, q workqueue.RateLimitingInterface) {
+	p.handlePodUpdate(q, evt.ObjectOld, evt.ObjectNew)
+}
+
+func (p *enqueueRequestForPod) handlePodCreate(q workqueue.RateLimitingInterface, obj runtime.Object) {
+	pod := obj.(*corev1.Pod)
+	if isInterestingPod(pod) {
+		q.Add(reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: pod.Namespace,
+				Name:      pod.Name,
+			},
+		})
+	}
+}
+
+func (p *enqueueRequestForPod) handlePodUpdate(q workqueue.RateLimitingInterface, old, cur runtime.Object) {
+	newPod := cur.(*corev1.Pod)
+	oldPod := old.(*corev1.Pod)
+	if oldPod.ResourceVersion == newPod.ResourceVersion {
+		return
+	}
+
+	if isInterestingPod(newPod) {
+		q.Add(reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: newPod.Namespace,
+				Name:      newPod.Name,
+			},
+		})
+	}
+}
+
+func isInterestingPod(pod *corev1.Pod) bool {
+	if pod.DeletionTimestamp != nil ||
+		pod.Status.Phase != corev1.PodRunning ||
+		pod.Spec.RestartPolicy == corev1.RestartPolicyAlways {
+		return false
+	}
+
+	if containersCompleted(pod, getSidecar(pod)) {
+		return false
+	}
+
+	switch pod.Spec.RestartPolicy {
+	case corev1.RestartPolicyNever:
+		return containersCompleted(pod, getMain(pod))
+	case corev1.RestartPolicyOnFailure:
+		return containersSucceeded(pod, getMain(pod))
+	}
+	return false
+}
+
+func getMain(pod *corev1.Pod) sets.String {
+	mainNames := sets.NewString()
+	for i := range pod.Spec.Containers {
+		if !isSidecar(pod.Spec.Containers[i]) {
+			mainNames.Insert(pod.Spec.Containers[i].Name)
+		}
+	}
+	return mainNames
+}
+
+func getSidecar(pod *corev1.Pod) sets.String {
+	sidecarNames := sets.NewString()
+	for i := range pod.Spec.Containers {
+		if isSidecar(pod.Spec.Containers[i]) {
+			sidecarNames.Insert(pod.Spec.Containers[i].Name)
+		}
+	}
+	return sidecarNames
+}
+
+func isSidecar(container corev1.Container) bool {
+	for _, env := range container.Env {
+		if env.Name == appsv1alpha1.KruiseTerminateSidecarEnv && strings.EqualFold(env.Value, "true") {
+			return true
+		} else if env.Name == appsv1alpha1.KruiseTerminateSidecarWithImageEnv && env.Value != "" {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/controller/sidecarterminator/sidecar_terminator_pod_event_handler_test.go
+++ b/pkg/controller/sidecarterminator/sidecar_terminator_pod_event_handler_test.go
@@ -1,0 +1,313 @@
+/*
+Copyright 2023 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sidecarterminator
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+func TestEnqueueRequestForPodUpdate(t *testing.T) {
+	oldPodDemo := podDemo.DeepCopy()
+	oldPodDemo.SetResourceVersion("1")
+	newPodDemo := podDemo.DeepCopy()
+	newPodDemo.SetResourceVersion("2")
+
+	cases := []struct {
+		name      string
+		getOldPod func() *corev1.Pod
+		getNewPod func() *corev1.Pod
+		expectLen int
+	}{
+		{
+			name: "Pod not running",
+			getOldPod: func() *corev1.Pod {
+				oldPod := oldPodDemo.DeepCopy()
+				return oldPod
+			},
+			getNewPod: func() *corev1.Pod {
+				newPod := newPodDemo.DeepCopy()
+				newPod.Status.Phase = corev1.PodPending
+				return newPod
+			},
+			expectLen: 0,
+		},
+		{
+			name: "Pod restartPolicy=Always",
+			getOldPod: func() *corev1.Pod {
+				oldPod := oldPodDemo.DeepCopy()
+				return oldPod
+			},
+			getNewPod: func() *corev1.Pod {
+				newPod := newPodDemo.DeepCopy()
+				newPod.Spec.RestartPolicy = corev1.RestartPolicyAlways
+				return newPod
+			},
+			expectLen: 0,
+		},
+		{
+			name: "Pod, main container uncompleted -> completed, sidecar container uncompleted",
+			getOldPod: func() *corev1.Pod {
+				oldPod := oldPodDemo.DeepCopy()
+				oldPod.Status.ContainerStatuses = []corev1.ContainerStatus{
+					uncompletedMainContainerStatus,
+					uncompletedSidecarContainerStatus,
+				}
+				return oldPod
+			},
+			getNewPod: func() *corev1.Pod {
+				newPod := newPodDemo.DeepCopy()
+				newPod.Status.ContainerStatuses = []corev1.ContainerStatus{
+					failedMainContainerStatus,
+					uncompletedSidecarContainerStatus,
+				}
+				return newPod
+			},
+			expectLen: 1,
+		},
+		{
+			name: "Pod, main container completed -> completed, sidecar container uncompleted",
+			getOldPod: func() *corev1.Pod {
+				oldPod := oldPodDemo.DeepCopy()
+				oldPod.Status.ContainerStatuses = []corev1.ContainerStatus{
+					succeededMainContainerStatus,
+					uncompletedSidecarContainerStatus,
+				}
+				return oldPod
+			},
+			getNewPod: func() *corev1.Pod {
+				newPod := newPodDemo.DeepCopy()
+				newPod.Status.ContainerStatuses = []corev1.ContainerStatus{
+					succeededMainContainerStatus,
+					uncompletedSidecarContainerStatus,
+				}
+				return newPod
+			},
+			expectLen: 1,
+		},
+		{
+			name: "Pod, main container uncompleted -> completed, sidecar container completed",
+			getOldPod: func() *corev1.Pod {
+				oldPod := oldPodDemo.DeepCopy()
+				oldPod.Status.ContainerStatuses = []corev1.ContainerStatus{
+					uncompletedMainContainerStatus,
+					completedSidecarContainerStatus,
+				}
+				return oldPod
+			},
+			getNewPod: func() *corev1.Pod {
+				newPod := newPodDemo.DeepCopy()
+				newPod.Status.ContainerStatuses = []corev1.ContainerStatus{
+					succeededMainContainerStatus,
+					completedSidecarContainerStatus,
+				}
+				return newPod
+			},
+			expectLen: 0,
+		},
+		{
+			name: "Pod, main container completed -> completed, sidecar container completed",
+			getOldPod: func() *corev1.Pod {
+				oldPod := oldPodDemo.DeepCopy()
+				oldPod.Status.ContainerStatuses = []corev1.ContainerStatus{
+					succeededMainContainerStatus,
+					completedSidecarContainerStatus,
+				}
+				return oldPod
+			},
+			getNewPod: func() *corev1.Pod {
+				newPod := newPodDemo.DeepCopy()
+				newPod.Status.ContainerStatuses = []corev1.ContainerStatus{
+					succeededMainContainerStatus,
+					completedSidecarContainerStatus,
+				}
+				return newPod
+			},
+			expectLen: 0,
+		},
+		{
+			name: "Pod, main container completed -> uncompleted, sidecar container completed",
+			getOldPod: func() *corev1.Pod {
+				oldPod := oldPodDemo.DeepCopy()
+				oldPod.Status.ContainerStatuses = []corev1.ContainerStatus{
+					succeededMainContainerStatus,
+					uncompletedSidecarContainerStatus,
+				}
+				return oldPod
+			},
+			getNewPod: func() *corev1.Pod {
+				newPod := newPodDemo.DeepCopy()
+				newPod.Status.ContainerStatuses = []corev1.ContainerStatus{
+					uncompletedMainContainerStatus,
+					completedSidecarContainerStatus,
+				}
+				return newPod
+			},
+			expectLen: 0,
+		},
+		{
+			name: "Pod, main container completed -> uncompleted, sidecar container uncompleted",
+			getOldPod: func() *corev1.Pod {
+				oldPod := oldPodDemo.DeepCopy()
+				oldPod.Status.ContainerStatuses = []corev1.ContainerStatus{
+					succeededMainContainerStatus,
+					uncompletedSidecarContainerStatus,
+				}
+				return oldPod
+			},
+			getNewPod: func() *corev1.Pod {
+				newPod := newPodDemo.DeepCopy()
+				newPod.Status.ContainerStatuses = []corev1.ContainerStatus{
+					uncompletedMainContainerStatus,
+					uncompletedSidecarContainerStatus,
+				}
+				return newPod
+			},
+			expectLen: 0,
+		},
+		{
+			name: "Pod, main container uncompleted, sidecar container uncompleted -> completed",
+			getOldPod: func() *corev1.Pod {
+				oldPod := oldPodDemo.DeepCopy()
+				oldPod.Status.ContainerStatuses = []corev1.ContainerStatus{
+					uncompletedMainContainerStatus,
+					uncompletedSidecarContainerStatus,
+				}
+				return oldPod
+			},
+			getNewPod: func() *corev1.Pod {
+				newPod := newPodDemo.DeepCopy()
+				newPod.Status.ContainerStatuses = []corev1.ContainerStatus{
+					uncompletedMainContainerStatus,
+					completedSidecarContainerStatus,
+				}
+				return newPod
+			},
+			expectLen: 0,
+		},
+	}
+
+	for _, cs := range cases {
+		t.Run(cs.name, func(t *testing.T) {
+			eventHandler := &enqueueRequestForPod{}
+			evt := event.UpdateEvent{
+				ObjectOld: cs.getOldPod(),
+				ObjectNew: cs.getNewPod(),
+			}
+			que := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+			eventHandler.Update(evt, que)
+			if que.Len() != cs.expectLen {
+				t.Fatalf("Get unexpected queue length, expected %v, actual %v", cs.expectLen, que.Len())
+			}
+		})
+	}
+}
+
+func TestEnqueueRequestForPodCreate(t *testing.T) {
+	demoPod := podDemo.DeepCopy()
+	demoPod.SetResourceVersion("1")
+
+	cases := []struct {
+		name      string
+		getPod    func() *corev1.Pod
+		expectLen int
+	}{
+		{
+			name: "Pod not running",
+			getPod: func() *corev1.Pod {
+				newPod := demoPod.DeepCopy()
+				newPod.Status.Phase = corev1.PodPending
+				return newPod
+			},
+			expectLen: 0,
+		},
+		{
+			name: "Pod restartPolicy=Always",
+			getPod: func() *corev1.Pod {
+				newPod := demoPod.DeepCopy()
+				newPod.Spec.RestartPolicy = corev1.RestartPolicyAlways
+				return newPod
+			},
+			expectLen: 0,
+		},
+		{
+			name: "Pod, main container completed, sidecar container uncompleted",
+			getPod: func() *corev1.Pod {
+				newPod := demoPod.DeepCopy()
+				newPod.Status.ContainerStatuses = []corev1.ContainerStatus{
+					failedMainContainerStatus,
+					uncompletedSidecarContainerStatus,
+				}
+				return newPod
+			},
+			expectLen: 1,
+		},
+		{
+			name: "Pod, main container completed, sidecar container completed",
+			getPod: func() *corev1.Pod {
+				newPod := demoPod.DeepCopy()
+				newPod.Status.ContainerStatuses = []corev1.ContainerStatus{
+					succeededMainContainerStatus,
+					completedSidecarContainerStatus,
+				}
+				return newPod
+			},
+			expectLen: 0,
+		},
+		{
+			name: "Pod, main container uncompleted, sidecar container completed",
+			getPod: func() *corev1.Pod {
+				newPod := demoPod.DeepCopy()
+				newPod.Status.ContainerStatuses = []corev1.ContainerStatus{
+					uncompletedMainContainerStatus,
+					completedSidecarContainerStatus,
+				}
+				return newPod
+			},
+			expectLen: 0,
+		},
+		{
+			name: "Pod, main container uncompleted, sidecar container uncompleted",
+			getPod: func() *corev1.Pod {
+				newPod := demoPod.DeepCopy()
+				newPod.Status.ContainerStatuses = []corev1.ContainerStatus{
+					uncompletedMainContainerStatus,
+					uncompletedSidecarContainerStatus,
+				}
+				return newPod
+			},
+			expectLen: 0,
+		},
+	}
+
+	for _, cs := range cases {
+		t.Run(cs.name, func(t *testing.T) {
+			eventHandler := &enqueueRequestForPod{}
+			evt := event.CreateEvent{
+				Object: cs.getPod(),
+			}
+			que := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+			eventHandler.Create(evt, que)
+			if que.Len() != cs.expectLen {
+				t.Fatalf("Get unexpected queue length, expected %v, actual %v", cs.expectLen, que.Len())
+			}
+		})
+	}
+}

--- a/pkg/controller/sidecarterminator/virtual_kubelet_manager.go
+++ b/pkg/controller/sidecarterminator/virtual_kubelet_manager.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2021 The Kruise Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sidecarterminator
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	DefaultVKLabelKey   = "type"
+	DefaultVKLabelValue = "virtual-kubelet"
+	DefaultVKTaintKey   = "virtual-kubelet.io/provider"
+)
+
+func IsPodRunningOnVirtualKubelet(pod *corev1.Pod, reader client.Reader) (bool, error) {
+	node := &corev1.Node{}
+	err := reader.Get(context.TODO(), types.NamespacedName{Name: pod.Spec.NodeName}, node)
+	if err != nil {
+		return false, err
+	}
+
+	if isVirtualKubelet(node) {
+		return true, nil
+	}
+	return false, nil
+}
+
+func isVirtualKubelet(node *corev1.Node) bool {
+	return node.Labels[DefaultVKLabelKey] == DefaultVKLabelValue
+}

--- a/pkg/features/kruise_features.go
+++ b/pkg/features/kruise_features.go
@@ -86,6 +86,10 @@ const (
 	// SidecarSetPatchPodMetadataDefaultsAllowed whether sidecarSet patch pod metadata is allowed
 	SidecarSetPatchPodMetadataDefaultsAllowed featuregate.Feature = "SidecarSetPatchPodMetadataDefaultsAllowed"
 
+	// SidecarTerminator enables SidecarTerminator to stop sidecar containers when all main containers exited.
+	// SidecarTerminator only works for the Pods with 'Never' or 'OnFailure' restartPolicy.
+	SidecarTerminator featuregate.Feature = "SidecarTerminator"
+
 	// PodProbeMarkerGate enable Kruise provide the ability to execute custom Probes.
 	// Note: custom probe execution requires kruise daemon, so currently only traditional Kubelet is supported, not virtual-kubelet.
 	PodProbeMarkerGate featuregate.Feature = "PodProbeMarkerGate"
@@ -112,6 +116,7 @@ var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	InPlaceUpdateEnvFromMetadata:              {Default: false, PreRelease: featuregate.Alpha},
 	StatefulSetAutoDeletePVC:                  {Default: false, PreRelease: featuregate.Alpha},
 	SidecarSetPatchPodMetadataDefaultsAllowed: {Default: false, PreRelease: featuregate.Alpha},
+	SidecarTerminator:                         {Default: false, PreRelease: featuregate.Alpha},
 	PodProbeMarkerGate:                        {Default: false, PreRelease: featuregate.Alpha},
 	PreDownloadImageForDaemonSetUpdate:        {Default: false, PreRelease: featuregate.Alpha},
 }

--- a/test/e2e/apps/sidecarterminator.go
+++ b/test/e2e/apps/sidecarterminator.go
@@ -1,0 +1,430 @@
+package apps
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
+	kruiseclientset "github.com/openkruise/kruise/pkg/client/clientset/versioned"
+	"github.com/openkruise/kruise/test/e2e/framework"
+	batchv1 "k8s.io/api/batch/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/utils/pointer"
+)
+
+var _ = SIGDescribe("SidecarTerminator", func() {
+	f := framework.NewDefaultFramework("sidecarterminator")
+	var ns string
+	var c clientset.Interface
+	var kc kruiseclientset.Interface
+	var randStr string
+
+	ginkgo.BeforeEach(func() {
+		c = f.ClientSet
+		kc = f.KruiseClientSet
+		ns = f.Namespace.Name
+		randStr = rand.String(10)
+	})
+
+	framework.KruiseDescribe("SidecarTerminator checker", func() {
+		ginkgo.It("use kruise-daemon to kill containers", func() {
+			mainContainer := v1.Container{
+				Name:            "main",
+				Image:           "busybox:latest",
+				ImagePullPolicy: v1.PullIfNotPresent,
+				Command:         []string{"/bin/sh", "-c", "sleep 5"},
+			}
+			sidecarContainer := v1.Container{
+				Name:            "sidecar",
+				Image:           "nginx:latest",
+				ImagePullPolicy: v1.PullIfNotPresent,
+				Env: []v1.EnvVar{
+					{
+						Name:  appsv1alpha1.KruiseTerminateSidecarEnv,
+						Value: "true",
+					},
+				},
+			}
+
+			cases := []struct {
+				name        string
+				createJob   func(str string) metav1.Object
+				checkStatus func(object metav1.Object) bool
+			}{
+				{
+					name: "native job, restartPolicy=Never",
+					createJob: func(str string) metav1.Object {
+						job := &batchv1.Job{
+							ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "job-" + str},
+							Spec: batchv1.JobSpec{
+								Template: v1.PodTemplateSpec{
+									Spec: v1.PodSpec{
+										Containers: []v1.Container{
+											*mainContainer.DeepCopy(),
+											*sidecarContainer.DeepCopy(),
+										},
+										RestartPolicy: v1.RestartPolicyNever,
+									},
+								},
+							},
+						}
+						job, err := c.BatchV1().Jobs(ns).Create(context.TODO(), job, metav1.CreateOptions{})
+						gomega.Expect(err).NotTo(gomega.HaveOccurred())
+						return job
+					},
+					checkStatus: func(object metav1.Object) bool {
+						job, err := c.BatchV1().Jobs(object.GetNamespace()).
+							Get(context.TODO(), object.GetName(), metav1.GetOptions{})
+						gomega.Expect(err).NotTo(gomega.HaveOccurred())
+						for _, cond := range job.Status.Conditions {
+							if cond.Type == batchv1.JobComplete {
+								return true
+							}
+						}
+						return false
+					},
+				},
+				{
+					name: "native job, restartPolicy=OnFailure, main failed",
+					createJob: func(str string) metav1.Object {
+						job := &batchv1.Job{
+							ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "job-" + str},
+							Spec: batchv1.JobSpec{
+								BackoffLimit: pointer.Int32Ptr(3),
+								Template: v1.PodTemplateSpec{
+									Spec: v1.PodSpec{
+										Containers: []v1.Container{
+											func() v1.Container {
+												main := mainContainer.DeepCopy()
+												main.Command = []string{"/bin/sh", "-c", "exit 1"}
+												return *main
+											}(),
+											*sidecarContainer.DeepCopy(),
+										},
+										RestartPolicy: v1.RestartPolicyOnFailure,
+									},
+								},
+							},
+						}
+						job, err := c.BatchV1().Jobs(ns).Create(context.TODO(), job, metav1.CreateOptions{})
+						gomega.Expect(err).NotTo(gomega.HaveOccurred())
+						return job
+					},
+					checkStatus: func(object metav1.Object) bool {
+						job, err := c.BatchV1().Jobs(object.GetNamespace()).
+							Get(context.TODO(), object.GetName(), metav1.GetOptions{})
+						gomega.Expect(err).NotTo(gomega.HaveOccurred())
+						for _, cond := range job.Status.Conditions {
+							if cond.Type == batchv1.JobFailed {
+								return true
+							}
+						}
+						return false
+					},
+				},
+				{
+					name: "native job, restartPolicy=OnFailure, main succeeded",
+					createJob: func(str string) metav1.Object {
+						job := &batchv1.Job{
+							ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "job-" + str},
+							Spec: batchv1.JobSpec{
+								BackoffLimit: pointer.Int32Ptr(3),
+								Template: v1.PodTemplateSpec{
+									Spec: v1.PodSpec{
+										Containers: []v1.Container{
+											*mainContainer.DeepCopy(),
+											*sidecarContainer.DeepCopy(),
+										},
+										RestartPolicy: v1.RestartPolicyOnFailure,
+									},
+								},
+							},
+						}
+						job, err := c.BatchV1().Jobs(ns).Create(context.TODO(), job, metav1.CreateOptions{})
+						gomega.Expect(err).NotTo(gomega.HaveOccurred())
+						return job
+					},
+					checkStatus: func(object metav1.Object) bool {
+						job, err := c.BatchV1().Jobs(object.GetNamespace()).
+							Get(context.TODO(), object.GetName(), metav1.GetOptions{})
+						gomega.Expect(err).NotTo(gomega.HaveOccurred())
+						for _, cond := range job.Status.Conditions {
+							if cond.Type == batchv1.JobComplete {
+								return true
+							}
+						}
+						return false
+					},
+				},
+				{
+					name: "BroadcastJob, restartPolicy=Never",
+					createJob: func(str string) metav1.Object {
+						job := &appsv1alpha1.BroadcastJob{
+							ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "job-" + str},
+							Spec: appsv1alpha1.BroadcastJobSpec{
+								Template: v1.PodTemplateSpec{
+									Spec: v1.PodSpec{
+										Containers: []v1.Container{
+											*mainContainer.DeepCopy(),
+											*sidecarContainer.DeepCopy(),
+										},
+										RestartPolicy: v1.RestartPolicyNever,
+									},
+								},
+								CompletionPolicy: appsv1alpha1.CompletionPolicy{Type: appsv1alpha1.Always},
+							},
+						}
+						job, err := kc.AppsV1alpha1().BroadcastJobs(ns).Create(context.TODO(), job, metav1.CreateOptions{})
+						gomega.Expect(err).NotTo(gomega.HaveOccurred())
+						return job
+					},
+					checkStatus: func(object metav1.Object) bool {
+						job, err := kc.AppsV1alpha1().BroadcastJobs(object.GetNamespace()).
+							Get(context.TODO(), object.GetName(), metav1.GetOptions{})
+						gomega.Expect(err).NotTo(gomega.HaveOccurred())
+						return job.Status.Phase == appsv1alpha1.PhaseCompleted
+					},
+				},
+				{
+					name: "BroadcastJob, restartPolicy=OnFailure, main failed",
+					createJob: func(str string) metav1.Object {
+						job := &appsv1alpha1.BroadcastJob{
+							ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "job-" + str},
+							Spec: appsv1alpha1.BroadcastJobSpec{
+								Template: v1.PodTemplateSpec{
+									Spec: v1.PodSpec{
+										Containers: []v1.Container{
+											func() v1.Container {
+												main := mainContainer.DeepCopy()
+												main.Command = []string{"/bin/sh", "-c", "exit 1"}
+												return *main
+											}(),
+											*sidecarContainer.DeepCopy(),
+										},
+										RestartPolicy: v1.RestartPolicyOnFailure,
+									},
+								},
+								CompletionPolicy: appsv1alpha1.CompletionPolicy{Type: appsv1alpha1.Always},
+							},
+						}
+						job, err := kc.AppsV1alpha1().BroadcastJobs(ns).Create(context.TODO(), job, metav1.CreateOptions{})
+						gomega.Expect(err).NotTo(gomega.HaveOccurred())
+						return job
+					},
+					checkStatus: func(object metav1.Object) bool {
+						job, err := kc.AppsV1alpha1().BroadcastJobs(object.GetNamespace()).
+							Get(context.TODO(), object.GetName(), metav1.GetOptions{})
+						gomega.Expect(err).NotTo(gomega.HaveOccurred())
+						return job.Status.Phase == appsv1alpha1.PhaseFailed
+					},
+				},
+				{
+					name: "BroadcastJob, restartPolicy=OnFailure, main succeeded",
+					createJob: func(str string) metav1.Object {
+						job := &appsv1alpha1.BroadcastJob{
+							ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "job-" + str},
+							Spec: appsv1alpha1.BroadcastJobSpec{
+								Template: v1.PodTemplateSpec{
+									Spec: v1.PodSpec{
+										Containers: []v1.Container{
+											*mainContainer.DeepCopy(),
+											*sidecarContainer.DeepCopy(),
+										},
+										RestartPolicy: v1.RestartPolicyOnFailure,
+									},
+								},
+								CompletionPolicy: appsv1alpha1.CompletionPolicy{Type: appsv1alpha1.Always},
+							},
+						}
+						job, err := kc.AppsV1alpha1().BroadcastJobs(ns).Create(context.TODO(), job, metav1.CreateOptions{})
+						gomega.Expect(err).NotTo(gomega.HaveOccurred())
+						return job
+					},
+					checkStatus: func(object metav1.Object) bool {
+						job, err := kc.AppsV1alpha1().BroadcastJobs(object.GetNamespace()).
+							Get(context.TODO(), object.GetName(), metav1.GetOptions{})
+						gomega.Expect(err).NotTo(gomega.HaveOccurred())
+						return job.Status.Phase == appsv1alpha1.PhaseCompleted
+					},
+				},
+			}
+
+			for i := range cases {
+				ginkgo.By(cases[i].name)
+				ginkgo.By("Create job-" + randStr)
+				job := cases[i].createJob(fmt.Sprintf("%v-%v", randStr, i))
+				time.Sleep(time.Second)
+				gomega.Eventually(func() bool {
+					return cases[i].checkStatus(job)
+				}, 10*time.Minute, time.Second).Should(gomega.BeTrue())
+			}
+		})
+		/*
+			ginkgo.It("use in-place update strategy to kill containers", func() {
+				mainContainer := v1.Container{
+					Name:            "main",
+					Image:           "busybox:latest",
+					ImagePullPolicy: v1.PullIfNotPresent,
+					Command:         []string{"/bin/sh", "-c", "sleep 5"},
+				}
+				sidecarContainer := v1.Container{
+					Name:            "sidecar",
+					Image:           "nginx:latest",
+					ImagePullPolicy: v1.PullIfNotPresent,
+					Env: []v1.EnvVar{
+						{
+							Name:  stutil.KruiseTerminateSidecarEnv,
+							Value: stutil.InplaceUpdateONLYStrategy,
+						},
+						{
+							Name:  stutil.KruiseTerminateSidecarWithImageEnv,
+							Value: "minchou/exit:v1.0",
+						},
+						{
+							Name:  stutil.KruiseTerminateSidecarWithDownwardAPI,
+							Value: "true",
+						},
+					},
+				}
+
+				cases := []struct {
+					name        string
+					createJob   func(str string) metav1.Object
+					checkStatus func(object metav1.Object) bool
+				}{
+					{
+						name: "native job, no command",
+						createJob: func(str string) metav1.Object {
+							job := &batchv1.Job{
+								ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "job-" + str},
+								Spec: batchv1.JobSpec{
+									Template: v1.PodTemplateSpec{
+										Spec: v1.PodSpec{
+											Containers: []v1.Container{
+												*mainContainer.DeepCopy(),
+												*sidecarContainer.DeepCopy(),
+											},
+											RestartPolicy: v1.RestartPolicyNever,
+										},
+									},
+								},
+							}
+							fmt.Println("Batch Job")
+							job, err := c.BatchV1().Jobs(ns).Create(context.TODO(), job, metav1.CreateOptions{})
+							gomega.Expect(err).NotTo(gomega.HaveOccurred())
+							return job
+						},
+						checkStatus: func(object metav1.Object) bool {
+							job, err := c.BatchV1().Jobs(object.GetNamespace()).
+								Get(context.TODO(), object.GetName(), metav1.GetOptions{})
+							gomega.Expect(err).NotTo(gomega.HaveOccurred())
+							for _, cond := range job.Status.Conditions {
+								if cond.Type == batchv1.JobComplete {
+									return true
+								}
+							}
+							return false
+						},
+					},
+					{
+						name: "native job, 3 commands",
+						createJob: func(str string) metav1.Object {
+							job := &batchv1.Job{
+								ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "job-" + str},
+								Spec: batchv1.JobSpec{
+									BackoffLimit: pointer.Int32Ptr(3),
+									Template: v1.PodTemplateSpec{
+										Spec: v1.PodSpec{
+											Containers: []v1.Container{
+												func() v1.Container {
+													main := mainContainer.DeepCopy()
+													main.Command = []string{"/bin/sh", "-c", "exit 1"}
+													return *main
+												}(),
+												func() v1.Container {
+													sidecar := sidecarContainer.DeepCopy()
+													sidecar.Command = []string{"/bin/sh", "-c", "sleep 10000"}
+													return *sidecar
+												}(),
+											},
+											RestartPolicy: v1.RestartPolicyOnFailure,
+										},
+									},
+								},
+							}
+							job, err := c.BatchV1().Jobs(ns).Create(context.TODO(), job, metav1.CreateOptions{})
+							gomega.Expect(err).NotTo(gomega.HaveOccurred())
+							return job
+						},
+						checkStatus: func(object metav1.Object) bool {
+							job, err := c.BatchV1().Jobs(object.GetNamespace()).
+								Get(context.TODO(), object.GetName(), metav1.GetOptions{})
+							gomega.Expect(err).NotTo(gomega.HaveOccurred())
+							for _, cond := range job.Status.Conditions {
+								if cond.Type == batchv1.JobFailed {
+									return true
+								}
+							}
+							return false
+						},
+					},
+					{
+						name: "native job, 4 commands",
+						createJob: func(str string) metav1.Object {
+							job := &batchv1.Job{
+								ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "job-" + str},
+								Spec: batchv1.JobSpec{
+									BackoffLimit: pointer.Int32Ptr(3),
+									Template: v1.PodTemplateSpec{
+										Spec: v1.PodSpec{
+											Containers: []v1.Container{
+												*mainContainer.DeepCopy(),
+												func() v1.Container {
+													sidecar := sidecarContainer.DeepCopy()
+													sidecar.Command = []string{"/bin/sh", "-c", "sleep 10000"}
+													sidecar.Args = []string{`echo "hello"`}
+													return *sidecar
+												}(),
+											},
+											RestartPolicy: v1.RestartPolicyOnFailure,
+										},
+									},
+								},
+							}
+							job, err := c.BatchV1().Jobs(ns).Create(context.TODO(), job, metav1.CreateOptions{})
+							gomega.Expect(err).NotTo(gomega.HaveOccurred())
+							return job
+						},
+						checkStatus: func(object metav1.Object) bool {
+							job, err := c.BatchV1().Jobs(object.GetNamespace()).
+								Get(context.TODO(), object.GetName(), metav1.GetOptions{})
+							gomega.Expect(err).NotTo(gomega.HaveOccurred())
+							for _, cond := range job.Status.Conditions {
+								if cond.Type == batchv1.JobComplete {
+									return true
+								}
+							}
+							return false
+						},
+					},
+				}
+
+				for i := range cases {
+					ginkgo.By(cases[i].name)
+					ginkgo.By("Create job-" + randStr)
+					job := cases[i].createJob(fmt.Sprintf("%v-%v", randStr, i))
+					time.Sleep(time.Second)
+					gomega.Eventually(func() bool {
+						return cases[i].checkStatus(job)
+					}, 5*time.Minute, time.Second).Should(gomega.BeTrue())
+				}
+			})
+		*/
+	})
+})


### PR DESCRIPTION
Signed-off-by: mingzhou.swx <mingzhou.swx@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
People can use this controller to terminate job sidecar containers when other main containers exited.

Just add env `KRUISE_TERMINATE_SIDECAR_WHEN_JOB_EXIT="true"` to sidecar containers to enable this feature.


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
#1050

### Ⅲ. Describe how to verify it
UT & E2E

