### PR TITLE
Update k8s registry references

### DIFF
--- a/test/e2e/testing-manifests/statefulset/cassandra/tester.yaml
+++ b/test/e2e/testing-manifests/statefulset/cassandra/tester.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: test-server
-        image: k8s.gcr.io/cassandra-e2e-test:0.1
+        image: registry.k8s.io/cassandra-e2e-test:0.1
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/test/e2e/testing-manifests/statefulset/etcd/statefulset.yaml
+++ b/test/e2e/testing-manifests/statefulset/etcd/statefulset.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: etcd
-        image: k8s.gcr.io/etcd:3.2.24
+        image: registry.k8s.io/etcd:3.2.24
         imagePullPolicy: Always
         ports:
         - containerPort: 2380

--- a/test/e2e/testing-manifests/statefulset/etcd/tester.yaml
+++ b/test/e2e/testing-manifests/statefulset/etcd/tester.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: test-server
-        image: k8s.gcr.io/etcd-statefulset-e2e-test:0.0
+        image: registry.k8s.io/etcd-statefulset-e2e-test:0.0
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/test/e2e/testing-manifests/statefulset/mysql-galera/statefulset.yaml
+++ b/test/e2e/testing-manifests/statefulset/mysql-galera/statefulset.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       initContainers:
       - name: install
-        image: k8s.gcr.io/galera-install:0.1
+        image: registry.k8s.io/galera-install:0.1
         imagePullPolicy: Always
         args:
         - "--work-dir=/work-dir"
@@ -44,7 +44,7 @@ spec:
           mountPath: "/etc/mysql"
       containers:
       - name: mysql
-        image: k8s.gcr.io/mysql-galera:e2e
+        image: registry.k8s.io/mysql-galera:e2e
         ports:
         - containerPort: 3306
           name: mysql
@@ -58,7 +58,7 @@ spec:
         - --defaults-file=/etc/mysql/my-galera.cnf
         - --user=root
         readinessProbe:
-          # TODO: If docker exec is buggy just use k8s.gcr.io/mysql-healthz:1.0
+          # TODO: If docker exec is buggy just use registry.k8s.io/mysql-healthz:1.0
           exec:
             command:
             - sh

--- a/test/e2e/testing-manifests/statefulset/mysql-upgrade/tester.yaml
+++ b/test/e2e/testing-manifests/statefulset/mysql-upgrade/tester.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: test-server
-        image: k8s.gcr.io/mysql-e2e-test:0.1
+        image: registry.k8s.io/mysql-e2e-test:0.1
         imagePullPolicy: Always
         ports:
         - containerPort: 8080


### PR DESCRIPTION
Per https://github.com/kubernetes/k8s.io/issues/4780, Kubernetes is migrating its image registry to registry.k8s.io, and this repository is impacted.

We have to update the references of k8s.gcr.io to registry.k8s.io by April 3rd to remain up-to-date.

Here's a quick search for k8s.gcr.io on this repo. [[search result]](https://github.com/search?q=org%3Adapr%20%22k8s.gcr.io%22&type=code). Note that there may be other valid references (like, in the form of generated code, etc) which we have to be aware of.

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

