### PR TITLE
fix InPlaceUpdateEnvFromMetadata bug

### DIFF
--- a/pkg/daemon/containermeta/container_meta_controller.go
+++ b/pkg/daemon/containermeta/container_meta_controller.go
@@ -391,7 +391,7 @@ func wrapEnvGetter(criRuntime criapi.RuntimeService, containerID, logID string) 
 			}
 			lines := strings.Split(strings.TrimSpace(string(stdout)), "\n")
 			for _, l := range lines {
-				words := strings.Split(strings.TrimSpace(l), "=")
+				words := strings.SplitN(strings.TrimSpace(l), "=", 2)
 				if len(words) == 2 {
 					envMap[words[0]] = words[1]
 				}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

fix InPlaceUpdateEnvFromMetadata bug:

When injecting environment variables via annoation like:
```
- name: PKG_VERSION
      valueFrom:
        fieldRef:
          apiVersion: v1
          fieldPath: metadata.annotations['DeployTime']
```
annotation DeployTime value is: 2022-10-19 17:55:29.892870834 +0800 CST m=+1.020884618.

Due to the Split,the container will be restarted constantly.