### PR TITLE
feat(imagePullJob): add type for pullPolicy like k8s imagePullPolicy

### DIFF
--- a/apis/apps/defaults/v1alpha1.go
+++ b/apis/apps/defaults/v1alpha1.go
@@ -364,4 +364,7 @@ func SetDefaultsImagePullJob(obj *v1alpha1.ImagePullJob) {
 	if obj.Spec.PullPolicy.BackoffLimit == nil {
 		obj.Spec.PullPolicy.BackoffLimit = utilpointer.Int32Ptr(3)
 	}
+	if obj.Spec.PullPolicy.Type == "" {
+		obj.Spec.PullPolicy.Type = v1alpha1.PullIfNotPresent
+	}
 }

--- a/apis/apps/v1alpha1/broadcastjob_types.go
+++ b/apis/apps/v1alpha1/broadcastjob_types.go
@@ -92,6 +92,18 @@ const (
 	Never CompletionPolicyType = "Never"
 )
 
+// PullPolicyType indicates the type of pull policy
+type PullPolicyType string
+
+const (
+	// PullAlways means the job always attempts to pull the latest image.
+	PullAlways PullPolicyType = "Always"
+
+	// PullIfNotPresent means the job pulls if the image isn't present on disk.
+	// This is the default PullPolicyType.
+	PullIfNotPresent PullPolicyType = "IfNotPresent"
+)
+
 // BroadcastJobStatus defines the observed state of BroadcastJob
 type BroadcastJobStatus struct {
 	// The latest available observations of an object's current state.

--- a/apis/apps/v1alpha1/imagepulljob_types.go
+++ b/apis/apps/v1alpha1/imagepulljob_types.go
@@ -83,6 +83,11 @@ type ImagePullJobNodeSelector struct {
 
 // PullPolicy defines the policy of the pulling task
 type PullPolicy struct {
+	// Specifies the type of Pod ImagePullPolicy of the pulling task.
+	// Defaults to IfNotPresent
+	// +optional
+	Type PullPolicyType `json:"type,omitempty"`
+
 	// Specifies the timeout of the pulling task.
 	// Defaults to 600
 	// +optional

--- a/apis/apps/v1alpha1/nodeimage_types.go
+++ b/apis/apps/v1alpha1/nodeimage_types.go
@@ -90,6 +90,11 @@ type ImageTagPullPolicy struct {
 	// +optional
 	BackoffLimit *int32 `json:"backoffLimit,omitempty"`
 
+	// Specifies the Pod ImagePullPolicy of the pulling task.
+	// Defaults to IfNotPresent
+	// +optional
+	Type PullPolicyType `json:"type,omitempty"`
+
 	// TTLSecondsAfterFinished limits the lifetime of a pulling task that has finished execution (either Complete or Failed).
 	// If this field is set, ttlSecondsAfterFinished after the task finishes, it is eligible to be automatically deleted.
 	// If this field is unset, the task won't be automatically deleted.

--- a/config/crd/bases/apps.kruise.io_imagepulljobs.yaml
+++ b/config/crd/bases/apps.kruise.io_imagepulljobs.yaml
@@ -165,6 +165,10 @@ spec:
                       to 600
                     format: int32
                     type: integer
+                  type:
+                    description: Specifies the type of Pod ImagePullPolicy of the
+                      pulling task. Defaults to IfNotPresent
+                    type: string
                 type: object
               pullSecrets:
                 description: ImagePullSecrets is an optional list of references to

--- a/config/crd/bases/apps.kruise.io_nodeimages.yaml
+++ b/config/crd/bases/apps.kruise.io_nodeimages.yaml
@@ -198,6 +198,10 @@ spec:
                                   after it finishes.
                                 format: int32
                                 type: integer
+                              type:
+                                description: Specifies the Pod ImagePullPolicy of
+                                  the pulling task. Defaults to IfNotPresent
+                                type: string
                             type: object
                           tag:
                             description: Specifies the image tag

--- a/pkg/controller/imagepulljob/imagepulljob_utils.go
+++ b/pkg/controller/imagepulljob/imagepulljob_utils.go
@@ -78,6 +78,7 @@ func getImagePullPolicy(job *appsv1alpha1.ImagePullJob) *appsv1alpha1.ImageTagPu
 	if job.Spec.PullPolicy != nil {
 		pullPolicy.BackoffLimit = job.Spec.PullPolicy.BackoffLimit
 		pullPolicy.TimeoutSeconds = job.Spec.PullPolicy.TimeoutSeconds
+		pullPolicy.Type = job.Spec.PullPolicy.Type
 	}
 	if job.Spec.CompletionPolicy.Type == appsv1alpha1.Never {
 		pullPolicy.TTLSecondsAfterFinished = getTTLSecondsForNever()

--- a/pkg/daemon/imagepuller/imagepuller_worker.go
+++ b/pkg/daemon/imagepuller/imagepuller_worker.go
@@ -424,11 +424,13 @@ func (w *pullWorker) doPullImage(ctx context.Context, newStatus *appsv1alpha1.Im
 	startTime := metav1.Now()
 
 	klog.Infof("Worker is starting to pull image %s:%s version %v", w.name, tag, w.tagSpec.Version)
-
-	if _, e := w.getImageInfo(ctx); e == nil {
-		klog.Infof("Image %s:%s is already exists", w.name, tag)
-		newStatus.Progress = 100
-		return nil
+	// When PullPolicy type is always, there is no need to check whether there is an image locally
+	if w.tagSpec.PullPolicy.Type != appsv1alpha1.PullAlways {
+		if _, e := w.getImageInfo(ctx); e == nil {
+			klog.Infof("Image %s:%s is already exists", w.name, tag)
+			newStatus.Progress = 100
+			return nil
+		}
 	}
 
 	// make it asynchronous for CRI runtime will block in pulling image


### PR DESCRIPTION
Signed-off-by: s1ark <maxinlin@vip.qq.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

When you need to overwrite/preheat the existing image or latest tag image on the machine, you need to set a PullPolicy that is the same as the ImagePullPolicy of k8s.This PR provides configuration to solve this problem.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

https://github.com/openkruise/kruise/issues/1267

### Ⅲ. Describe how to verify it
Everythings is ok in our cluster.

### Ⅳ. Special notes for reviews

