### PR TITLE
remove the kubebuiler validation Minimum in the types file

### DIFF
--- a/apis/apps/v1alpha1/advancedcronjob_types.go
+++ b/apis/apps/v1alpha1/advancedcronjob_types.go
@@ -36,8 +36,6 @@ type AdvancedCronJobSpec struct {
 	// +optional
 	TimeZone *string `json:"timeZone,omitempty" protobuf:"bytes,8,opt,name=timeZone"`
 
-	// +kubebuilder:validation:Minimum=0
-
 	// Optional deadline in seconds for starting the job if it misses scheduled
 	// time for any reason.  Missed jobs executions will be counted as failed ones.
 	// +optional
@@ -55,14 +53,10 @@ type AdvancedCronJobSpec struct {
 	// +optional
 	Paused *bool `json:"paused,omitempty" protobuf:"bytes,4,opt,name=paused"`
 
-	// +kubebuilder:validation:Minimum=0
-
 	// The number of successful finished jobs to retain.
 	// This is a pointer to distinguish between explicit zero and not specified.
 	// +optional
 	SuccessfulJobsHistoryLimit *int32 `json:"successfulJobsHistoryLimit,omitempty" protobuf:"varint,5,opt,name=successfulJobsHistoryLimit"`
-
-	// +kubebuilder:validation:Minimum=0
 
 	// The number of failed finished jobs to retain.
 	// This is a pointer to distinguish between explicit zero and not specified.

--- a/config/crd/bases/apps.kruise.io_advancedcronjobs.yaml
+++ b/config/crd/bases/apps.kruise.io_advancedcronjobs.yaml
@@ -73,7 +73,6 @@ spec:
                 description: The number of failed finished jobs to retain. This is
                   a pointer to distinguish between explicit zero and not specified.
                 format: int32
-                minimum: 0
                 type: integer
               paused:
                 description: Paused will pause the cron job.
@@ -87,13 +86,11 @@ spec:
                   it misses scheduled time for any reason.  Missed jobs executions
                   will be counted as failed ones.
                 format: int64
-                minimum: 0
                 type: integer
               successfulJobsHistoryLimit:
                 description: The number of successful finished jobs to retain. This
                   is a pointer to distinguish between explicit zero and not specified.
                 format: int32
-                minimum: 0
                 type: integer
               template:
                 description: Specifies the job that will be created when executing

--- a/pkg/webhook/advancedcronjob/validating/advancedcronjob_create_update_handler.go
+++ b/pkg/webhook/advancedcronjob/validating/advancedcronjob_create_update_handler.go
@@ -69,6 +69,12 @@ func validateAdvancedCronJobSpec(spec *appsv1alpha1.AdvancedCronJobSpec, fldPath
 	if spec.StartingDeadlineSeconds != nil {
 		allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(*spec.StartingDeadlineSeconds, fldPath.Child("startingDeadlineSeconds"))...)
 	}
+	if spec.SuccessfulJobsHistoryLimit != nil {
+		allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(*spec.SuccessfulJobsHistoryLimit), fldPath.Child("successfulJobsHistoryLimit"))...)
+	}
+	if spec.FailedJobsHistoryLimit != nil {
+		allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(*spec.FailedJobsHistoryLimit), fldPath.Child("failedJobsHistoryLimit"))...)
+	}
 	allErrs = append(allErrs, validateTimeZone(spec.TimeZone, fldPath.Child("timeZone"))...)
 	return allErrs
 }


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
kruise in k8s 1.18 cluster using helm upgrade will fail, see this issue for details https://github.com/helm/helm/issues/5806.

So, remove **+kubebuilder:validation:Minimum** in the types file
