### PR TITLE
sidecarset support pods ns(kube-system, kube-public)

### DIFF
--- a/pkg/control/sidecarcontrol/util.go
+++ b/pkg/control/sidecarcontrol/util.go
@@ -62,7 +62,7 @@ const (
 
 var (
 	// SidecarIgnoredNamespaces specifies the namespaces where Pods won't get injected
-	SidecarIgnoredNamespaces = []string{"kube-system", "kube-public"}
+	// SidecarIgnoredNamespaces = []string{"kube-system", "kube-public"}
 	// SubPathExprEnvReg format: $(ODD_NAME)、$(POD_NAME)...
 	SubPathExprEnvReg, _ = regexp.Compile(`\$\(([-._a-zA-Z][-._a-zA-Z0-9]*)\)`)
 )
@@ -95,11 +95,11 @@ func PodMatchedSidecarSet(pod *corev1.Pod, sidecarSet appsv1alpha1.SidecarSet) (
 
 // IsActivePod determines the pod whether need be injected and updated
 func IsActivePod(pod *corev1.Pod) bool {
-	for _, namespace := range SidecarIgnoredNamespaces {
+	/*for _, namespace := range SidecarIgnoredNamespaces {
 		if pod.Namespace == namespace {
 			return false
 		}
-	}
+	}*/
 	return kubecontroller.IsPodActive(pod)
 }
 

--- a/pkg/controller/sidecarset/sidecarset_processor.go
+++ b/pkg/controller/sidecarset/sidecarset_processor.go
@@ -269,9 +269,8 @@ func (p *Processor) getMatchingPods(s *appsv1alpha1.SidecarSet) ([]*corev1.Pod, 
 	}
 
 	// filter out pods that don't require updated, include the following:
-	// 1. Deletion pod
-	// 2. ignore namespace: "kube-system", "kube-public"
-	// 3. never be injected sidecar container
+	// 1. inActive pod
+	// 2. never be injected sidecar container
 	var filteredPods []*corev1.Pod
 	for _, pod := range selectedPods {
 		if sidecarcontrol.IsActivePod(pod) && sidecarcontrol.IsPodInjectedSidecarSet(pod, s) &&

--- a/pkg/webhook/pod/mutating/sidecarset.go
+++ b/pkg/webhook/pod/mutating/sidecarset.go
@@ -45,9 +45,7 @@ func (h *PodCreateHandler) sidecarsetMutatingPod(ctx context.Context, req admiss
 		req.AdmissionRequest.Resource.Resource != "pods" {
 		return true, nil
 	}
-	// filter out pods that don't require inject, include the following:
-	// 1. Deletion pod
-	// 2. ignore namespace: "kube-system", "kube-public"
+	// filter out pods that don't require inject
 	if !sidecarcontrol.IsActivePod(pod) {
 		return true, nil
 	}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
Currently sidecarSet ignores the pods under kube-system and kube-public. However, some system components actually have similar requirements. So, remove the restriction.