### PR TITLE
Performance optimization for workloadSpread when suitable subset maxReplicas is niil

### DIFF
--- a/pkg/util/workloadspread/workloadspread.go
+++ b/pkg/util/workloadspread/workloadspread.go
@@ -458,6 +458,10 @@ func (h *Handler) updateSubsetForPod(ws *appsv1alpha1.WorkloadSpread,
 				ws.Namespace, ws.Name, pod.Name)
 			return false, nil, ""
 		}
+		// no need to update WorkloadSpread status if MaxReplicas == nil
+		if suitableSubset.MissingReplicas == -1 {
+			return false, suitableSubset, ""
+		}
 		if suitableSubset.CreatingPods == nil {
 			suitableSubset.CreatingPods = map[string]metav1.Time{}
 		}
@@ -482,6 +486,9 @@ func (h *Handler) updateSubsetForPod(ws *appsv1alpha1.WorkloadSpread,
 		if suitableSubset == nil {
 			klog.V(5).Infof("Pod (%s/%s) matched WorkloadSpread (%s) not found Subset(%s)", ws.Namespace, pod.Name, ws.Name, injectWS.Subset)
 			return false, nil, ""
+		}
+		if suitableSubset.MissingReplicas == -1 {
+			return false, suitableSubset, ""
 		}
 		if suitableSubset.DeletingPods == nil {
 			suitableSubset.DeletingPods = map[string]metav1.Time{}

--- a/pkg/util/workloadspread/workloadspread_test.go
+++ b/pkg/util/workloadspread/workloadspread_test.go
@@ -163,7 +163,8 @@ func TestWorkloadSpreadCreatePodWithoutFullName(t *testing.T) {
 	ws := workloadSpreadDemo.DeepCopy()
 	ws.Status.SubsetStatuses[0].MissingReplicas = 0
 	subset := appsv1alpha1.WorkloadSpreadSubset{
-		Name: "subset-b",
+		Name:        "subset-b",
+		MaxReplicas: &intstr.IntOrString{Type: intstr.Int, IntVal: 2},
 		RequiredNodeSelectorTerm: &corev1.NodeSelectorTerm{
 			MatchExpressions: []corev1.NodeSelectorRequirement{
 				{
@@ -177,7 +178,7 @@ func TestWorkloadSpreadCreatePodWithoutFullName(t *testing.T) {
 	ws.Spec.Subsets = append(ws.Spec.Subsets, subset)
 	status := appsv1alpha1.WorkloadSpreadSubsetStatus{
 		Name:            "subset-b",
-		MissingReplicas: -1,
+		MissingReplicas: 2,
 		CreatingPods:    map[string]metav1.Time{},
 		DeletingPods:    map[string]metav1.Time{},
 	}
@@ -365,7 +366,6 @@ func TestWorkloadSpreadMutatingPod(t *testing.T) {
 				}
 				demo.Status.SubsetStatuses = append(demo.Status.SubsetStatuses, status)
 				demo.ResourceVersion = "1"
-				demo.Status.SubsetStatuses[1].CreatingPods[podDemo.Name] = metav1.Time{Time: defaultTime}
 				return demo
 			},
 		},
@@ -493,7 +493,6 @@ func TestWorkloadSpreadMutatingPod(t *testing.T) {
 				workloadSpread := workloadSpreadDemo.DeepCopy()
 				workloadSpread.ResourceVersion = "1"
 				workloadSpread.Status.SubsetStatuses[0].MissingReplicas = -1
-				workloadSpread.Status.SubsetStatuses[0].CreatingPods[podDemo.Name] = metav1.Time{Time: defaultTime}
 				return workloadSpread
 			},
 		},
@@ -738,7 +737,6 @@ func TestWorkloadSpreadMutatingPod(t *testing.T) {
 			expectWorkloadSpread: func() *appsv1alpha1.WorkloadSpread {
 				workloadSpread := workloadSpreadDemo.DeepCopy()
 				workloadSpread.Status.SubsetStatuses[0].MissingReplicas = -1
-				workloadSpread.Status.SubsetStatuses[0].DeletingPods[podDemo.Name] = metav1.Time{Time: defaultTime}
 				return workloadSpread
 			},
 		},


### PR DESCRIPTION
Signed-off-by: mingzhou.swx <mingzhou.swx@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Optimize workloadSpread when suitable subset maxReplicas is `nil`.

In this situation, update status is meaningless because the subset is unlimited for replicas.
