### PR TITLE
pub support to configure Evict,Delete,Update Operation

### DIFF
--- a/apis/policy/v1alpha1/podunavailablebudget_types.go
+++ b/apis/policy/v1alpha1/podunavailablebudget_types.go
@@ -27,14 +27,16 @@ import (
 type PubOperation string
 
 const (
-	// PubProtectOperationAnnotation indicates the pub protected Operation[DELETE,UPDATE]
-	// the following indicates the pub only protect DELETE,UPDATE Operation
-	// annotations[kruise.io/pub-protect-operations]=DELETE,UPDATE
-	// if the annotations do not exist, the default DELETE and UPDATE are protected
+	// PubProtectOperationAnnotation indicates the pub protected Operation[DELETE,UPDATE,EVICT]
+	// if annotations[kruise.io/pub-protect-operations]=EVICT indicates the pub only protect evict pod
+	// if the annotations do not exist, the default DELETE,EVICT,UPDATE are protected
 	PubProtectOperationAnnotation = "kruise.io/pub-protect-operations"
 	// pod webhook operation
 	PubUpdateOperation PubOperation = "UPDATE"
 	PubDeleteOperation PubOperation = "DELETE"
+	PubEvictOperation  PubOperation = "EVICT"
+	// Marked the pod will not be pub-protected, solving the scenario of force pod deletion
+	PodPubNoProtectionAnnotation = "pub.kruise.io/no-protect"
 )
 
 // PodUnavailableBudgetSpec defines the desired state of PodUnavailableBudget

--- a/pkg/control/pubcontrol/pub_control_utils.go
+++ b/pkg/control/pubcontrol/pub_control_utils.go
@@ -51,8 +51,6 @@ var ConflictRetry = wait.Backoff{
 }
 
 const (
-	// Marked pods will not be pub-protected, solving the scenario of force pod deletion
-	PodPubNoProtectionAnnotation = "pub.kruise.io/no-protect"
 	// related-pub annotation in pod
 	PodRelatedPubAnnotation = "kruise.io/related-pub"
 )
@@ -64,8 +62,8 @@ func PodUnavailableBudgetValidatePod(client client.Client, control PubControl, p
 	klog.V(3).Infof("validating pod(%s/%s) operation(%s) for PodUnavailableBudget", pod.Namespace, pod.Name, operation)
 	// pods that contain annotations[pod.kruise.io/pub-no-protect]="true" will be ignore
 	// and will no longer check the pub quota
-	if pod.Annotations[PodPubNoProtectionAnnotation] == "true" {
-		klog.V(3).Infof("pod(%s/%s) contains annotations[%s]=true, then don't need check pub", pod.Namespace, pod.Name, PodPubNoProtectionAnnotation)
+	if pod.Annotations[policyv1alpha1.PodPubNoProtectionAnnotation] == "true" {
+		klog.V(3).Infof("pod(%s/%s) contains annotations[%s]=true, then don't need check pub", pod.Namespace, pod.Name, policyv1alpha1.PodPubNoProtectionAnnotation)
 		return true, "", nil
 		// If the pod is not ready, it doesn't count towards healthy and we should not decrement
 	} else if !control.IsPodReady(pod) {

--- a/pkg/webhook/pod/validating/pod_unavailable_budget.go
+++ b/pkg/webhook/pod/validating/pod_unavailable_budget.go
@@ -34,23 +34,11 @@ import (
 // +kubebuilder:rbac:groups=policy.kruise.io,resources=podunavailablebudgets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=policy.kruise.io,resources=podunavailablebudgets/status,verbs=get;update;patch
 
-var (
-	// IgnoredNamespaces specifies the namespaces where Pods won't get injected
-	IgnoredNamespaces = []string{"kube-system", "kube-public"}
-)
-
 // parameters:
 // 1. allowed(bool) whether to allow this request
 // 2. reason(string)
 // 3. err(error)
 func (p *PodCreateHandler) podUnavailableBudgetValidatingPod(ctx context.Context, req admission.Request) (bool, string, error) {
-	// ignore kube-system, kube-public
-	for _, namespace := range IgnoredNamespaces {
-		if req.Namespace == namespace {
-			return true, "", nil
-		}
-	}
-
 	var checkPod *corev1.Pod
 	var dryRun bool
 	var operation policyv1alpha1.PubOperation
@@ -131,7 +119,7 @@ func (p *PodCreateHandler) podUnavailableBudgetValidatingPod(ctx context.Context
 		if err = p.Client.Get(ctx, key, checkPod); err != nil {
 			return false, "", err
 		}
-		operation = policyv1alpha1.PubDeleteOperation
+		operation = policyv1alpha1.PubEvictOperation
 	}
 
 	if checkPod.Annotations[pubcontrol.PodRelatedPubAnnotation] == "" {

--- a/test/e2e/policy/podunavailablebudget.go
+++ b/test/e2e/policy/podunavailablebudget.go
@@ -27,7 +27,6 @@ import (
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
 	policyv1alpha1 "github.com/openkruise/kruise/apis/policy/v1alpha1"
 	kruiseclientset "github.com/openkruise/kruise/pkg/client/clientset/versioned"
-	"github.com/openkruise/kruise/pkg/control/pubcontrol"
 	"github.com/openkruise/kruise/test/e2e/framework"
 	corev1 "k8s.io/api/core/v1"
 	policy "k8s.io/api/policy/v1beta1"
@@ -154,7 +153,7 @@ var _ = SIGDescribe("PodUnavailableBudget", func() {
 			if podIn.Annotations == nil {
 				podIn.Annotations = map[string]string{}
 			}
-			podIn.Annotations[pubcontrol.PodPubNoProtectionAnnotation] = "true"
+			podIn.Annotations[policyv1alpha1.PodPubNoProtectionAnnotation] = "true"
 			_, err = c.CoreV1().Pods(deployment.Namespace).Update(context.TODO(), podIn, metav1.UpdateOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			time.Sleep(time.Second)


### PR DESCRIPTION
Signed-off-by: liheng.zms <liheng.zms@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Support to separate configure the operation of protection. As follows, pub.annotations[kruise.io/pub-protect-operations]=EVICT,DELETE 
