### PR TITLE
fix the bug that pub calculates pods(deployment) totalReplicas incorrectly

### DIFF
--- a/pkg/control/pubcontrol/pub_control.go
+++ b/pkg/control/pubcontrol/pub_control.go
@@ -137,6 +137,7 @@ func (c *commonControl) IsPodStateConsistent(pod *corev1.Pod) bool {
 	sidecarSets, sidecars := getSidecarSetsInPod(pod)
 	if sidecarSets.Len() > 0 && sidecars.Len() > 0 {
 		if !sidecarcontrol.IsSidecarContainerUpdateCompleted(pod, sidecarSets, sidecars) {
+			klog.V(5).Infof("PodUnavailableBudget check Pod(%s/%s) is inconsistent", pod.Namespace, pod.Name)
 			return false
 		}
 	}

--- a/test/e2e/framework/podunavailablebudget_util.go
+++ b/test/e2e/framework/podunavailablebudget_util.go
@@ -113,7 +113,7 @@ func (s *PodUnavailableBudgetTester) NewBaseDeployment(namespace string) *apps.D
 				RollingUpdate: &apps.RollingUpdateDeployment{
 					MaxUnavailable: &intstr.IntOrString{
 						Type:   intstr.String,
-						StrVal: "100%",
+						StrVal: "50%",
 					},
 					MaxSurge: &intstr.IntOrString{
 						Type:   intstr.Int,


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
When PUB protects the Deployment, the pub controller needs to take Rs into account when calculating the totalReplicas corresponding to the Pod. 
However, the current calculation method incorrectly calculates rs.spec.replicas, for example: deployment.spec.replicas=10, which contains two rs, and the pub controller will calculate totalReplicas = 20.

```yaml
apiVersion: policy.kruise.io/v1alpha1
kind: PodUnavailableBudget
metadata:
  name: test1-pub
spec:
  maxUnavailable: 25%
  selector:
    matchLabels:
      app-name: test1
status:
  currentAvailable: 10
  desiredAvailable: 15
  totalReplicas: 20
  unavailableAllowed: 0
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: test1
spec:
  replicas: 10
  selector:
    matchLabels:
      app-name: test1
  template:
    metadata:
      labels:
        app-name: test1
```
As shown above, pub.status.totalReplicas should be 10.
