### PR TITLE
Make OnFailure as default restartPolicy for BroadcastJob

### DIFF
--- a/apis/apps/defaults/v1alpha1.go
+++ b/apis/apps/defaults/v1alpha1.go
@@ -192,6 +192,11 @@ func SetDefaultsBroadcastJob(obj *v1alpha1.BroadcastJob, injectTemplateDefaults 
 	if obj.Spec.FailurePolicy.Type == "" {
 		obj.Spec.FailurePolicy.Type = v1alpha1.FailurePolicyTypeFailFast
 	}
+
+	// Default to 'OnFailure' if no restartPolicy is specified
+	if obj.Spec.Template.Spec.RestartPolicy == "" {
+		obj.Spec.Template.Spec.RestartPolicy = corev1.RestartPolicyOnFailure
+	}
 }
 
 // SetDefaults_UnitedDeployment set default values for UnitedDeployment.


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
Creation of a _BroadcastJob_ without specifying _restartPolicy_ fails with the following error:

`Error from server: error when creating "broadcastjob_kruise.yaml": admission webhook "vbroadcastjob.kb.io" denied the request: spec.template.spec.restartPolicy: Invalid value: "Always": pod restartPolicy can only be Never or OnFailure`

**Root Cause:**
_restartPolicy_ is present under spec.template.spec block. This block is defined with _PodSpec_ structure and the _restartPolicy_ element in it has a default value of _Always_.

**Solution:**
For _BroadcastJob_ changed the default value to _OnFailure_ in `/Users/surkade/Documents/dev/kruise/pkg/webhook/broadcastjob/validating/broadcastjob_create_update_handler.go` file

### Ⅱ. Does this pull request fix one issue?
No

### Ⅲ. Describe how to verify it
Create a sample _BroadcastJob_ with the following template (Do not specify restartPolicy under _spec.template.spec_:
```
apiVersion: apps.kruise.io/v1alpha1
kind: BroadcastJob
metadata:
    labels:
        app: <name>
    name: <name>
spec:
    template:
        metadata:
            labels:
                app: <name>
        spec:
            containers:
            - image: <image>
              imagePullPolicy: <policy>
              name: <name>
              ports:
              - containerPort: <port>
```
The previously mentioned error can be seen

### Ⅳ. Special notes for reviews
I have kept the new default for _restartPolicy_ as _OnFailure_. Please let me know if _Never_ would make more sense as a default.