### PR TITLE
Add missing finalizers permissions

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -161,6 +161,12 @@ rules:
 - apiGroups:
   - apps.kruise.io
   resources:
+  - advancedcronjobs/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - apps.kruise.io
+  resources:
   - advancedcronjobs/status
   verbs:
   - get
@@ -178,6 +184,12 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - broadcastjobs/finalizers
+  verbs:
+  - update
 - apiGroups:
   - apps.kruise.io
   resources:
@@ -201,6 +213,12 @@ rules:
 - apiGroups:
   - apps.kruise.io
   resources:
+  - clonesets/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - apps.kruise.io
+  resources:
   - clonesets/status
   verbs:
   - get
@@ -221,6 +239,12 @@ rules:
 - apiGroups:
   - apps.kruise.io
   resources:
+  - containerrecreaterequests/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - apps.kruise.io
+  resources:
   - containerrecreaterequests/status
   verbs:
   - get
@@ -238,6 +262,12 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - daemonsets/finalizers
+  verbs:
+  - update
 - apiGroups:
   - apps.kruise.io
   resources:
@@ -280,6 +310,12 @@ rules:
 - apiGroups:
   - apps.kruise.io
   resources:
+  - imagepulljobs/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - apps.kruise.io
+  resources:
   - imagepulljobs/status
   verbs:
   - get
@@ -297,6 +333,12 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - nodeimages/finalizers
+  verbs:
+  - update
 - apiGroups:
   - apps.kruise.io
   resources:
@@ -320,6 +362,12 @@ rules:
 - apiGroups:
   - apps.kruise.io
   resources:
+  - nodepodprobes/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - apps.kruise.io
+  resources:
   - nodepodprobes/status
   verbs:
   - get
@@ -337,6 +385,12 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - persistentpodstates/finalizers
+  verbs:
+  - update
 - apiGroups:
   - apps.kruise.io
   resources:
@@ -360,6 +414,12 @@ rules:
 - apiGroups:
   - apps.kruise.io
   resources:
+  - podprobemarkers/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - apps.kruise.io
+  resources:
   - podprobemarkers/status
   verbs:
   - get
@@ -373,6 +433,12 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - resourcedistributions/finalizers
+  verbs:
+  - update
 - apiGroups:
   - apps.kruise.io
   resources:
@@ -396,6 +462,12 @@ rules:
 - apiGroups:
   - apps.kruise.io
   resources:
+  - sidecarsets/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - apps.kruise.io
+  resources:
   - sidecarsets/status
   verbs:
   - get
@@ -413,6 +485,12 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - statefulsets/finalizers
+  verbs:
+  - update
 - apiGroups:
   - apps.kruise.io
   resources:
@@ -436,6 +514,12 @@ rules:
 - apiGroups:
   - apps.kruise.io
   resources:
+  - uniteddeployments/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - apps.kruise.io
+  resources:
   - uniteddeployments/status
   verbs:
   - get
@@ -451,6 +535,12 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - workloadspreads/finalizers
+  verbs:
+  - update
 - apiGroups:
   - apps.kruise.io
   resources:
@@ -575,6 +665,12 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - policy.kruise.io
+  resources:
+  - podunavailablebudgets/finalizers
+  verbs:
+  - update
 - apiGroups:
   - policy.kruise.io
   resources:

--- a/pkg/controller/advancedcronjob/advancedcronjob_broadcastjob_controller.go
+++ b/pkg/controller/advancedcronjob/advancedcronjob_broadcastjob_controller.go
@@ -44,9 +44,6 @@ func watchBroadcastJob(c controller.Controller) error {
 	return nil
 }
 
-// +kubebuilder:rbac:groups=apps.kruise.io,resources=broadcastjobs,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=apps.kruise.io,resources=broadcastjobs/status,verbs=get;update;patch
-
 func (r *ReconcileAdvancedCronJob) reconcileBroadcastJob(ctx context.Context, req ctrl.Request, advancedCronJob appsv1alpha1.AdvancedCronJob) (ctrl.Result, error) {
 	advancedCronJob.Status.Type = appsv1alpha1.BroadcastJobTemplate
 

--- a/pkg/controller/advancedcronjob/advancedcronjob_controller.go
+++ b/pkg/controller/advancedcronjob/advancedcronjob_controller.go
@@ -125,6 +125,7 @@ type ReconcileAdvancedCronJob struct {
 
 // +kubebuilder:rbac:groups=apps.kruise.io,resources=advancedcronjobs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps.kruise.io,resources=advancedcronjobs/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=apps.kruise.io,resources=advancedcronjobs/finalizers,verbs=update
 
 func (r *ReconcileAdvancedCronJob) Reconcile(_ context.Context, req ctrl.Request) (ctrl.Result, error) {
 	ctx := context.Background()

--- a/pkg/controller/broadcastjob/broadcastjob_controller.go
+++ b/pkg/controller/broadcastjob/broadcastjob_controller.go
@@ -142,6 +142,7 @@ type ReconcileBroadcastJob struct {
 // +kubebuilder:rbac:groups=core,resources=pods/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=apps.kruise.io,resources=broadcastjobs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps.kruise.io,resources=broadcastjobs/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=apps.kruise.io,resources=broadcastjobs/finalizers,verbs=update
 
 // Reconcile reads that state of the cluster for a BroadcastJob object and makes changes based on the state read
 // and what is in the BroadcastJob.Spec

--- a/pkg/controller/cloneset/cloneset_controller.go
+++ b/pkg/controller/cloneset/cloneset_controller.go
@@ -173,6 +173,7 @@ type ReconcileCloneSet struct {
 // +kubebuilder:rbac:groups=apps,resources=controllerrevisions,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps.kruise.io,resources=clonesets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps.kruise.io,resources=clonesets/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=apps.kruise.io,resources=clonesets/finalizers,verbs=update
 
 // Reconcile reads that state of the cluster for a CloneSet object and makes changes based on the state read
 // and what is in the CloneSet.Spec

--- a/pkg/controller/containerrecreaterequest/crr_controller.go
+++ b/pkg/controller/containerrecreaterequest/crr_controller.go
@@ -114,6 +114,7 @@ type ReconcileContainerRecreateRequest struct {
 
 // +kubebuilder:rbac:groups=apps.kruise.io,resources=containerrecreaterequests,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps.kruise.io,resources=containerrecreaterequests/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=apps.kruise.io,resources=containerrecreaterequests/finalizers,verbs=update
 
 // Reconcile reads that state of the cluster for a ContainerRecreateRequest object and makes changes based on the state read
 // and what is in the ContainerRecreateRequest.Spec

--- a/pkg/controller/daemonset/daemonset_controller.go
+++ b/pkg/controller/daemonset/daemonset_controller.go
@@ -300,6 +300,7 @@ type ReconcileDaemonSet struct {
 // +kubebuilder:rbac:groups=apps,resources=controllerrevisions,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps.kruise.io,resources=daemonsets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps.kruise.io,resources=daemonsets/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=apps.kruise.io,resources=daemonsets/finalizers,verbs=update
 
 // Reconcile reads that state of the cluster for a DaemonSet object and makes changes based on the state read
 // and what is in the DaemonSet.Spec

--- a/pkg/controller/imagepulljob/imagepulljob_controller.go
+++ b/pkg/controller/imagepulljob/imagepulljob_controller.go
@@ -121,6 +121,7 @@ type ReconcileImagePullJob struct {
 
 // +kubebuilder:rbac:groups=apps.kruise.io,resources=imagepulljobs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps.kruise.io,resources=imagepulljobs/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=apps.kruise.io,resources=imagepulljobs/finalizers,verbs=update
 
 // Reconcile reads that state of the cluster for a ImagePullJob object and makes changes based on the state read
 // and what is in the ImagePullJob.Spec

--- a/pkg/controller/nodeimage/nodeimage_controller.go
+++ b/pkg/controller/nodeimage/nodeimage_controller.go
@@ -142,6 +142,7 @@ type ReconcileNodeImage struct {
 // +kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list;watch
 // +kubebuilder:rbac:groups=apps.kruise.io,resources=nodeimages,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps.kruise.io,resources=nodeimages/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=apps.kruise.io,resources=nodeimages/finalizers,verbs=update
 
 // Reconcile reads that state of the cluster for a NodeImage object and makes changes based on the state read
 // and what is in the NodeImage.Spec

--- a/pkg/controller/nodepodprobe/node_pod_probe_controller.go
+++ b/pkg/controller/nodepodprobe/node_pod_probe_controller.go
@@ -119,6 +119,7 @@ type ReconcileNodePodProbe struct {
 
 // +kubebuilder:rbac:groups=apps.kruise.io,resources=nodepodprobes,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps.kruise.io,resources=nodepodprobes/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=apps.kruise.io,resources=nodepodprobes/finalizers,verbs=update
 
 // Reconcile reads that state of the cluster for a NodePodProbe object and makes changes based on the state read
 // and what is in the NodePodProbe.Spec

--- a/pkg/controller/persistentpodstate/persistent_pod_state_controller.go
+++ b/pkg/controller/persistentpodstate/persistent_pod_state_controller.go
@@ -161,10 +161,9 @@ type ReconcilePersistentPodState struct {
 // +kubebuilder:rbac:groups=core,resources=pods/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=apps.kruise.io,resources=persistentpodstates,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps.kruise.io,resources=persistentpodstates/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=apps.kruise.io,resources=persistentpodstates/finalizers,verbs=update
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps,resources=statefulsets/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=apps.kruise.io,resources=statefulsets,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=apps.kruise.io,resources=statefulsets/status,verbs=get;update;patch
 
 // Reconcile reads that state of the cluster for a PersistentPodState object and makes changes based on the state read
 // and what is in the PersistentPodState.Spec

--- a/pkg/controller/podprobemarker/pod_probe_marker_controller.go
+++ b/pkg/controller/podprobemarker/pod_probe_marker_controller.go
@@ -118,8 +118,7 @@ type ReconcilePodProbeMarker struct {
 
 // +kubebuilder:rbac:groups=apps.kruise.io,resources=podprobemarkers,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps.kruise.io,resources=podprobemarkers/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=apps.kruise.io,resources=nodepodprobes,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=apps.kruise.io,resources=nodepodprobes/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=apps.kruise.io,resources=podprobemarkers/finalizers,verbs=update
 
 // Reconcile reads that state of the cluster for a PodProbeMarker object and makes changes based on the state read
 // and what is in the PodProbeMarker.Spec

--- a/pkg/controller/podunavailablebudget/podunavailablebudget_controller.go
+++ b/pkg/controller/podunavailablebudget/podunavailablebudget_controller.go
@@ -208,6 +208,7 @@ type ReconcilePodUnavailableBudget struct {
 
 // +kubebuilder:rbac:groups=policy.kruise.io,resources=podunavailablebudgets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=policy.kruise.io,resources=podunavailablebudgets/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=policy.kruise.io,resources=podunavailablebudgets/finalizers,verbs=update
 // +kubebuilder:rbac:groups=*,resources=*/scale,verbs=get;list;watch
 
 // pkg/controller/cloneset/cloneset_controller.go Watch for changes to CloneSet

--- a/pkg/controller/resourcedistribution/resourcedistribution_controller.go
+++ b/pkg/controller/resourcedistribution/resourcedistribution_controller.go
@@ -159,6 +159,7 @@ type ReconcileResourceDistribution struct {
 
 //+kubebuilder:rbac:groups=apps.kruise.io,resources=resourcedistributions,verbs=get;list;watch;
 //+kubebuilder:rbac:groups=apps.kruise.io,resources=resourcedistributions/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=apps.kruise.io,resources=resourcedistributions/finalizers,verbs=update
 //+kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch;
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;delete
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;delete

--- a/pkg/controller/sidecarset/sidecarset_controller.go
+++ b/pkg/controller/sidecarset/sidecarset_controller.go
@@ -122,6 +122,7 @@ type ReconcileSidecarSet struct {
 
 // +kubebuilder:rbac:groups=apps.kruise.io,resources=sidecarsets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps.kruise.io,resources=sidecarsets/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=apps.kruise.io,resources=sidecarsets/finalizers,verbs=update
 // +kubebuilder:rbac:groups=apps,resources=controllerrevisions,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile reads that state of the cluster for a SidecarSet object and makes changes based on the state read

--- a/pkg/controller/statefulset/statefulset_controller.go
+++ b/pkg/controller/statefulset/statefulset_controller.go
@@ -223,6 +223,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 // +kubebuilder:rbac:groups=apps,resources=controllerrevisions,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps.kruise.io,resources=statefulsets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps.kruise.io,resources=statefulsets/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=apps.kruise.io,resources=statefulsets/finalizers,verbs=update
 
 // Reconcile reads that state of the cluster for a StatefulSet object and makes changes based on the state read
 // and what is in the StatefulSet.Spec

--- a/pkg/controller/uniteddeployment/uniteddeployment_controller.go
+++ b/pkg/controller/uniteddeployment/uniteddeployment_controller.go
@@ -162,10 +162,9 @@ type ReconcileUnitedDeployment struct {
 
 // +kubebuilder:rbac:groups=apps.kruise.io,resources=uniteddeployments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps.kruise.io,resources=uniteddeployments/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=apps.kruise.io,resources=uniteddeployments/finalizers,verbs=update
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps,resources=statefulsets/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=apps.kruise.io,resources=statefulsets,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=apps.kruise.io,resources=statefulsets/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps,resources=deployments/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=apps,resources=replicasets,verbs=get;list;watch

--- a/pkg/controller/workloadspread/workloadspread_controller.go
+++ b/pkg/controller/workloadspread/workloadspread_controller.go
@@ -178,6 +178,7 @@ type ReconcileWorkloadSpread struct {
 
 // +kubebuilder:rbac:groups=apps.kruise.io,resources=workloadspreads,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=apps.kruise.io,resources=workloadspreads/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=apps.kruise.io,resources=workloadspreads/finalizers,verbs=update
 // +kubebuilder:rbac:groups=apps.kruise.io,resources=clonesets,verbs=get;list;watch
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch
 // +kubebuilder:rbac:groups=apps,resources=replicasets,verbs=get;list;watch

--- a/pkg/webhook/pod/validating/pod_unavailable_budget.go
+++ b/pkg/webhook/pod/validating/pod_unavailable_budget.go
@@ -31,9 +31,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
-// +kubebuilder:rbac:groups=policy.kruise.io,resources=podunavailablebudgets,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=policy.kruise.io,resources=podunavailablebudgets/status,verbs=get;update;patch
-
 // parameters:
 // 1. allowed(bool) whether to allow this request
 // 2. reason(string)


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Add missing finalizers permissions.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
Workload cannot be create normally because  _ControllerRevision_ 's `metadata.ownerReferences[x].blockOwnerDeletion` cannot  be updated when the [OwnerReferencesPermissionEnforcement](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement) plugin is enabled.

Enable _OwnerReferencesPermissionEnforcement_:
![image](https://user-images.githubusercontent.com/89241565/227490507-925b58f1-d609-4114-a303-6f0722012b3f.png)

sts workload:
![image](https://user-images.githubusercontent.com/89241565/227489854-1bbb66c3-9c95-4fbd-aa98-a6ac1d0d40b8.png)

Error log:
![image](https://user-images.githubusercontent.com/89241565/227490141-72721087-3a72-4b94-aba5-7a102ebc1157.png)

### Ⅲ. Describe how to verify it
Turn on _OwnerReferencesPermissionEnforcement_ and create new workload.

### Ⅳ. Special notes for reviews

