### PR TITLE
enable mcloneset deleting pvc when pod hanging

### DIFF
--- a/apis/apps/v1alpha1/cloneset_types.go
+++ b/apis/apps/v1alpha1/cloneset_types.go
@@ -93,6 +93,10 @@ type CloneSetScaleStrategy struct {
 	// The scale will fail if the number of unavailable pods were greater than this MaxUnavailable at scaling up.
 	// MaxUnavailable works only when scaling up.
 	MaxUnavailable *intstr.IntOrString `json:"maxUnavailable,omitempty"`
+
+	// Indicate if cloneset will reuse already existed pvc to
+	// rebuild a new pod
+	DisablePVCReuse bool `json:"disablePVCReuse,omitempty"`
 }
 
 // CloneSetUpdateStrategy defines strategies for pods update.

--- a/config/crd/bases/apps.kruise.io_clonesets.yaml
+++ b/config/crd/bases/apps.kruise.io_clonesets.yaml
@@ -172,6 +172,10 @@ spec:
                 description: ScaleStrategy indicates the ScaleStrategy that will be
                   employed to create and delete Pods in the CloneSet.
                 properties:
+                  disablePVCReuse:
+                    description: Indicate if cloneset will reuse already existed pvc
+                      to rebuild a new pod
+                    type: boolean
                   maxUnavailable:
                     anyOf:
                     - type: integer

--- a/config/crd/bases/apps.kruise.io_uniteddeployments.yaml
+++ b/config/crd/bases/apps.kruise.io_uniteddeployments.yaml
@@ -670,6 +670,10 @@ spec:
                               that will be employed to create and delete Pods in the
                               CloneSet.
                             properties:
+                              disablePVCReuse:
+                                description: Indicate if cloneset will reuse already
+                                  existed pvc to rebuild a new pod
+                                type: boolean
                               maxUnavailable:
                                 anyOf:
                                 - type: integer

--- a/pkg/controller/cloneset/sync/cloneset_scale.go
+++ b/pkg/controller/cloneset/sync/cloneset_scale.go
@@ -23,6 +23,11 @@ import (
 	"sync"
 	"sync/atomic"
 
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog/v2"
+
 	appspub "github.com/openkruise/kruise/apis/apps/pub"
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
 	clonesetcore "github.com/openkruise/kruise/pkg/controller/cloneset/core"
@@ -30,10 +35,6 @@ import (
 	"github.com/openkruise/kruise/pkg/util"
 	"github.com/openkruise/kruise/pkg/util/expectations"
 	"github.com/openkruise/kruise/pkg/util/lifecycle"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/rand"
-	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/klog/v2"
 )
 
 const (

--- a/pkg/util/ownerref.go
+++ b/pkg/util/ownerref.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2022 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func HasOwnerRef(target, owner metav1.Object) bool {
+	ownerUID := owner.GetUID()
+	for _, ownerRef := range target.GetOwnerReferences() {
+		if ownerRef.UID == ownerUID {
+			return true
+		}
+	}
+	return false
+}
+
+func RemoveOwnerRef(target, owner metav1.Object) bool {
+	if !HasOwnerRef(target, owner) {
+		return false
+	}
+	ownerUID := owner.GetUID()
+	oldRefs := target.GetOwnerReferences()
+	newRefs := make([]metav1.OwnerReference, len(oldRefs)-1)
+	skip := 0
+	for i := range oldRefs {
+		if oldRefs[i].UID == ownerUID {
+			skip = -1
+		} else {
+			newRefs[i+skip] = oldRefs[i]
+		}
+	}
+	target.SetOwnerReferences(newRefs)
+	return true
+}
+
+func SetOwnerRef(target, owner metav1.Object, ownerType metav1.TypeMeta) bool {
+	if HasOwnerRef(target, owner) {
+		return false
+	}
+	ownerRefs := append(
+		target.GetOwnerReferences(),
+		*metav1.NewControllerRef(owner, ownerType.GroupVersionKind()),
+	)
+	target.SetOwnerReferences(ownerRefs)
+	return true
+}

--- a/pkg/util/ownerref_test.go
+++ b/pkg/util/ownerref_test.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2022 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
+)
+
+func TestHasOwnerRef(t *testing.T) {
+	pvc := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "datadir-foo-id1",
+			Labels: map[string]string{
+				appsv1alpha1.CloneSetInstanceID: "id1",
+				"foo":                           "bar",
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         "v1",
+					Kind:               "Pod",
+					Name:               "foo",
+					UID:                "test",
+					Controller:         func() *bool { a := true; return &a }(),
+					BlockOwnerDeletion: func() *bool { a := true; return &a }(),
+				},
+			},
+			ResourceVersion: "1",
+		},
+		Spec: v1.PersistentVolumeClaimSpec{
+			Resources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceStorage: resource.MustParse("10"),
+				},
+			},
+		},
+	}
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "foo",
+			UID:       "test",
+		},
+	}
+
+	if !HasOwnerRef(pvc, pod) {
+		t.Fatalf("expect pvc %v has pod %v ownerref", pvc, pod)
+	}
+}
+
+func TestRemoveOnwer(t *testing.T) {
+	pvc := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "datadir-foo-id1",
+			Labels: map[string]string{
+				appsv1alpha1.CloneSetInstanceID: "id1",
+				"foo":                           "bar",
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         "v1",
+					Kind:               "Pod",
+					Name:               "foo",
+					UID:                "test",
+					Controller:         func() *bool { a := true; return &a }(),
+					BlockOwnerDeletion: func() *bool { a := true; return &a }(),
+				},
+			},
+			ResourceVersion: "1",
+		},
+		Spec: v1.PersistentVolumeClaimSpec{
+			Resources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceStorage: resource.MustParse("10"),
+				},
+			},
+		},
+	}
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "foo",
+			UID:       "test",
+		},
+	}
+
+	if !RemoveOwnerRef(pvc, pod) {
+		t.Fatalf("expect pvc %v to remove pod %v ownerref", pvc, pod)
+	}
+
+	if HasOwnerRef(pvc, pod) {
+		t.Fatalf("expect pvc %v has no pod %v ownerref", pvc, pod)
+	}
+}
+
+func TestSetOwnerRef(t *testing.T) {
+	pvc := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "datadir-foo-id1",
+			Labels: map[string]string{
+				appsv1alpha1.CloneSetInstanceID: "id1",
+				"foo":                           "bar",
+			},
+			ResourceVersion: "1",
+		},
+		Spec: v1.PersistentVolumeClaimSpec{
+			Resources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceStorage: resource.MustParse("10"),
+				},
+			},
+		},
+	}
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "foo",
+			UID:       "test",
+		},
+	}
+
+	if !SetOwnerRef(pvc, pod, metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"}) {
+		t.Fatalf("expect pvc %v has no pod %v ownerref", pvc, pod)
+	}
+
+	if !HasOwnerRef(pvc, pod) {
+		t.Fatalf("expect pvc %s has pod %v ownerref", pvc, pod)
+	}
+}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
fixes #1099


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #1099

### Ⅲ. Describe how to verify it
1. Create a cloneset with setting "cleanUpPVC=false" and PVC
2. Edit a pod created by  cloneset with a finalizer
3. Delete the above pod and verify the new pod can't be created with name conflict
4. Edit cloneset with setting "cleanUpPVC=true" 
5. Verify a new pod with new PVC has been created and old pod hangs in terminating state.

### Ⅳ. Special notes for reviews

