### PR TITLE
add_enhanced_livenessProbe_webhook

### DIFF
--- a/pkg/features/kruise_features.go
+++ b/pkg/features/kruise_features.go
@@ -93,6 +93,9 @@ const (
 	// PreDownloadImageForDaemonSetUpdate enables daemonset-controller to create ImagePullJobs to
 	// pre-download images for update.
 	PreDownloadImageForDaemonSetUpdate featuregate.Feature = "PreDownloadImageForDaemonSetUpdate"
+
+	// Enables a enhanced livenessProbe solution
+	EnhancedLivenessProbe featuregate.Feature = "EnhancedLivenessProbe"
 )
 
 var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
@@ -114,6 +117,7 @@ var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	SidecarSetPatchPodMetadataDefaultsAllowed: {Default: false, PreRelease: featuregate.Alpha},
 	PodProbeMarkerGate:                        {Default: false, PreRelease: featuregate.Alpha},
 	PreDownloadImageForDaemonSetUpdate:        {Default: false, PreRelease: featuregate.Alpha},
+	EnhancedLivenessProbe:                     {Default: false, PreRelease: featuregate.Alpha},
 }
 
 func init() {

--- a/pkg/webhook/pod/mutating/enhancedlivenessprobe_handler.go
+++ b/pkg/webhook/pod/mutating/enhancedlivenessprobe_handler.go
@@ -1,0 +1,90 @@
+package mutating
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/openkruise/kruise/pkg/features"
+	"github.com/openkruise/kruise/pkg/util"
+	utilfeature "github.com/openkruise/kruise/pkg/util/feature"
+	admissionv1 "k8s.io/api/admission/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+const (
+	AnnotationUsingEnhancedLiveness = "apps.kruise.io/using-enhanced-liveness"
+	AnnotationNativeLivenessContext = "apps.kruise.io/livenessprobe-context"
+)
+
+type containerLivenessProbe struct {
+	Name          string   `json:"name"`
+	LivenessProbe v1.Probe `json:"livenessProbe"`
+}
+
+func (h *PodCreateHandler) enhancedLivenessProbeWhenPodCreate(req admission.Request, pod *v1.Pod) (skip bool, err error) {
+
+	if len(req.AdmissionRequest.SubResource) > 0 ||
+		req.AdmissionRequest.Operation != admissionv1.Create ||
+		req.AdmissionRequest.Resource.Resource != "pods" {
+		return true, nil
+	}
+
+	if !util.IsPodOwnedByKruise(pod) && !utilfeature.DefaultFeatureGate.Enabled(features.EnhancedLivenessProbe) {
+		return true, nil
+	}
+
+	if !usingEnhancedLivenessProbe(pod) {
+		return true, nil
+	}
+
+	context, err := removeAndBackUpPodContainerLivenessProbe(pod)
+	if err != nil {
+		klog.Errorf("remove pod (%v/%v) container livenessProbe config and backup error: %v", pod.Namespace, pod.Name, err)
+		return false, err
+	}
+	klog.V(3).Infof("mutating add pod(%s/%s) annotation[%s]=%s", pod.Namespace, pod.Name, AnnotationNativeLivenessContext, context)
+	return false, nil
+}
+
+func removeAndBackUpPodContainerLivenessProbe(pod *v1.Pod) (string, error) {
+	if len(pod.Spec.Containers) == 0 {
+		return "", nil
+	}
+
+	containersLivenessProbe := []containerLivenessProbe{}
+	for index, _ := range pod.Spec.Containers {
+		getContainer := &pod.Spec.Containers[index]
+		if getContainer.LivenessProbe == nil {
+			continue
+		}
+		containersLivenessProbe = append(containersLivenessProbe, containerLivenessProbe{
+			Name:          getContainer.Name,
+			LivenessProbe: *getContainer.LivenessProbe,
+		})
+		getContainer.LivenessProbe = nil
+	}
+
+	if len(containersLivenessProbe) == 0 {
+		return "", nil
+	}
+	containersLivenessProbeRaw, err := json.Marshal(containersLivenessProbe)
+	if err != nil {
+		klog.Errorf("failed to json marshal %v for pod: %v/%v, err: %v",
+			containersLivenessProbe, pod.Namespace, pod.Name, err)
+		return "", fmt.Errorf("failed to json marshal %v for pod: %v/%v, err: %v",
+			containersLivenessProbe, pod.Namespace, pod.Name, err)
+	}
+	if pod.Annotations == nil {
+		pod.Annotations = map[string]string{}
+	}
+	pod.Annotations[AnnotationNativeLivenessContext] = string(containersLivenessProbeRaw)
+	return pod.Annotations[AnnotationNativeLivenessContext], nil
+}
+
+func usingEnhancedLivenessProbe(pod *v1.Pod) bool {
+	if pod.Annotations[AnnotationUsingEnhancedLiveness] == "true" {
+		return true
+	}
+	return false
+}

--- a/pkg/webhook/pod/mutating/enhancedlivenessprobe_handler_test.go
+++ b/pkg/webhook/pod/mutating/enhancedlivenessprobe_handler_test.go
@@ -1,0 +1,185 @@
+package mutating
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"reflect"
+	"testing"
+)
+
+func TestRemoveAndBackUpPodContainerLivenessProbe(t *testing.T) {
+
+	testCases := []struct {
+		name         string
+		pod          *corev1.Pod
+		expectResult string
+	}{
+		{
+			name: "testcase1",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod1",
+					Namespace: "sp1",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "c1",
+							LivenessProbe: &corev1.Probe{
+								FailureThreshold:    3,
+								InitialDelaySeconds: 3000,
+								PeriodSeconds:       100,
+								SuccessThreshold:    1,
+								TimeoutSeconds:      5,
+								Handler: corev1.Handler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path: "/health",
+										Port: intstr.IntOrString{
+											Type:   intstr.Int,
+											IntVal: 7001,
+										},
+										Scheme: corev1.URISchemeHTTP,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectResult: `[{"name":"c1","livenessProbe":{"httpGet":{"path":"/health","port":7001,"scheme":"HTTP"},"initialDelaySeconds":3000,"timeoutSeconds":5,"periodSeconds":100,"successThreshold":1,"failureThreshold":3}}]`,
+		},
+		{
+			name: "testcase2",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod2",
+					Namespace: "sp1",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "c1",
+							LivenessProbe: &corev1.Probe{
+								FailureThreshold:    3,
+								InitialDelaySeconds: 3000,
+								PeriodSeconds:       100,
+								SuccessThreshold:    1,
+								TimeoutSeconds:      5,
+								Handler: corev1.Handler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path: "/health",
+										Port: intstr.IntOrString{
+											Type:   intstr.Int,
+											IntVal: 7001,
+										},
+										Scheme: corev1.URISchemeHTTP,
+									},
+								},
+							},
+						},
+						{
+							Name: "c2",
+							LivenessProbe: &corev1.Probe{
+								FailureThreshold:    3,
+								InitialDelaySeconds: 3000,
+								PeriodSeconds:       100,
+								SuccessThreshold:    1,
+								TimeoutSeconds:      5,
+								Handler: corev1.Handler{
+									Exec: &corev1.ExecAction{
+										Command: []string{
+											"/home/admin/liveness.sh",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectResult: `[{"name":"c1","livenessProbe":{"httpGet":{"path":"/health","port":7001,"scheme":"HTTP"},"initialDelaySeconds":3000,"timeoutSeconds":5,"periodSeconds":100,"successThreshold":1,"failureThreshold":3}},{"name":"c2","livenessProbe":{"exec":{"command":["/home/admin/liveness.sh"]},"initialDelaySeconds":3000,"timeoutSeconds":5,"periodSeconds":100,"successThreshold":1,"failureThreshold":3}}]`,
+		},
+		{
+			name: "testcase3",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod3",
+					Namespace: "sp1",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "c1",
+							LivenessProbe: &corev1.Probe{
+								FailureThreshold:    3,
+								InitialDelaySeconds: 3000,
+								PeriodSeconds:       100,
+								SuccessThreshold:    1,
+								TimeoutSeconds:      5,
+								Handler: corev1.Handler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path: "/health",
+										Port: intstr.IntOrString{
+											Type:   intstr.Int,
+											IntVal: 7001,
+										},
+										Scheme: corev1.URISchemeHTTP,
+									},
+								},
+							},
+						},
+						{
+							Name: "c2",
+							LivenessProbe: &corev1.Probe{
+								FailureThreshold:    3,
+								InitialDelaySeconds: 3000,
+								PeriodSeconds:       100,
+								SuccessThreshold:    1,
+								TimeoutSeconds:      5,
+								Handler: corev1.Handler{
+									Exec: &corev1.ExecAction{
+										Command: []string{
+											"/home/admin/liveness.sh",
+										},
+									},
+								},
+							},
+						},
+						{
+							Name: "c3",
+						},
+					},
+				},
+			},
+			expectResult: `[{"name":"c1","livenessProbe":{"httpGet":{"path":"/health","port":7001,"scheme":"HTTP"},"initialDelaySeconds":3000,"timeoutSeconds":5,"periodSeconds":100,"successThreshold":1,"failureThreshold":3}},{"name":"c2","livenessProbe":{"exec":{"command":["/home/admin/liveness.sh"]},"initialDelaySeconds":3000,"timeoutSeconds":5,"periodSeconds":100,"successThreshold":1,"failureThreshold":3}}]`,
+		},
+		{
+			name: "testcase4",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod3",
+					Namespace: "sp1",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "c1",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		str, err := removeAndBackUpPodContainerLivenessProbe(tc.pod)
+		if err != nil {
+			t.Fatalf("test case %v failed", tc.name)
+		}
+		if !reflect.DeepEqual(str, tc.expectResult) {
+			t.Fatalf("failed to test case: %v, expect: %v, but: %v",
+				tc.name, tc.expectResult, str)
+		}
+	}
+}

--- a/pkg/webhook/pod/mutating/pod_create_update_handler.go
+++ b/pkg/webhook/pod/mutating/pod_create_update_handler.go
@@ -103,6 +103,15 @@ func (h *PodCreateHandler) Handle(ctx context.Context, req admission.Request) ad
 		changed = true
 	}
 
+	// EnhancedLivenessProbe
+	if utilfeature.DefaultFeatureGate.Enabled(features.EnhancedLivenessProbe) {
+		if skip, err := h.enhancedLivenessProbeWhenPodCreate(req, obj); err != nil {
+			return admission.Errored(http.StatusInternalServerError, err)
+		} else if !skip {
+			changed = true
+		}
+	}
+
 	if !changed {
 		return admission.Allowed("")
 	}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

An enhanced livenessProbe solution is developed in the OpenKruise suite, where is compatible with the standard livenessProbe design in the Kubernetes OpenSource community, which fully considers the service availability when the application containers are restarting.

This PR is the first solution(1/3) in our feature.

Q: How to convert the standard livenessProbe configuration to this schema?
● a webhook can convert the standrad livenssProbe to the special field in pod annotations.

Q: How to takeover the probe detection, using the kruise daemon?
● disable the native kubelet probe detection, remove the native livenessProbe configuration.
++ for livenssProbe configured cases, one webhook will admit the pod resource to remove the native probe and to restore in pod annotations with this scheme.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
No, just a part of new feature.

### Ⅲ. Describe how to verify it
1. The enhanced liveness feature is released in a Kubernetes cluster.
2. Prepering a Pod with native livenessProbe configuration and Setting the pod.annotation `pps.kruise.io/using-enhanced-liveness = true`

The standard livenessProbe configuration will be saved in Pod annotation with `apps.kruise.io/livenessprobe-context`.

### Ⅳ. Special notes for reviews
