### PR TITLE
feat: Optimize UnitedDeployment replicas settings

### DIFF
--- a/apis/apps/defaults/v1alpha1.go
+++ b/apis/apps/defaults/v1alpha1.go
@@ -201,9 +201,6 @@ func SetDefaultsBroadcastJob(obj *v1alpha1.BroadcastJob, injectTemplateDefaults 
 
 // SetDefaults_UnitedDeployment set default values for UnitedDeployment.
 func SetDefaultsUnitedDeployment(obj *v1alpha1.UnitedDeployment, injectTemplateDefaults bool) {
-	if obj.Spec.Replicas == nil {
-		obj.Spec.Replicas = utilpointer.Int32Ptr(1)
-	}
 	if obj.Spec.RevisionHistoryLimit == nil {
 		obj.Spec.RevisionHistoryLimit = utilpointer.Int32Ptr(10)
 	}

--- a/pkg/controller/uniteddeployment/allocator_test.go
+++ b/pkg/controller/uniteddeployment/allocator_test.go
@@ -167,6 +167,23 @@ func TestSpecifyValidReplicas(t *testing.T) {
 	if " t1 -> 1; t2 -> 2; t3 -> 3; t4 -> 4;" != allocator.String() {
 		t.Fatalf("unexpected %s", allocator)
 	}
+
+	infos = subsetInfos{
+		createSubset("t1", 4),
+		createSubset("t2", 2),
+		createSubset("t3", 2),
+		createSubset("t4", 2),
+	}
+	allocator = infos.SortToAllocator()
+	allocator.AllocateReplicas(-1, &map[string]int32{
+		"t1": 1,
+		"t2": 2,
+		"t3": 3,
+		"t4": 4,
+	})
+	if " t1 -> 1; t2 -> 2; t3 -> 3; t4 -> 4;" != allocator.String() {
+		t.Fatalf("unexpected %s", allocator)
+	}
 }
 
 func TestSpecifyInvalidReplicas(t *testing.T) {

--- a/pkg/controller/uniteddeployment/uniteddeployment_controller_utils.go
+++ b/pkg/controller/uniteddeployment/uniteddeployment_controller_utils.go
@@ -41,6 +41,10 @@ func ParseSubsetReplicas(udReplicas int32, subsetReplicas intstr.IntOrString) (i
 		return subsetReplicas.IntVal, nil
 	}
 
+	if udReplicas < 0 {
+		return 0, fmt.Errorf("subsetReplicas (%v) should not be string when unitedDeployment replicas is empty", subsetReplicas.StrVal)
+	}
+
 	strVal := subsetReplicas.StrVal
 	if !strings.HasSuffix(strVal, "%") {
 		return 0, fmt.Errorf("subset replicas (%s) only support integer value or percentage value with a suffix '%%'", strVal)


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Optimize UnitedDeployment replicas settings:
add optimization for the situation when `spec.replicas` is not set (`nil`)
### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixed #1220
### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

