### PR TITLE
Sidecar terminator ignore the exit code of the sidecar container

### DIFF
--- a/pkg/controller/sidecarterminator/sidecar_terminator_pod_event_handler_test.go
+++ b/pkg/controller/sidecarterminator/sidecar_terminator_pod_event_handler_test.go
@@ -143,6 +143,48 @@ func TestEnqueueRequestForPodUpdate(t *testing.T) {
 			expectLen: 0,
 		},
 		{
+			name: "Pod, main container completed -> completed, sidecar container completed and pod has reached succeeded phase",
+			getOldPod: func() *corev1.Pod {
+				oldPod := oldPodDemo.DeepCopy()
+				oldPod.Status.ContainerStatuses = []corev1.ContainerStatus{
+					succeededMainContainerStatus,
+					completedSidecarContainerStatus,
+				}
+				return oldPod
+			},
+			getNewPod: func() *corev1.Pod {
+				newPod := newPodDemo.DeepCopy()
+				newPod.Status.ContainerStatuses = []corev1.ContainerStatus{
+					succeededMainContainerStatus,
+					completedSidecarContainerStatus,
+				}
+				newPod.Status.Phase = corev1.PodSucceeded
+				return newPod
+			},
+			expectLen: 0,
+		},
+		{
+			name: "Pod, main container completed -> completed, sidecar container failed and pod has reached succeeded phase",
+			getOldPod: func() *corev1.Pod {
+				oldPod := oldPodDemo.DeepCopy()
+				oldPod.Status.ContainerStatuses = []corev1.ContainerStatus{
+					succeededMainContainerStatus,
+					completedSidecarContainerStatus,
+				}
+				return oldPod
+			},
+			getNewPod: func() *corev1.Pod {
+				newPod := newPodDemo.DeepCopy()
+				newPod.Status.ContainerStatuses = []corev1.ContainerStatus{
+					succeededMainContainerStatus,
+					failedSidecarContainerStatus,
+				}
+				newPod.Status.Phase = corev1.PodSucceeded
+				return newPod
+			},
+			expectLen: 0,
+		},
+		{
 			name: "Pod, main container completed -> uncompleted, sidecar container completed",
 			getOldPod: func() *corev1.Pod {
 				oldPod := oldPodDemo.DeepCopy()
@@ -260,13 +302,27 @@ func TestEnqueueRequestForPodCreate(t *testing.T) {
 			expectLen: 1,
 		},
 		{
-			name: "Pod, main container completed, sidecar container completed",
+			name: "Pod, main container completed, sidecar container completed and pod has reached succeeded phase",
 			getPod: func() *corev1.Pod {
 				newPod := demoPod.DeepCopy()
 				newPod.Status.ContainerStatuses = []corev1.ContainerStatus{
 					succeededMainContainerStatus,
 					completedSidecarContainerStatus,
 				}
+				newPod.Status.Phase = corev1.PodSucceeded
+				return newPod
+			},
+			expectLen: 0,
+		},
+		{
+			name: "Pod, main container completed, sidecar container failed and pod has reached succeeded phase",
+			getPod: func() *corev1.Pod {
+				newPod := demoPod.DeepCopy()
+				newPod.Status.ContainerStatuses = []corev1.ContainerStatus{
+					succeededMainContainerStatus,
+					failedSidecarContainerStatus,
+				}
+				newPod.Status.Phase = corev1.PodSucceeded
 				return newPod
 			},
 			expectLen: 0,

--- a/pkg/webhook/util/util.go
+++ b/pkg/webhook/util/util.go
@@ -20,8 +20,9 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/openkruise/kruise/pkg/util"
 	"k8s.io/klog/v2"
+
+	"github.com/openkruise/kruise/pkg/util"
 )
 
 func GetHost() string {


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

Pods are not allowed to transition out of terminal phases when kubelet report the pod status.([ref](https://github.com/kubernetes/kubernetes/blob/c07c739f04880a41b624009f4a2c5459d5cbac6c/pkg/kubelet/kubelet_pods.go#L1586))
Base on this context, the proposal as bellow：
In the sidecar terminator controller:
1，Calculate the Pod phase from the exit-code of the main container:
   the pod phase will be Succeeded,  if all main containers are succeeded .
   the pod phase will be failed ,if at least one main container is failed(the exitCode is not zero)  .
2,  Terminate it if the job pod is complete.

3, Terminate the pod and set the condition of the pod as the bellow:

```yaml
- lastProbeTime: null
    lastTransitionTime: "2023-06-06T14:06:08Z"
    status: "True"
    type: SidecarTerminated
```

4, If the job pod is completed, we will skip terminating the pod. Check whether a job is complete by:

```go
func isJobPodCompleted(pod *corev1.Pod) bool {
	mainContainers := getMain(pod)
	if !containersCompleted(pod, mainContainers) {
		return false
	}
	if containersSucceeded(pod, mainContainers) {
		return pod.Status.Phase == corev1.PodSucceeded
	} else {
		return pod.Status.Phase == corev1.PodFailed
	}
}
```

Native controller actions:

1 .Job controller update the status of the job when pod phase is updated. 
2. As we said above, kubelet only update the container status and do not update the pod phase since it is terminal phase. And the pod will reach a final state.
3. Kubelet will kill the containers that are not in terminal phase, after the pod the terminated by sidecar terminator.


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #1285 
### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

