### PR TITLE
 update the image status when start pulling images

### DIFF
--- a/pkg/daemon/criruntime/imageruntime/helpers_test.go
+++ b/pkg/daemon/criruntime/imageruntime/helpers_test.go
@@ -117,3 +117,76 @@ func TestMatchRegistryAuths(t *testing.T) {
 		})
 	}
 }
+
+func TestContainsImage(t *testing.T) {
+	cases := []struct {
+		name       string
+		ImageName  string
+		Tag        string
+		ImageInfos []ImageInfo
+		Expect     bool
+	}{
+		{
+			name:      "test_nginx",
+			ImageName: "nginx",
+			Tag:       "latest",
+			ImageInfos: []ImageInfo{{
+				RepoTags: []string{"docker.io/library/nginx:latest"},
+			},
+			},
+			Expect: true,
+		},
+		{
+			name:      "test_test/nginx:1.0",
+			ImageName: "test/nginx",
+			Tag:       "1.0",
+			ImageInfos: []ImageInfo{{
+				RepoTags: []string{"docker.io/test/nginx:1.0"},
+			},
+			},
+			Expect: true,
+		},
+		{
+			name:      "test_test/nginx:1.0_false",
+			ImageName: "test/nginx",
+			Tag:       "1.0",
+			ImageInfos: []ImageInfo{{
+				RepoTags: []string{"docker.io/library/nginx:1.0"},
+			},
+			},
+			Expect: false,
+		},
+
+		{
+			name:      "test_docker.io/library/nginx",
+			ImageName: "docker.io/library/nginx",
+			Tag:       "latest",
+			ImageInfos: []ImageInfo{{
+				RepoTags: []string{"docker.io/library/nginx:latest"},
+			},
+			},
+			Expect: false,
+		},
+		{
+			name:      "test_1.1.1.1:8080/test/nginx",
+			ImageName: "1.1.1.1:8080/test/nginx",
+			Tag:       "latest",
+			ImageInfos: []ImageInfo{{
+				RepoTags: []string{"1.1.1.1:8080/test/nginx:latest"},
+			},
+			},
+			Expect: true,
+		},
+	}
+
+	for _, cs := range cases {
+		t.Run(cs.name, func(t *testing.T) {
+			for _, info := range cs.ImageInfos {
+				res := info.ContainsImage(cs.ImageName, cs.Tag)
+				if res != cs.Expect {
+					t.Fatalf("ContainsImage failed")
+				}
+			}
+		})
+	}
+}

--- a/pkg/daemon/imagepuller/imagepuller_worker.go
+++ b/pkg/daemon/imagepuller/imagepuller_worker.go
@@ -324,6 +324,13 @@ func (w *pullWorker) Run() {
 		StartTime: &startTime,
 		Version:   w.tagSpec.Version,
 	}
+
+	// We should update the image status when we start pulling images,
+	// which can meet the scenario that some large size images cannot return the result from CRI.PullImage within 60s. For one reason:
+	// For nodeimage controller will mark image:tag task failed (not responded for a long time) if daemon does not report status in 60s.
+	// Ref: https://github.com/openkruise/kruise/issues/1273
+	w.statusUpdater.UpdateStatus(newStatus)
+
 	defer func() {
 		cost := time.Since(startTime.Time)
 		if newStatus.Phase == appsv1alpha1.ImagePhaseFailed {


### PR DESCRIPTION


<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
We should update the image status when we start pulling images,
which can meet the scenario that some large size images cannot return the result from CRI.PullImage within 60s. For one reason:
	1.For nodeimage controller will mark image:tag task failed (not responded for a long time) if daemon does not report status in 60s.

When checking whether a image exists, we should compare the name(without defaultDomain and officialRepoName) and tag of the image.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #1273 
### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

