### PR TITLE
pub support get total replicas from annotations

### DIFF
--- a/apis/policy/v1alpha1/podunavailablebudget_types.go
+++ b/apis/policy/v1alpha1/podunavailablebudget_types.go
@@ -35,6 +35,9 @@ const (
 	PubUpdateOperation PubOperation = "UPDATE"
 	PubDeleteOperation PubOperation = "DELETE"
 	PubEvictOperation  PubOperation = "EVICT"
+	// PubProtectTotalReplicas indicates the pub protected total replicas, rather than workload.spec.replicas.
+	// and must be used with pub.spec.selector.
+	PubProtectTotalReplicas = "pub.kruise.io/protect-total-replicas"
 	// Marked the pod will not be pub-protected, solving the scenario of force pod deletion
 	PodPubNoProtectionAnnotation = "pub.kruise.io/no-protect"
 )

--- a/pkg/control/pubcontrol/pub_control_utils.go
+++ b/pkg/control/pubcontrol/pub_control_utils.go
@@ -78,6 +78,9 @@ func PodUnavailableBudgetValidatePod(client client.Client, control PubControl, p
 		// if there is no matching PodUnavailableBudget, just return true
 	} else if pub == nil {
 		return true, "", nil
+		// if desired available == 0, then allow all request
+	} else if pub.Status.DesiredAvailable == 0 {
+		return true, "", nil
 	} else if !isNeedPubProtection(pub, operation) {
 		klog.V(3).Infof("pod(%s/%s) operation(%s) is not in pub(%s) protection", pod.Namespace, pod.Name, pub.Name)
 		return true, "", nil

--- a/pkg/control/pubcontrol/pub_control_utils_test.go
+++ b/pkg/control/pubcontrol/pub_control_utils_test.go
@@ -68,6 +68,7 @@ var (
 			UnavailablePods:    map[string]metav1.Time{},
 			DisruptedPods:      map[string]metav1.Time{},
 			UnavailableAllowed: 0,
+			DesiredAvailable:   1,
 		},
 	}
 

--- a/pkg/controller/podunavailablebudget/podunavailablebudget_controller.go
+++ b/pkg/controller/podunavailablebudget/podunavailablebudget_controller.go
@@ -145,6 +145,9 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 			}
 			return false
 		},
+		DeleteFunc: func(deleteEvent event.DeleteEvent) bool {
+			return true
+		},
 	}); err != nil {
 		return err
 	}
@@ -158,6 +161,9 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 				return true
 			}
 			return false
+		},
+		DeleteFunc: func(deleteEvent event.DeleteEvent) bool {
+			return true
 		},
 	}); err != nil {
 		return err
@@ -173,6 +179,9 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 			}
 			return false
 		},
+		DeleteFunc: func(deleteEvent event.DeleteEvent) bool {
+			return true
+		},
 	}); err != nil {
 		return err
 	}
@@ -186,6 +195,9 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 				return true
 			}
 			return false
+		},
+		DeleteFunc: func(deleteEvent event.DeleteEvent) bool {
+			return true
 		},
 	}); err != nil {
 		return err
@@ -301,7 +313,6 @@ func (r *ReconcilePodUnavailableBudget) syncPodUnavailableBudget(pub *policyv1al
 			} else {
 				pubClone = pub.DeepCopy()
 			}
-
 			informerCached := &policyv1alpha1.PodUnavailableBudget{}
 			if err := r.Get(context.TODO(), types.NamespacedName{Namespace: pub.Namespace,
 				Name: pub.Name}, informerCached); err == nil {

--- a/pkg/util/controllerfinder/controller_finder.go
+++ b/pkg/util/controllerfinder/controller_finder.go
@@ -120,9 +120,10 @@ func (r *ControllerFinder) GetExpectedScaleForPods(pods []*corev1.Pod) (int32, e
 		workload, err := r.GetScaleAndSelectorForRef(ref.APIVersion, ref.Kind, pod.Namespace, ref.Name, ref.UID)
 		if err != nil && !errors.IsNotFound(err) {
 			return 0, err
-		}
-		if workload != nil && workload.Metadata.DeletionTimestamp.IsZero() {
-			controllerScale[workload.UID] = workload.Scale
+		} else if workload != nil && workload.Metadata.DeletionTimestamp.IsZero() {
+			controllerScale[ref.UID] = workload.Scale
+		} else {
+			controllerScale[ref.UID] = 0
 		}
 	}
 

--- a/pkg/util/controllerfinder/pods_finder.go
+++ b/pkg/util/controllerfinder/pods_finder.go
@@ -44,7 +44,7 @@ func (r *ControllerFinder) GetPodsForRef(apiVersion, kind, ns, name string, acti
 		if err != nil {
 			return nil, -1, err
 		}
-		if rs == nil {
+		if rs == nil || !rs.DeletionTimestamp.IsZero() {
 			return nil, 0, nil
 		}
 		workloadReplicas = *rs.Spec.Replicas
@@ -54,7 +54,7 @@ func (r *ControllerFinder) GetPodsForRef(apiVersion, kind, ns, name string, acti
 		obj, err := r.GetScaleAndSelectorForRef(apiVersion, kind, ns, name, "")
 		if err != nil {
 			return nil, -1, err
-		} else if obj == nil {
+		} else if obj == nil || !obj.Metadata.DeletionTimestamp.IsZero() {
 			return nil, 0, nil
 		}
 		workloadReplicas = obj.Scale
@@ -64,7 +64,7 @@ func (r *ControllerFinder) GetPodsForRef(apiVersion, kind, ns, name string, acti
 		obj, err := r.GetScaleAndSelectorForRef(apiVersion, kind, ns, name, "")
 		if err != nil {
 			return nil, -1, err
-		} else if obj == nil {
+		} else if obj == nil || !obj.Metadata.DeletionTimestamp.IsZero() {
 			return nil, 0, nil
 		}
 		workloadReplicas = obj.Scale

--- a/pkg/webhook/pod/validating/pod_unavailable_budget.go
+++ b/pkg/webhook/pod/validating/pod_unavailable_budget.go
@@ -125,15 +125,5 @@ func (p *PodCreateHandler) podUnavailableBudgetValidatingPod(ctx context.Context
 	if checkPod.Annotations[pubcontrol.PodRelatedPubAnnotation] == "" {
 		return true, "", nil
 	}
-
-	// Get the workload corresponding to the pod, if it has been deleted then it is not protected
-	if ref := metav1.GetControllerOf(checkPod); ref != nil {
-		workload, err := p.finders.GetScaleAndSelectorForRef(ref.APIVersion, ref.Kind, checkPod.Namespace, ref.Name, ref.UID)
-		if err != nil {
-			return false, "", err
-		} else if workload == nil || !workload.Metadata.DeletionTimestamp.IsZero() {
-			return true, "", nil
-		}
-	}
 	return pubcontrol.PodUnavailableBudgetValidatePod(p.Client, p.pubControl, checkPod, operation, dryRun)
 }

--- a/pkg/webhook/pod/validating/pod_unavailable_budget_test.go
+++ b/pkg/webhook/pod/validating/pod_unavailable_budget_test.go
@@ -624,6 +624,43 @@ func TestValidateEvictPodForPub(t *testing.T) {
 				return pubStatus
 			},
 		},
+		{
+			name: "evict pod, allow",
+			eviction: func() *policy.Eviction {
+				return &policy.Eviction{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod-0",
+						Namespace: "default",
+					},
+					DeleteOptions: &metav1.DeleteOptions{},
+				}
+			},
+			newPod: func() *corev1.Pod {
+				podIn := podDemo.DeepCopy()
+				return podIn
+			},
+			pub: func() *policyv1alpha1.PodUnavailableBudget {
+				pub := pubDemo.DeepCopy()
+				pub.Status = policyv1alpha1.PodUnavailableBudgetStatus{
+					TotalReplicas:      0,
+					DesiredAvailable:   0,
+					CurrentAvailable:   10,
+					UnavailableAllowed: 0,
+				}
+				return pub
+			},
+			subresource: "eviction",
+			expectAllow: true,
+			expectPubStatus: func() *policyv1alpha1.PodUnavailableBudgetStatus {
+				pubStatus := &policyv1alpha1.PodUnavailableBudgetStatus{
+					TotalReplicas:      0,
+					DesiredAvailable:   0,
+					CurrentAvailable:   10,
+					UnavailableAllowed: 0,
+				}
+				return pubStatus
+			},
+		},
 	}
 
 	for _, cs := range cases {

--- a/pkg/webhook/podunavailablebudget/validating/pub_validating_test.go
+++ b/pkg/webhook/podunavailablebudget/validating/pub_validating_test.go
@@ -153,7 +153,29 @@ func TestValidatingPub(t *testing.T) {
 				pub := pubDemo.DeepCopy()
 				pub.Spec.Selector = nil
 				pub.Spec.MinAvailable = nil
-				pub.Annotations[policyv1alpha1.PubProtectOperationAnnotation] = "DELETE"
+				pub.Annotations[policyv1alpha1.PubProtectOperationAnnotation] = string(policyv1alpha1.PubEvictOperation + "," + policyv1alpha1.PubDeleteOperation)
+				return pub
+			},
+			expectErrList: 0,
+		},
+		{
+			name: "invalid pub feature-gate annotation",
+			pub: func() *policyv1alpha1.PodUnavailableBudget {
+				pub := pubDemo.DeepCopy()
+				pub.Spec.Selector = nil
+				pub.Spec.MinAvailable = nil
+				pub.Annotations[policyv1alpha1.PubProtectTotalReplicas] = "%%"
+				return pub
+			},
+			expectErrList: 1,
+		},
+		{
+			name: "valid pub feature-gate annotation",
+			pub: func() *policyv1alpha1.PodUnavailableBudget {
+				pub := pubDemo.DeepCopy()
+				pub.Spec.Selector = nil
+				pub.Spec.MinAvailable = nil
+				pub.Annotations[policyv1alpha1.PubProtectTotalReplicas] = "1000"
 				return pub
 			},
 			expectErrList: 0,


### PR DESCRIPTION
Signed-off-by: liheng.zms <liheng.zms@alibaba-inc.com>
### Ⅰ. Describe what this PR does
At present, the PUB protection must be the Pod under the workload. But there may be no workload in some scenarios. For this scenario, pub supports obtaining total replicas via pub.annotations[kruise.io/pub-protect-total-replicas]

