### PR TITLE
Store historical patchPodMetadata field for SidecarSet

### DIFF
--- a/pkg/control/sidecarcontrol/history_control.go
+++ b/pkg/control/sidecarcontrol/history_control.go
@@ -264,6 +264,7 @@ func copySidecarSetSpecRevision(dst, src map[string]interface{}) {
 	dst["containers"] = src["containers"]
 	dst["initContainers"] = src["initContainers"]
 	dst["imagePullSecrets"] = src["imagePullSecrets"]
+	dst["patchPodMetadata"] = src["patchPodMetadata"]
 }
 
 func restoreRevisionInfo(sidecarSet *appsv1alpha1.SidecarSet, revision *apps.ControllerRevision) error {

--- a/test/e2e/policy/podunavailablebudget.go
+++ b/test/e2e/policy/podunavailablebudget.go
@@ -965,6 +965,7 @@ var _ = SIGDescribe("PodUnavailableBudget", func() {
 				return nowStatus
 			}, 30*time.Second, time.Second).Should(gomega.Equal(expectStatus))
 
+			time.Sleep(5 * time.Second)
 			// check now pod
 			pods, err := sidecarTester.GetSelectorPods(cloneset.Namespace, cloneset.Spec.Selector)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())


### PR DESCRIPTION
Signed-off-by: mingzhou.swx <mingzhou.swx@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
1. store history `patchPodMetadata` field for SidecarSet;
2. make sidecar injection logic more robust;
