### PR TITLE
fix: modify the ginkgo.By name of pvc deletion protection e2e

### DIFF
--- a/test/e2e/policy/deletionprotection.go
+++ b/test/e2e/policy/deletionprotection.go
@@ -153,7 +153,7 @@ var _ = SIGDescribe("DeletionProtection", func() {
 			gomega.Expect(err).To(gomega.HaveOccurred())
 			gomega.Expect(err.Error()).Should(gomega.ContainSubstring(deleteForbiddenMessage))
 
-			ginkgo.By("Delete the PV bounded to PVC")
+			ginkgo.By("Delete the PVC just created")
 			err = c.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.TODO(), pvcName, metav1.DeleteOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			time.Sleep(3 * time.Second)


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
In the e2e of pvc deletion protection, I notice there is a "ginkgo.By" name at [here](https://github.com/openkruise/kruise/blob/master/test/e2e/policy/deletionprotection.go#L156) sholud be changed.
The operation at here is to delete the PVC itself, which is not "Delete the PV bounded to PVC".

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
None.

### Ⅲ. Describe how to verify it
None.

### Ⅳ. Special notes for reviews
None.
