### PR TITLE
fix: bcj doesn't make pod on node that has erased taint

### DIFF
--- a/pkg/controller/broadcastjob/broadcastjob_controller.go
+++ b/pkg/controller/broadcastjob/broadcastjob_controller.go
@@ -529,14 +529,9 @@ func getNodesToRunPod(nodes *corev1.NodeList, job *appsv1alpha1.BroadcastJob,
 		// there's pod existing on the node
 		if pod, ok := existingNodeToPodMap[node.Name]; ok {
 			canFit, err = checkNodeFitness(pod, &node)
-			if err != nil {
-				klog.Errorf("pod %s failed to checkNodeFitness for node %s, %v", pod.Name, node.Name, err)
-				continue
-			}
-			if !canFit {
-				if pod.DeletionTimestamp == nil {
-					podsToDelete = append(podsToDelete, pod)
-				}
+			if !canFit && pod.DeletionTimestamp == nil {
+				klog.Infof("Pod %s does not fit on node %s due to %v", pod.Name, node.Name, err)
+				podsToDelete = append(podsToDelete, pod)
 				continue
 			}
 			desiredNodes[node.Name] = pod
@@ -545,12 +540,8 @@ func getNodesToRunPod(nodes *corev1.NodeList, job *appsv1alpha1.BroadcastJob,
 			// considering nodeName, label affinity and taints
 			mockPod := NewMockPod(job, node.Name)
 			canFit, err = checkNodeFitness(mockPod, &node)
-			if err != nil {
-				klog.Errorf("failed to checkNodeFitness for node %s, %v", node.Name, err)
-				continue
-			}
 			if !canFit {
-				klog.Infof("Pod does not fit on node %s", node.Name)
+				klog.Infof("Pod does not fit on node %s due to %v", node.Name, err)
 				continue
 			}
 			restNodesToRunPod = append(restNodesToRunPod, &nodes.Items[i])

--- a/pkg/controller/broadcastjob/broadcastjob_event_handler.go
+++ b/pkg/controller/broadcastjob/broadcastjob_event_handler.go
@@ -108,12 +108,8 @@ func (p *enqueueBroadcastJobForNode) addNode(q workqueue.RateLimitingInterface, 
 	for _, bcj := range jobList.Items {
 		mockPod := NewMockPod(&bcj, node.Name)
 		canFit, err := checkNodeFitness(mockPod, node)
-		if err != nil {
-			klog.Errorf("failed to checkNodeFitness for job %s/%s, on node %s, %v", bcj.Namespace, bcj.Name, node.Name, err)
-			continue
-		}
 		if !canFit {
-			klog.Infof("Job %s/%s does not fit on node %s", bcj.Namespace, bcj.Name, node.Name)
+			klog.Infof("Job %s/%s does not fit on node %s due to %v", bcj.Namespace, bcj.Name, node.Name, err)
 			continue
 		}
 
@@ -138,17 +134,8 @@ func (p *enqueueBroadcastJobForNode) updateNode(q workqueue.RateLimitingInterfac
 	}
 	for _, bcj := range jobList.Items {
 		mockPod := NewMockPod(&bcj, oldNode.Name)
-		canOldNodeFit, err := checkNodeFitness(mockPod, oldNode)
-		if err != nil {
-			klog.Errorf("failed to checkNodeFitness for job %s/%s, on old node %s, %v", bcj.Namespace, bcj.Name, oldNode.Name, err)
-			continue
-		}
-
-		canCurNodeFit, err := checkNodeFitness(mockPod, curNode)
-		if err != nil {
-			klog.Errorf("failed to checkNodeFitness for job %s/%s, on cur node %s, %v", bcj.Namespace, bcj.Name, curNode.Name, err)
-			continue
-		}
+		canOldNodeFit, _ := checkNodeFitness(mockPod, oldNode)
+		canCurNodeFit, _ := checkNodeFitness(mockPod, curNode)
 
 		if canOldNodeFit != canCurNodeFit {
 			// enqueue the broadcast job for matching node


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
fix the bug that broadcastjob won't make pod when a tainted node has erased its taint

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #1199

### Ⅲ. Describe how to verify it
1.cordon a node
2.apply a new broadcastjob, and the pod will not appear on that cordoned node
3.uncordon that node, a new pod is made 


### Ⅳ. Special notes for reviews
the returned err of function `checkNodeFitness` is not error actually, but the reason why the node is not fit
