### PR TITLE
fix sidecarset hot upgrade reset empty container bug

### DIFF
--- a/pkg/control/sidecarcontrol/sidecarset_control.go
+++ b/pkg/control/sidecarcontrol/sidecarset_control.go
@@ -96,12 +96,8 @@ func (c *commonControl) IsPodReady(pod *v1.Pod) bool {
 }
 
 func (c *commonControl) UpdatePodAnnotationsInUpgrade(changedContainers []string, pod *v1.Pod) {
-
 	sidecarSet := c.GetSidecarset()
-	// 1. sidecar hash
-	updatePodSidecarSetHash(pod, sidecarSet)
-
-	// 3. record the ImageID, before update pod sidecar container
+	// record the ImageID, before update pod sidecar container
 	// if it is changed, indicates the update is complete.
 	//format: sidecarset.name -> appsv1alpha1.InPlaceUpdateState
 	sidecarUpdateStates := make(map[string]*pub.InPlaceUpdateState)

--- a/pkg/controller/sidecarset/sidecarset_pod_event_handler_test.go
+++ b/pkg/controller/sidecarset/sidecarset_pod_event_handler_test.go
@@ -108,7 +108,6 @@ func TestGetPodMatchedSidecarSets(t *testing.T) {
 			getSidecarSets: func() []*appsv1alpha1.SidecarSet {
 				sidecar1 := sidecarSetDemo.DeepCopy()
 				sidecar1.Name = "test-sidecarset-1"
-				fmt.Println(sidecar1.Name, sidecar1.ResourceVersion)
 				sidecar2 := sidecarSetDemo.DeepCopy()
 				sidecar2.Name = "test-sidecarset-2"
 				sidecar3 := sidecarSetDemo.DeepCopy()

--- a/pkg/controller/sidecarset/sidecarset_strategy_test.go
+++ b/pkg/controller/sidecarset/sidecarset_strategy_test.go
@@ -92,6 +92,7 @@ func factoryPodsCommon(count, upgraded int, sidecarSet *appsv1alpha1.SidecarSet)
 	}
 	for i := 0; i < upgraded; i++ {
 		pods[i].Spec.Containers[1].Image = "test-image:v2"
+		sidecarcontrol.UpdatePodSidecarSetHash(pods[i], control.GetSidecarset())
 		control.UpdatePodAnnotationsInUpgrade([]string{"test-sidecar"}, pods[i])
 	}
 	return pods
@@ -323,9 +324,9 @@ func testGetNextUpgradePods(t *testing.T, factoryPods FactoryPods, factorySideca
 		t.Run(cs.name, func(t *testing.T) {
 			control := sidecarcontrol.New(cs.getSidecarset())
 			pods := cs.getPods()
-			injectedPods := strategy.GetNextUpgradePods(control, pods)
-			if cs.exceptNeedUpgradeCount != len(injectedPods) {
-				t.Fatalf("except NeedUpgradeCount(%d), but get value(%d)", cs.exceptNeedUpgradeCount, len(injectedPods))
+			upgradePods := strategy.GetNextUpgradePods(control, pods)
+			if cs.exceptNeedUpgradeCount != len(upgradePods) {
+				t.Fatalf("except NeedUpgradeCount(%d), but get value(%d)", cs.exceptNeedUpgradeCount, len(upgradePods))
 			}
 		})
 	}


### PR DESCRIPTION
Signed-off-by: liheng.zms <liheng.zms@alibaba-inc.com>

### Ⅰ. Describe what this PR does
1. flip old container to empty image logic: only the image should be updated at this point, but not the Pod sidecarSet hash, which will cause this hash error if published consecutively
2. when only update main container, need patch sidecarSet pod metadata
