### PR TITLE
Workloadspread support statefulset

### DIFF
--- a/pkg/controller/workloadspread/workloadspread_controller.go
+++ b/pkg/controller/workloadspread/workloadspread_controller.go
@@ -85,11 +85,13 @@ const (
 )
 
 var (
-	controllerKruiseKindWS = appsv1alpha1.SchemeGroupVersion.WithKind("WorkloadSpread")
-	controllerKruiseKindCS = appsv1alpha1.SchemeGroupVersion.WithKind("CloneSet")
-	controllerKindRS       = appsv1.SchemeGroupVersion.WithKind("ReplicaSet")
-	controllerKindDep      = appsv1.SchemeGroupVersion.WithKind("Deployment")
-	controllerKindJob      = batchv1.SchemeGroupVersion.WithKind("Job")
+	controllerKruiseKindWS  = appsv1alpha1.SchemeGroupVersion.WithKind("WorkloadSpread")
+	controllerKruiseKindCS  = appsv1alpha1.SchemeGroupVersion.WithKind("CloneSet")
+	controllerKruiseKindSts = appsv1alpha1.SchemeGroupVersion.WithKind("StatefulSet")
+	controllerKindSts       = appsv1.SchemeGroupVersion.WithKind("StatefulSet")
+	controllerKindRS        = appsv1.SchemeGroupVersion.WithKind("ReplicaSet")
+	controllerKindDep       = appsv1.SchemeGroupVersion.WithKind("Deployment")
+	controllerKindJob       = batchv1.SchemeGroupVersion.WithKind("Job")
 )
 
 // this is a short cut for any sub-functions to notify the reconcile how long to wait to requeue
@@ -269,7 +271,7 @@ func (r *ReconcileWorkloadSpread) getPodsForWorkloadSpread(ws *appsv1alpha1.Work
 	targetRef := ws.Spec.TargetReference
 
 	switch targetRef.Kind {
-	case controllerKindDep.Kind, controllerKindRS.Kind, controllerKruiseKindCS.Kind:
+	case controllerKindDep.Kind, controllerKindRS.Kind, controllerKruiseKindCS.Kind, controllerKindSts.Kind:
 		pods, workloadReplicas, err = r.controllerFinder.GetPodsForRef(targetRef.APIVersion, targetRef.Kind, ws.Namespace, targetRef.Name, false)
 	case controllerKindJob.Kind:
 		pods, workloadReplicas, err = r.getPodJob(targetRef, ws.Namespace)

--- a/pkg/util/workloadspread/workloadspread.go
+++ b/pkg/util/workloadspread/workloadspread.go
@@ -19,6 +19,9 @@ package workloadspread
 import (
 	"context"
 	"encoding/json"
+	"math"
+	"regexp"
+	"strconv"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -37,6 +40,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
+	appsv1beta1 "github.com/openkruise/kruise/apis/apps/v1beta1"
 	kubeClient "github.com/openkruise/kruise/pkg/client"
 	"github.com/openkruise/kruise/pkg/util"
 )
@@ -52,10 +56,13 @@ const (
 )
 
 var (
-	controllerKruiseKindCS = appsv1alpha1.SchemeGroupVersion.WithKind("CloneSet")
-	controllerKindRS       = appsv1.SchemeGroupVersion.WithKind("ReplicaSet")
-	controllerKindDep      = appsv1.SchemeGroupVersion.WithKind("Deployment")
-	controllerKindJob      = batchv1.SchemeGroupVersion.WithKind("Job")
+	controllerKruiseKindCS       = appsv1alpha1.SchemeGroupVersion.WithKind("CloneSet")
+	controllerKruiseKindAlphaSts = appsv1alpha1.SchemeGroupVersion.WithKind("StatefulSet")
+	controllerKruiseKindBetaSts  = appsv1beta1.SchemeGroupVersion.WithKind("StatefulSet")
+	controllerKindJob            = batchv1.SchemeGroupVersion.WithKind("Job")
+	controllerKindRS             = appsv1.SchemeGroupVersion.WithKind("ReplicaSet")
+	controllerKindDep            = appsv1.SchemeGroupVersion.WithKind("Deployment")
+	controllerKindSts            = appsv1.SchemeGroupVersion.WithKind("StatefulSet")
 )
 
 type Operation string
@@ -76,6 +83,7 @@ var (
 		{Kind: controllerKruiseKindCS.Kind, Groups: []string{controllerKruiseKindCS.Group}},
 		{Kind: controllerKindRS.Kind, Groups: []string{controllerKindRS.Group}},
 		{Kind: controllerKindJob.Kind, Groups: []string{controllerKindJob.Group}},
+		{Kind: controllerKindSts.Kind, Groups: []string{controllerKindSts.Group, controllerKruiseKindAlphaSts.Group, controllerKruiseKindBetaSts.Group}},
 	}
 )
 
@@ -292,50 +300,83 @@ func (h *Handler) acquireSuitableSubset(matchedWS *appsv1alpha1.WorkloadSpread,
 	var conflictTimes int
 	var costOfGet, costOfUpdate time.Duration
 
-	if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		unlock := util.GlobalKeyedMutex.Lock(string(matchedWS.GetUID()))
-		defer unlock()
-
-		var err error
-		startGet := time.Now()
-		// try best to get the latest revision of matchedWS in a low cost:
-		// 1. get two matchedWS, one is cached by this webhook process,
-		// another is cached by informer, compare and get the newer one;
-		// 2. if 1. failed, directly fetch matchedWS from APIServer;
-		wsClone, err = h.tryToGetTheLatestMatchedWS(matchedWS, refresh)
-		costOfGet += time.Since(startGet)
-		if err != nil {
-			return err
-		} else if wsClone == nil {
-			return nil
-		}
-
-		// check whether WorkloadSpread has suitable subset for the pod
-		// 1. changed indicates whether workloadSpread status changed
-		// 2. suitableSubset is matched subset for the pod
-		changed, suitableSubset, generatedUID = h.updateSubsetForPod(wsClone, pod, injectWS, operation)
-		if !changed {
-			return nil
-		}
-
-		// update WorkloadSpread status
-		start := time.Now()
-		if err = h.Client.Status().Update(context.TODO(), wsClone); err != nil {
-			refresh = true
-			conflictTimes++
-		} else {
-			klog.V(3).Infof("update workloadSpread(%s/%s) SubsetStatus(%s) missingReplicas(%d) creatingPods(%d) deletingPods(%d) success",
-				wsClone.Namespace, wsClone.Name, suitableSubset.Name,
-				suitableSubset.MissingReplicas, len(suitableSubset.CreatingPods), len(suitableSubset.DeletingPods))
-			if cacheErr := util.GlobalCache.Add(wsClone); cacheErr != nil {
-				klog.Warningf("Failed to update workloadSpread(%s/%s) cache after update status, err: %v", wsClone.Namespace, wsClone.Name, cacheErr)
+	switch matchedWS.Spec.TargetReference.Kind {
+	case controllerKindSts.Kind:
+		// StatefulSet has special logic about pod assignment for subsets.
+		// For example, suppose that we have the following sub sets config:
+		//	- name: subset-a
+		//	  maxReplicas: 5
+		//	- name: subset-b
+		//	  maxReplicas: 5
+		//	- name: subset-c
+		// the pods with order within [0, 5) will be assigned to subset-a;
+		// the pods with order within [5, 10) will be assigned to subset-b;
+		// the pods with order within [10, inf) will be assigned to subset-c.
+		currentThresholdID := int64(0)
+		for _, subset := range matchedWS.Spec.Subsets {
+			cond := getSubsetCondition(matchedWS, subset.Name, appsv1alpha1.SubsetSchedulable)
+			if cond != nil && cond.Status == corev1.ConditionFalse {
+				continue
+			}
+			subsetReplicasLimit := math.MaxInt32
+			if subset.MaxReplicas != nil {
+				subsetReplicasLimit = subset.MaxReplicas.IntValue()
+			}
+			// currently, we do not support reserveOrdinals feature for advanced statefulSet
+			currentThresholdID += int64(subsetReplicasLimit)
+			_, orderID := getParentNameAndOrdinal(pod)
+			if int64(orderID) < currentThresholdID {
+				suitableSubsetName = subset.Name
+				break
 			}
 		}
-		costOfUpdate += time.Since(start)
-		return err
-	}); err != nil {
-		klog.Errorf("update WorkloadSpread(%s/%s) error %s", matchedWS.Namespace, matchedWS.Name, err.Error())
-		return "", "", err
+
+	default:
+		if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+			unlock := util.GlobalKeyedMutex.Lock(string(matchedWS.GetUID()))
+			defer unlock()
+
+			var err error
+			startGet := time.Now()
+			// try best to get the latest revision of matchedWS in a low cost:
+			// 1. get two matchedWS, one is cached by this webhook process,
+			// another is cached by informer, compare and get the newer one;
+			// 2. if 1. failed, directly fetch matchedWS from APIServer;
+			wsClone, err = h.tryToGetTheLatestMatchedWS(matchedWS, refresh)
+			costOfGet += time.Since(startGet)
+			if err != nil {
+				return err
+			} else if wsClone == nil {
+				return nil
+			}
+
+			// check whether WorkloadSpread has suitable subset for the pod
+			// 1. changed indicates whether workloadSpread status changed
+			// 2. suitableSubset is matched subset for the pod
+			changed, suitableSubset, generatedUID = h.updateSubsetForPod(wsClone, pod, injectWS, operation)
+			if !changed {
+				return nil
+			}
+
+			// update WorkloadSpread status
+			start := time.Now()
+			if err = h.Client.Status().Update(context.TODO(), wsClone); err != nil {
+				refresh = true
+				conflictTimes++
+			} else {
+				klog.V(3).Infof("update workloadSpread(%s/%s) SubsetStatus(%s) missingReplicas(%d) creatingPods(%d) deletingPods(%d) success",
+					wsClone.Namespace, wsClone.Name, suitableSubset.Name,
+					suitableSubset.MissingReplicas, len(suitableSubset.CreatingPods), len(suitableSubset.DeletingPods))
+				if cacheErr := util.GlobalCache.Add(wsClone); cacheErr != nil {
+					klog.Warningf("Failed to update workloadSpread(%s/%s) cache after update status, err: %v", wsClone.Namespace, wsClone.Name, cacheErr)
+				}
+			}
+			costOfUpdate += time.Since(start)
+			return err
+		}); err != nil {
+			klog.Errorf("update WorkloadSpread(%s/%s) error %s", matchedWS.Namespace, matchedWS.Name, err.Error())
+			return "", "", err
+		}
 	}
 
 	if suitableSubset != nil {
@@ -620,4 +661,39 @@ func (h Handler) isReferenceEqual(target *appsv1alpha1.TargetReference, owner *m
 	}
 
 	return targetGv.Group == ownerGv.Group && target.Kind == owner.Kind && target.Name == owner.Name
+}
+
+// statefulPodRegex is a regular expression that extracts the parent StatefulSet and ordinal from the Name of a Pod
+var statefulPodRegex = regexp.MustCompile("(.*)-([0-9]+)$")
+
+// getParentNameAndOrdinal gets the name of pod's parent StatefulSet and pod's ordinal as extracted from its Name. If
+// the Pod was not created by a StatefulSet, its parent is considered to be empty string, and its ordinal is considered
+// to be -1.
+func getParentNameAndOrdinal(pod *corev1.Pod) (string, int) {
+	parent := ""
+	ordinal := -1
+	subMatches := statefulPodRegex.FindStringSubmatch(pod.Name)
+	if len(subMatches) < 3 {
+		return parent, ordinal
+	}
+	parent = subMatches[1]
+	if i, err := strconv.ParseInt(subMatches[2], 10, 32); err == nil {
+		ordinal = int(i)
+	}
+	return parent, ordinal
+}
+
+func getSubsetCondition(ws *appsv1alpha1.WorkloadSpread, subsetName string, condType appsv1alpha1.WorkloadSpreadSubsetConditionType) *appsv1alpha1.WorkloadSpreadSubsetCondition {
+	for i := range ws.Status.SubsetStatuses {
+		subset := &ws.Status.SubsetStatuses[i]
+		if subset.Name != subsetName {
+			continue
+		}
+		for _, condition := range subset.Conditions {
+			if condition.Type == condType {
+				return &condition
+			}
+		}
+	}
+	return nil
 }

--- a/pkg/util/workloadspread/workloadspread_test.go
+++ b/pkg/util/workloadspread/workloadspread_test.go
@@ -36,6 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
+	appsv1beta1 "github.com/openkruise/kruise/apis/apps/v1beta1"
 	"github.com/openkruise/kruise/pkg/util"
 )
 
@@ -153,6 +154,7 @@ var (
 func init() {
 	scheme = runtime.NewScheme()
 	_ = appsv1alpha1.AddToScheme(scheme)
+	_ = appsv1beta1.AddToScheme(scheme)
 	_ = corev1.AddToScheme(scheme)
 }
 
@@ -984,6 +986,20 @@ func TestFilterReference(t *testing.T) {
 	for _, ref := range refs {
 		if matched, _ := matchReference(ref); !matched {
 			t.Fatalf("error")
+		}
+	}
+}
+
+func TestGetParentNameAndOrdinal(t *testing.T) {
+	for i := 0; i < 500; i++ {
+		pod := corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: fmt.Sprintf("sample-%d", i),
+			},
+		}
+		_, id := getParentNameAndOrdinal(&pod)
+		if id != i {
+			t.Fatal("failed to parse pod name")
 		}
 	}
 }

--- a/pkg/webhook/workloadspread/validating/workloadspread_validation_test.go
+++ b/pkg/webhook/workloadspread/validating/workloadspread_validation_test.go
@@ -176,6 +176,84 @@ func TestValidateWorkloadSpreadCreate(t *testing.T) {
 			},
 		},
 		{
+			ObjectMeta: metav1.ObjectMeta{Name: "ws-1", Namespace: metav1.NamespaceDefault},
+			Spec: appsv1alpha1.WorkloadSpreadSpec{
+				TargetReference: &appsv1alpha1.TargetReference{
+					APIVersion: "apps/v1",
+					Kind:       "StatefulSet",
+					Name:       "demo",
+				},
+				Subsets: []appsv1alpha1.WorkloadSpreadSubset{
+					{
+						Name:        "subset-a",
+						MaxReplicas: &replicas1,
+						Patch: runtime.RawExtension{
+							Raw: []byte(`{"metadata":{"annotations":{"subset":"subset-a"}}}`),
+						},
+					},
+					{
+						Name:        "subset-b",
+						MaxReplicas: nil,
+						Patch: runtime.RawExtension{
+							Raw: []byte(`{"metadata":{"annotations":{"subset":"subset-b"}}}`),
+						},
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "ws-1", Namespace: metav1.NamespaceDefault},
+			Spec: appsv1alpha1.WorkloadSpreadSpec{
+				TargetReference: &appsv1alpha1.TargetReference{
+					APIVersion: "apps.kruise.io/v1alpha1",
+					Kind:       "StatefulSet",
+					Name:       "demo",
+				},
+				Subsets: []appsv1alpha1.WorkloadSpreadSubset{
+					{
+						Name:        "subset-a",
+						MaxReplicas: &replicas1,
+						Patch: runtime.RawExtension{
+							Raw: []byte(`{"metadata":{"annotations":{"subset":"subset-a"}}}`),
+						},
+					},
+					{
+						Name:        "subset-b",
+						MaxReplicas: nil,
+						Patch: runtime.RawExtension{
+							Raw: []byte(`{"metadata":{"annotations":{"subset":"subset-b"}}}`),
+						},
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "ws-1", Namespace: metav1.NamespaceDefault},
+			Spec: appsv1alpha1.WorkloadSpreadSpec{
+				TargetReference: &appsv1alpha1.TargetReference{
+					APIVersion: "apps.kruise.io/v1beta1",
+					Kind:       "StatefulSet",
+					Name:       "demo",
+				},
+				Subsets: []appsv1alpha1.WorkloadSpreadSubset{
+					{
+						Name:        "subset-a",
+						MaxReplicas: &replicas1,
+						Patch: runtime.RawExtension{
+							Raw: []byte(`{"metadata":{"annotations":{"subset":"subset-a"}}}`),
+						},
+					},
+					{
+						Name:        "subset-b",
+						MaxReplicas: nil,
+						Patch: runtime.RawExtension{
+							Raw: []byte(`{"metadata":{"annotations":{"subset":"subset-b"}}}`),
+						},
+					},
+				},
+			},
+		},
+		{
 			ObjectMeta: metav1.ObjectMeta{Name: "ws-2", Namespace: metav1.NamespaceDefault},
 			Spec: appsv1alpha1.WorkloadSpreadSpec{
 				TargetReference: &appsv1alpha1.TargetReference{
@@ -436,6 +514,34 @@ func TestValidateWorkloadSpreadCreate(t *testing.T) {
 			},
 			errorSuffix: "spec.subsets",
 		},
+		{
+			name: "statefulset group error",
+			getWorkloadSpread: func() *appsv1alpha1.WorkloadSpread {
+				workloadSpread := workloadSpreadDemo.DeepCopy()
+				workloadSpread.Spec.TargetReference = &appsv1alpha1.TargetReference{
+					APIVersion: "rollouts.kruise.io/v2",
+					Kind:       "StatefulSet",
+					Name:       "demo",
+				}
+				return workloadSpread
+			},
+			errorSuffix: "spec.targetRef",
+		},
+		{
+			name: "statefulset subset is percentage",
+			getWorkloadSpread: func() *appsv1alpha1.WorkloadSpread {
+				workloadSpread := workloadSpreadDemo.DeepCopy()
+				workloadSpread.Spec.TargetReference = &appsv1alpha1.TargetReference{
+					APIVersion: "apps.kruise.io/v1beta1",
+					Kind:       "StatefulSet",
+					Name:       "demo",
+				}
+				workloadSpread.Spec.Subsets[0].MaxReplicas = &replicas2
+				return workloadSpread
+			},
+			errorSuffix: "spec.subsets[0].maxReplicas",
+		},
+
 		//{
 		//	name: "one subset",
 		//	getWorkloadSpread: func() *appsv1alpha1.WorkloadSpread {

--- a/test/e2e/apps/workloadspread.go
+++ b/test/e2e/apps/workloadspread.go
@@ -43,7 +43,8 @@ import (
 const WorkloadSpreadFakeZoneKey = "e2e.kruise.io/workloadspread-fake-zone"
 
 var (
-	KruiseKindCloneSet = appsv1alpha1.SchemeGroupVersion.WithKind("CloneSet")
+	KruiseKindCloneSet    = appsv1alpha1.SchemeGroupVersion.WithKind("CloneSet")
+	KruiseKindStatefulSet = appsv1alpha1.SchemeGroupVersion.WithKind("StatefulSet")
 	//controllerKindDep  = appsv1.SchemeGroupVersion.WithKind("Deployment")
 	//controllerKindJob  = batchv1.SchemeGroupVersion.WithKind("Job")
 )
@@ -1426,6 +1427,85 @@ var _ = SIGDescribe("workloadspread", func() {
 			}
 
 			ginkgo.By("manage existing pods by only preferredNodeSelector, then deletion subset-b, done")
+		})
+
+		framework.ConformanceIt("manage statefulset pods only with patch", func() {
+			sts, svc := tester.NewBaseHeadlessStatefulSet(ns)
+			// create workloadSpread
+			targetRef := appsv1alpha1.TargetReference{
+				APIVersion: KruiseKindStatefulSet.GroupVersion().String(),
+				Kind:       KruiseKindStatefulSet.Kind,
+				Name:       sts.Name,
+			}
+			subsets := []appsv1alpha1.WorkloadSpreadSubset{
+				{
+					Name:        "subset-a",
+					MaxReplicas: &intstr.IntOrString{Type: intstr.Int, IntVal: 2},
+					Patch: runtime.RawExtension{
+						Raw: []byte(`{"metadata":{"annotations":{"subset":"subset-a"}}}`),
+					},
+				},
+				{
+					Name:        "subset-b",
+					MaxReplicas: &intstr.IntOrString{Type: intstr.Int, IntVal: 2},
+					Patch: runtime.RawExtension{
+						Raw: []byte(`{"metadata":{"annotations":{"subset":"subset-b"}}}`),
+					},
+				},
+				{
+					Name: "subset-c",
+					Patch: runtime.RawExtension{
+						Raw: []byte(`{"metadata":{"annotations":{"subset":"subset-c"}}}`),
+					},
+				},
+			}
+
+			ginkgo.By("Creating workloadspread and waiting for its reconcile...")
+			ws := tester.NewWorkloadSpread(ns, workloadSpreadName, &targetRef, subsets)
+			ws = tester.CreateWorkloadSpread(ws)
+			tester.WaitForWorkloadSpreadRunning(ws)
+
+			ginkgo.By("Creating statefulset with 5 replicas and waiting for pods to be ready...")
+			sts.Spec.Replicas = pointer.Int32Ptr(5)
+			tester.CreateService(svc)
+			statefulSet := tester.CreateStatefulSet(sts)
+			tester.WaitForStatefulSetRunning(statefulSet)
+
+			ginkgo.By("Check workloadspread status...")
+			ws, err := tester.GetWorkloadSpread(ws.Namespace, ws.Name)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			var replicasForSubsetA, replicasForSubsetB, replicasForSubsetC int32
+			for _, subset := range ws.Status.SubsetStatuses {
+				switch subset.Name {
+				case "subset-a":
+					replicasForSubsetA += subset.Replicas
+				case "subset-b":
+					replicasForSubsetB += subset.Replicas
+				case "subset-c":
+					replicasForSubsetC += subset.Replicas
+				}
+			}
+			gomega.Expect(replicasForSubsetA).To(gomega.Equal(int32(2)))
+			gomega.Expect(replicasForSubsetB).To(gomega.Equal(int32(2)))
+			gomega.Expect(replicasForSubsetC).To(gomega.Equal(int32(1)))
+
+			ginkgo.By("List pods of cloneset and check their patch...")
+			pods, err := tester.GetSelectorPods(ns, statefulSet.Spec.Selector)
+			var podForSubsetA, podForSubsetB, podForSubsetC int32
+			for _, pod := range pods {
+				switch pod.Annotations["subset"] {
+				case "subset-a":
+					podForSubsetA++
+				case "subset-b":
+					podForSubsetB++
+				case "subset-c":
+					podForSubsetC++
+				}
+			}
+			gomega.Expect(podForSubsetA).To(gomega.Equal(int32(2)))
+			gomega.Expect(podForSubsetB).To(gomega.Equal(int32(2)))
+			gomega.Expect(podForSubsetC).To(gomega.Equal(int32(1)))
+			ginkgo.By("manage statefulset pods only with patch, done")
 		})
 
 		//ginkgo.It("deploy in two zone, maxReplicas=50%", func() {

--- a/test/e2e/framework/workloadspread_util.go
+++ b/test/e2e/framework/workloadspread_util.go
@@ -33,6 +33,7 @@ import (
 	utilpointer "k8s.io/utils/pointer"
 
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
+	appsv1beta1 "github.com/openkruise/kruise/apis/apps/v1beta1"
 	kruiseclientset "github.com/openkruise/kruise/pkg/client/clientset/versioned"
 	"github.com/openkruise/kruise/pkg/util"
 )
@@ -100,6 +101,63 @@ func (t *WorkloadSpreadTester) NewBaseCloneSet(namespace string) *appsv1alpha1.C
 			},
 		},
 	}
+}
+
+func (t *WorkloadSpreadTester) NewBaseHeadlessStatefulSet(namespace string) (*appsv1alpha1.StatefulSet, *corev1.Service) {
+	statefulset := &appsv1alpha1.StatefulSet{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "CloneSet",
+			APIVersion: appsv1alpha1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "busybox",
+			Namespace: namespace,
+		},
+		Spec: appsv1alpha1.StatefulSetSpec{
+			Replicas: utilpointer.Int32Ptr(2),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": namespace,
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": namespace,
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "main",
+							Image: imageutils.GetE2EImage(imageutils.Httpd),
+							//Command: []string{"/bin/sh", "-c", "sleep 10000000"},
+						},
+					},
+				},
+			},
+		},
+	}
+	headlessSVC := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "busybox",
+			Namespace: namespace,
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{
+				"app": namespace,
+			},
+			ClusterIP: corev1.ClusterIPNone,
+			Ports: []corev1.ServicePort{
+				{
+					Name: "web-port",
+					Port: 8080,
+				},
+			},
+		},
+	}
+
+	return statefulset, headlessSVC
 }
 
 func (t *WorkloadSpreadTester) NewBaseJob(namespace string) *batchv1.Job {
@@ -229,6 +287,21 @@ func (t *WorkloadSpreadTester) CreateCloneSet(cloneSet *appsv1alpha1.CloneSet) *
 	return cloneSet
 }
 
+func (t *WorkloadSpreadTester) CreateStatefulSet(statefulSet *appsv1alpha1.StatefulSet) *appsv1beta1.StatefulSet {
+	Logf("create statefulSet (%s/%s)", statefulSet.Namespace, statefulSet.Name)
+	_, err := t.kc.AppsV1alpha1().StatefulSets(statefulSet.Namespace).Create(context.TODO(), statefulSet, metav1.CreateOptions{})
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	Logf("create statefulSet (%s/%s) success", statefulSet.Namespace, statefulSet.Name)
+	asts, _ := t.kc.AppsV1beta1().StatefulSets(statefulSet.Namespace).Get(context.TODO(), statefulSet.Name, metav1.GetOptions{})
+	return asts
+}
+
+func (t *WorkloadSpreadTester) CreateService(svc *corev1.Service) {
+	Logf("create Service (%s/%s)", svc.Namespace, svc.Name)
+	_, err := t.C.CoreV1().Services(svc.Namespace).Create(context.TODO(), svc, metav1.CreateOptions{})
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+}
+
 func (t *WorkloadSpreadTester) CreateDeployment(deployment *appsv1.Deployment) *appsv1.Deployment {
 	Logf("create Deployment (%s/%s)", deployment.Namespace, deployment.Name)
 	_, err := t.C.AppsV1().Deployments(deployment.Namespace).Create(context.TODO(), deployment, metav1.CreateOptions{})
@@ -264,6 +337,25 @@ func (t *WorkloadSpreadTester) WaitForCloneSetRunning(cloneSet *appsv1alpha1.Clo
 		Failf("Failed waiting for cloneSet to enter running: %v", pollErr)
 	}
 	Logf("wait cloneSet (%s/%s) running success", cloneSet.Namespace, cloneSet.Name)
+}
+
+func (t *WorkloadSpreadTester) WaitForStatefulSetRunning(statefulSet *appsv1beta1.StatefulSet) {
+	pollErr := wait.PollImmediate(time.Second, time.Minute*10,
+		func() (bool, error) {
+			inner, err := t.kc.AppsV1beta1().StatefulSets(statefulSet.Namespace).Get(context.TODO(), statefulSet.Name, metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
+			if inner.Generation == inner.Status.ObservedGeneration && *inner.Spec.Replicas == inner.Status.ReadyReplicas &&
+				*inner.Spec.Replicas == inner.Status.Replicas && *inner.Spec.Replicas == inner.Status.UpdatedReplicas {
+				return true, nil
+			}
+			return false, nil
+		})
+	if pollErr != nil {
+		Failf("Failed waiting for statefulSet to enter running: %v", pollErr)
+	}
+	Logf("wait statefulSet (%s/%s) running success", statefulSet.Namespace, statefulSet.Name)
 }
 
 func (t *WorkloadSpreadTester) WaitForCloneSetRunReplicas(cloneSet *appsv1alpha1.CloneSet, replicas int32) {


### PR DESCRIPTION
Signed-off-by: mingzhou.swx <mingzhou.swx@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

StatefulSet has special logic about pod assignment for subsets. For example, suppose that we have the following sub sets config:
```
subsets:
- name: subset-a
  maxReplicas: 5
- name: subset-b
  maxReplicas: 5
- name: subset-c
```
the pods with order within [0, 5) will be assigned to subset-a;
the pods with order within [5, 10) will be assigned to subset-b;
the pods with order within [10, inf) will be assigned to subset-c.


**Note:**
1. **DO NOT SUPPORT set percentage as `subset[x].maxReplicas` for all StatefulSet;**
2. **DO NOT SUPPORT reserveOrdinals feature for Advanced StatefulSet;**
