### PR TITLE
Add validation for the WorkloadSpreadSubset patch field

### DIFF
--- a/pkg/webhook/util/convertor/util.go
+++ b/pkg/webhook/util/convertor/util.go
@@ -36,6 +36,15 @@ func ConvertPodTemplateSpec(template *v1.PodTemplateSpec) (*core.PodTemplateSpec
 	return coreTemplate, nil
 }
 
+func ConvertPod(pod *v1.Pod) (*core.Pod, error) {
+	corePod := &core.Pod{}
+	defaults.SetDefaultPodSpec(&pod.Spec)
+	if err := corev1.Convert_v1_Pod_To_core_Pod(pod.DeepCopy(), corePod, nil); err != nil {
+		return nil, err
+	}
+	return corePod, nil
+}
+
 func ConvertCoreVolumes(volumes []v1.Volume) ([]core.Volume, error) {
 	coreVolumes := []core.Volume{}
 	for _, volume := range volumes {


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Add validation for the WorkloadSpreadSubset patch field

When scheduling-related parameters exist in the patch without validation, they may conflict with the subset of workloadspread. Therefore, this type of patch should be excluded.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

### Ⅲ. Describe how to verify it

kubectl apply -f config/samples/apps_v1alpha1_cloneset.yaml

kubectl apply -f workloadspread.yaml
```yaml
apiVersion: apps.kruise.io/v1alpha1
kind: WorkloadSpread
metadata:
  name: workloadspread-sample
spec:
  targetRef:
    apiVersion: apps.kruise.io/v1alpha1
    kind: CloneSet
    name: sample
  subsets:
  - name: subset-a
    requiredNodeSelectorTerm:
      matchExpressions:
        - key: node
          operator: In
          values:
          - zone-a
    maxReplicas: 3
    patch:
      metadata:
        labels:
          subset-name: "subset-a"
      spec:
        # scheduling-related parameters
        nodeName: "kind-worker3"
        nodeSelector:
          node: zone-c
        affinity:
          nodeAffinity:
            requiredDuringSchedulingIgnoredDuringExecution:
              nodeSelectorTerms:
                - matchExpressions:
                    - key: node
                      operator: In
                      values:
                        - zone-c

  - name: subset-b
    requiredNodeSelectorTerm:
      matchExpressions:
        - key: node
          operator: In
          values:
          - zone-b
    patch:
      metadata:
        labels:
          subset-name: "subset-b"
```

It will report the following error:
```shell
Error from server: error when creating "apps_v1alpha1_workloadspread.yaml": admission webhook "vworkloadspread.kb.io" denied the request: [spec.subsets[0].patch: Invalid value: "kind-worker3": NodeName is not permitted in patch, spec.subsets[0].patch: Invalid value: "{\"node\":\"zone-c\"}": NodeSelector is not permitted in patch, spec.subsets[0].patch: Invalid value: "{\"nodeAffinity\":{\"requiredDuringSchedulingIgnoredDuringExecution\":{\"nodeSelectorTerms\":[{\"matchExpressions\":[{\"key\":\"node\",\"operator\":\"In\",\"values\":[\"zone-c\"]}]}]}}}": Affinity is not permitted in patch]
```

### Ⅳ. Special notes for reviews

