### PR TITLE
fix the default value of imagePullPolicy

### DIFF
--- a/pkg/webhook/sidecarset/mutating/sidecarset_create_update_handler.go
+++ b/pkg/webhook/sidecarset/mutating/sidecarset_create_update_handler.go
@@ -77,7 +77,15 @@ func (h *SidecarSetCreateHandler) Handle(ctx context.Context, req admission.Requ
 	var copy runtime.Object = obj.DeepCopy()
 	switch req.AdmissionRequest.Operation {
 	case admissionv1.Create, admissionv1.Update:
-		defaults.SetDefaultsSidecarSet(obj)
+		var old *appsv1alpha1.SidecarSet
+		if req.AdmissionRequest.Operation == admissionv1.Update {
+			old = new(appsv1alpha1.SidecarSet)
+			err = h.Decoder.DecodeRaw(req.AdmissionRequest.OldObject, old)
+			if err != nil {
+				return admission.Errored(http.StatusBadRequest, err)
+			}
+		}
+		defaults.SetDefaultsSidecarSet(obj, old)
 		if err := setHashSidecarSet(obj); err != nil {
 			return admission.Errored(http.StatusInternalServerError, err)
 		}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
Fixed an issue that caused sidecarset in-place update to not work in some scenarios

### Ⅱ. Does this pull request fix one issue?
fix #1270 

### Ⅲ. Describe how to verify it
just see the unit test

### Ⅳ. Special notes for reviews
The setting of default value of the container's imagePullPolicy in sidecarSet is [affected by the image tag](https://github.com/kubernetes/kubernetes/blob/8f3f997a98c7b44925f7654e5c66e6f46e328147/pkg/apis/core/v1/defaults.go#L73-L83C3) , which makes it possible to change the value of SidecarSetHashWithoutImage even if only the image tag is modified, thus making the in-place upgrade of the container ineffective.
