### PR TITLE
add condition and event info for not upgradable pods when update sidecarset (#1272)

### DIFF
--- a/pkg/control/sidecarcontrol/util.go
+++ b/pkg/control/sidecarcontrol/util.go
@@ -61,6 +61,9 @@ const (
 	// SidecarsetInplaceUpdateStateKey records the state of inplace-update.
 	// The value of annotation is SidecarsetInplaceUpdateStateKey.
 	SidecarsetInplaceUpdateStateKey string = "kruise.io/sidecarset-inplace-update-state"
+
+	// SidecarSetUpgradable is a pod condition to indicate whether the pod's sidecarset is upgradable
+	SidecarSetUpgradable corev1.PodConditionType = "SidecarSetUpgradable"
 )
 
 var (

--- a/pkg/controller/sidecarset/sidecarset_processor.go
+++ b/pkg/controller/sidecarset/sidecarset_processor.go
@@ -31,6 +31,7 @@ import (
 	utilclient "github.com/openkruise/kruise/pkg/util/client"
 	historyutil "github.com/openkruise/kruise/pkg/util/history"
 	webhookutil "github.com/openkruise/kruise/pkg/webhook/util"
+	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 
 	apps "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -155,7 +156,18 @@ func (p *Processor) UpdateSidecarSet(sidecarSet *appsv1alpha1.SidecarSet) (recon
 func (p *Processor) updatePods(control sidecarcontrol.SidecarControl, pods []*corev1.Pod) error {
 	sidecarset := control.GetSidecarset()
 	// compute next updated pods based on the sidecarset upgrade strategy
-	upgradePods := NewStrategy().GetNextUpgradePods(control, pods)
+	upgradePods, notUpgradablePods := NewStrategy().GetNextUpgradePods(control, pods)
+	for _, pod := range notUpgradablePods {
+		if err := p.updateNotUpgradablePodCondition(sidecarset, pod); err != nil {
+			klog.Errorf("update NotUpgradable PodCondition error, s:%s, pod:%s, err:%v", sidecarset.Name, pod.Name, err)
+			return err
+		}
+		sidecarcontrol.UpdateExpectations.ExpectUpdated(sidecarset.Name, sidecarcontrol.GetSidecarSetRevision(sidecarset), pod)
+	}
+	if len(notUpgradablePods) > 0 {
+		p.recorder.Eventf(sidecarset, corev1.EventTypeNormal, "NotUpgradablePods", "SidecarSet in-place update detected %d not upgradable pod(s) in this round, will skip them.", len(notUpgradablePods))
+	}
+
 	if len(upgradePods) == 0 {
 		klog.V(3).Infof("sidecarSet next update is nil, skip this round, name: %s", sidecarset.Name)
 		return nil
@@ -197,9 +209,26 @@ func (p *Processor) updatePodSidecarAndHash(control sidecarcontrol.SidecarContro
 			klog.Errorf("sidecarSet(%s) patch pod(%s/%s) metadata failed: %s", sidecarSet.Name, podClone.Namespace, podClone.Name, err.Error())
 			return err
 		}
-		//update pod in store
+		// update pod in store
 		return p.Client.Update(context.TODO(), podClone)
 	})
+
+	if err != nil {
+		return err
+	}
+
+	// patch SidecarSetUpgradable condition
+	if conditionChanged := podutil.UpdatePodCondition(&podClone.Status, &corev1.PodCondition{
+		Type:   sidecarcontrol.SidecarSetUpgradable,
+		Status: corev1.ConditionTrue,
+	}); !conditionChanged {
+		// reduce unnecessary patch.
+		return nil
+	}
+
+	_, condition := podutil.GetPodCondition(&podClone.Status, sidecarcontrol.SidecarSetUpgradable)
+	mergePatch := fmt.Sprintf(`{"status": {"conditions": [%s]}}`, util.DumpJSON(condition))
+	err = p.Client.Status().Patch(context.TODO(), podClone, client.RawPatch(types.StrategicMergePatchType, []byte(mergePatch)))
 	return err
 }
 
@@ -601,4 +630,34 @@ func inconsistentStatus(sidecarSet *appsv1alpha1.SidecarSet, status *appsv1alpha
 
 func isSidecarSetUpdateFinish(status *appsv1alpha1.SidecarSetStatus) bool {
 	return status.UpdatedPods >= status.MatchedPods
+}
+
+func (p *Processor) updateNotUpgradablePodCondition(sidecarset *appsv1alpha1.SidecarSet, notUpgradablePod *corev1.Pod) error {
+
+	podClone := &corev1.Pod{}
+
+	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		if err := p.Client.Get(context.TODO(), types.NamespacedName{Namespace: notUpgradablePod.Namespace, Name: notUpgradablePod.Name}, podClone); err != nil {
+			klog.Errorf("error getting pod %s/%s from client", notUpgradablePod.Namespace, notUpgradablePod.Name)
+			return err
+		}
+		// update pod condition
+		conditionUpdateResult := podutil.UpdatePodCondition(&podClone.Status, &corev1.PodCondition{
+			Type:    sidecarcontrol.SidecarSetUpgradable,
+			Status:  corev1.ConditionFalse,
+			Reason:  "UpdateImmutableField",
+			Message: "Pod's sidecar set is not upgradable due to changes out of image field",
+		})
+		if !conditionUpdateResult {
+			return nil
+		}
+		err := p.Client.Status().Update(context.TODO(), podClone)
+		if err != nil {
+			return err
+		}
+		klog.V(3).Infof("sidecarSet(%s) updated pods(%s/%s) condition(%s=%s) success", sidecarset.Name, notUpgradablePod.Namespace, notUpgradablePod.Name, sidecarcontrol.SidecarSetUpgradable, corev1.ConditionFalse)
+		return nil
+	})
+
+	return err
 }

--- a/pkg/controller/sidecarset/sidecarset_strategy.go
+++ b/pkg/controller/sidecarset/sidecarset_strategy.go
@@ -22,7 +22,8 @@ type Strategy interface {
 	//2. Sort Pods with default sequence
 	//3. sort waitUpdateIndexes based on the scatter rules
 	//4. calculate max count of pods can update with maxUnavailable
-	GetNextUpgradePods(control sidecarcontrol.SidecarControl, pods []*corev1.Pod) []*corev1.Pod
+	//5. also return the pods that are not upgradable
+	GetNextUpgradePods(control sidecarcontrol.SidecarControl, pods []*corev1.Pod) (upgradePods []*corev1.Pod, notUpgradablePods []*corev1.Pod)
 }
 
 type spreadingStrategy struct{}
@@ -35,10 +36,12 @@ func NewStrategy() Strategy {
 	return globalSpreadingStrategy
 }
 
-func (p *spreadingStrategy) GetNextUpgradePods(control sidecarcontrol.SidecarControl, pods []*corev1.Pod) (upgradePods []*corev1.Pod) {
+func (p *spreadingStrategy) GetNextUpgradePods(control sidecarcontrol.SidecarControl, pods []*corev1.Pod) (upgradePods []*corev1.Pod, notUpgradablePods []*corev1.Pod) {
 	sidecarset := control.GetSidecarset()
 	// wait to upgrade pod index
 	var waitUpgradedIndexes []int
+	// because SidecarSet in-place update only support upgrading Image, if other fields are changed they will not be upgraded.
+	var notUpgradableIndexes []int
 	strategy := sidecarset.Spec.UpdateStrategy
 
 	// If selector is not nil, check whether the pods is selected to upgrade
@@ -68,12 +71,17 @@ func (p *spreadingStrategy) GetNextUpgradePods(control sidecarcontrol.SidecarCon
 	//  * It is to determine whether there are other fields that have been modified for pod.
 	for index, pod := range pods {
 		isUpdated := sidecarcontrol.IsPodSidecarUpdated(sidecarset, pod)
-		if !isUpdated && isSelected(pod) && control.IsSidecarSetUpgradable(pod) {
-			waitUpgradedIndexes = append(waitUpgradedIndexes, index)
+		if !isUpdated && isSelected(pod) {
+			if control.IsSidecarSetUpgradable(pod) {
+				waitUpgradedIndexes = append(waitUpgradedIndexes, index)
+			} else if sidecarcontrol.GetPodSidecarSetWithoutImageRevision(sidecarset.Name, pod) != sidecarcontrol.GetSidecarSetWithoutImageRevision(sidecarset) {
+				// only image field can be in-place updated, if other fields changed, mark pod as not upgradable
+				notUpgradableIndexes = append(notUpgradableIndexes, index)
+			}
 		}
 	}
 
-	klog.V(3).Infof("sidecarSet(%s) matchedPods(%d) waitUpdated(%d)", sidecarset.Name, len(pods), len(waitUpgradedIndexes))
+	klog.V(3).Infof("sidecarSet(%s) matchedPods(%d) waitUpdated(%d) notUpgradable(%d)", sidecarset.Name, len(pods), len(waitUpgradedIndexes), len(notUpgradableIndexes))
 	//2. sort Pods with default sequence and scatter
 	waitUpgradedIndexes = SortUpdateIndexes(strategy, pods, waitUpgradedIndexes)
 
@@ -86,6 +94,10 @@ func (p *spreadingStrategy) GetNextUpgradePods(control sidecarcontrol.SidecarCon
 	//4. injectPods will be upgraded in the following process
 	for _, idx := range waitUpgradedIndexes {
 		upgradePods = append(upgradePods, pods[idx])
+	}
+	// 5. pods that are not upgradable will not be skipped in the following process
+	for _, idx := range notUpgradableIndexes {
+		notUpgradablePods = append(notUpgradablePods, pods[idx])
 	}
 	return
 }

--- a/pkg/controller/util/pod_condition_utils.go
+++ b/pkg/controller/util/pod_condition_utils.go
@@ -1,0 +1,24 @@
+package util
+
+import (
+	"encoding/json"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+// using pod condition message to get key-value pairs
+func GetMessageKvFromCondition(condition *v1.PodCondition) (map[string]interface{}, error) {
+	messageKv := make(map[string]interface{})
+	if condition != nil && condition.Message != "" {
+		if err := json.Unmarshal([]byte(condition.Message), &messageKv); err != nil {
+			return nil, err
+		}
+	}
+	return messageKv, nil
+}
+
+// using pod condition message to save key-value pairs
+func UpdateMessageKvCondition(kv map[string]interface{}, condition *v1.PodCondition) {
+	message, _ := json.Marshal(kv)
+	condition.Message = string(message)
+}

--- a/test/e2e/apps/sidecarset.go
+++ b/test/e2e/apps/sidecarset.go
@@ -899,6 +899,95 @@ var _ = SIGDescribe("SidecarSet", func() {
 			ginkgo.By("sidecarSet upgrade sidecar container (more than image field), no pod should be updated done")
 		})
 
+		framework.ConformanceIt("multi sidecarSet upgrade sidecar container, check pod condition", func() {
+			// create sidecarSet 1
+			sidecarSetIn1 := tester.NewBaseSidecarSet(ns)
+			sidecarSetIn1.Name = "test-sidecarset-1"
+			sidecarSetIn1.Spec.UpdateStrategy = appsv1alpha1.SidecarSetUpdateStrategy{
+				Type: appsv1alpha1.RollingUpdateSidecarSetStrategyType,
+			}
+			sidecarSetIn1.Spec.Containers = sidecarSetIn1.Spec.Containers[:1]
+			ginkgo.By(fmt.Sprintf("Creating SidecarSet %s", sidecarSetIn1.Name))
+			sidecarSetIn1, _ = tester.CreateSidecarSet(sidecarSetIn1)
+			time.Sleep(time.Second)
+
+			// create sidecarSet 2
+			sidecarSetIn2 := tester.NewBaseSidecarSet(ns)
+			sidecarSetIn2.Name = "test-sidecarset-2"
+			sidecarSetIn2.Spec.UpdateStrategy = appsv1alpha1.SidecarSetUpdateStrategy{
+				Type: appsv1alpha1.RollingUpdateSidecarSetStrategyType,
+			}
+			sidecarSetIn2.Spec.InitContainers = []appsv1alpha1.SidecarContainer{}
+			sidecarSetIn2.Spec.Containers = sidecarSetIn2.Spec.Containers[1:2]
+			ginkgo.By(fmt.Sprintf("Creating SidecarSet %s", sidecarSetIn2.Name))
+			sidecarSetIn2, _ = tester.CreateSidecarSet(sidecarSetIn2)
+			time.Sleep(time.Second)
+
+			// create deployment
+			deploymentIn := tester.NewBaseDeployment(ns)
+			deploymentIn.Spec.Replicas = utilpointer.Int32Ptr(2)
+			ginkgo.By(fmt.Sprintf("Creating Deployment(%s/%s)", deploymentIn.Namespace, deploymentIn.Name))
+			tester.CreateDeployment(deploymentIn)
+
+			sidecarSetIn1, err := kc.AppsV1alpha1().SidecarSets().Get(context.TODO(), sidecarSetIn1.Name, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			sidecarSetIn2, err = kc.AppsV1alpha1().SidecarSets().Get(context.TODO(), sidecarSetIn2.Name, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// modify sidecarSet1 field out of image, should not update pod
+			sidecarSetIn1.Spec.Containers[0].Command = []string{"sleep", "1000"}
+			tester.UpdateSidecarSet(sidecarSetIn1)
+			except := &appsv1alpha1.SidecarSetStatus{
+				MatchedPods:      2,
+				UpdatedPods:      0,
+				UpdatedReadyPods: 0,
+				ReadyPods:        2,
+			}
+			tester.WaitForSidecarSetUpgradeComplete(sidecarSetIn1, except)
+
+			// modify sidecarSet2, only change image
+			sidecarSetIn2.Spec.Containers[0].Image = NginxImage
+			tester.UpdateSidecarSet(sidecarSetIn2)
+			except = &appsv1alpha1.SidecarSetStatus{
+				MatchedPods:      2,
+				UpdatedPods:      2,
+				UpdatedReadyPods: 2,
+				ReadyPods:        2,
+			}
+			tester.WaitForSidecarSetUpgradeComplete(sidecarSetIn2, except)
+
+			// check all the pods' condition, due to sidecarSet1 is not updated, so the condition should be false
+			pods, err := tester.GetSelectorPods(deploymentIn.Namespace, deploymentIn.Spec.Selector)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			for _, pod := range pods {
+				_, condition := podutil.GetPodCondition(&pod.Status, sidecarcontrol.SidecarSetUpgradable)
+				gomega.Expect(condition.Status).Should(gomega.Equal(corev1.ConditionFalse))
+			}
+
+			// then update sidecarSet1, all the pods should be updated
+			sidecarSetIn1.Spec.Containers[0].Image = NewNginxImage
+			sidecarSetIn1.Spec.Containers[0].Command = []string{"tail", "-f", "/dev/null"}
+			tester.UpdateSidecarSet(sidecarSetIn1)
+			except = &appsv1alpha1.SidecarSetStatus{
+				MatchedPods:      2,
+				UpdatedPods:      2,
+				UpdatedReadyPods: 2,
+				ReadyPods:        2,
+			}
+			tester.WaitForSidecarSetUpgradeComplete(sidecarSetIn1, except)
+
+			// all the sidecarset is updated, so the condition should be true
+			pods, err = tester.GetSelectorPods(deploymentIn.Namespace, deploymentIn.Spec.Selector)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			for _, pod := range pods {
+				_, condition := podutil.GetPodCondition(&pod.Status, sidecarcontrol.SidecarSetUpgradable)
+				gomega.Expect(condition.Status).Should(gomega.Equal(corev1.ConditionTrue))
+			}
+
+			ginkgo.By("multi sidecarSet upgrade sidecar container, check pod condition done")
+		})
+
 		framework.ConformanceIt("sidecarSet upgrade cold sidecar container image, and paused", func() {
 			// create sidecarSet
 			sidecarSetIn := tester.NewBaseSidecarSet(ns)

--- a/test/e2e/apps/sidecarset.go
+++ b/test/e2e/apps/sidecarset.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
 	clientset "k8s.io/client-go/kubernetes"
+	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/controller/history"
 	utilpointer "k8s.io/utils/pointer"
 )
@@ -739,6 +740,8 @@ var _ = SIGDescribe("SidecarSet", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			for _, pod := range pods {
 				gomega.Expect(pod.Spec.Containers[0].Image).Should(gomega.Equal(BusyboxImage))
+				_, sidecarSetUpgradable := podutil.GetPodCondition(&pod.Status, sidecarcontrol.SidecarSetUpgradable)
+				gomega.Expect(sidecarSetUpgradable.Status).Should(gomega.Equal(corev1.ConditionTrue))
 			}
 			ginkgo.By(fmt.Sprintf("sidecarSet upgrade cold sidecar container image done"))
 		})


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

Currently the sidecar container in-place upgrade can only support changing of `image` field, if user changed other fields, the injected pods will not execute sidecar container upgrade. 

However, this rule is not explicit for users, they can not get any hint or info in this situation. This PR add an event for pods, when the injected sidecar  changed but cannot be upgrade. If user changed SidecarSet but the pods are not upgraded, they can use `kubectl describe sidecarset <sidecarset-name>` or `kubectl describe pod <pod-name>` to see the event and figure out the reason.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #1272 

### Ⅲ. Describe how to verify it

1. create a sidecar set

```
apiVersion: apps.kruise.io/v1alpha1
kind: SidecarSet
metadata:
  name: demo-sidecarset
spec:
  selector:
    matchLabels:
      app: demo-server
  updateStrategy:
    type: RollingUpdate
  containers:
  - name: sidecar
    image: nginx
```

2. create some pods with label (here I using a CloneSet), the pods will be injected with sidecar container immediately

```
apiVersion: apps.kruise.io/v1alpha1
kind: CloneSet
metadata:
  labels:
    app: demo-server
  name: demo-server
spec:
  updateStrategy:
    type: InPlaceIfPossible
  replicas: 3
  selector:
    matchLabels:
      app: demo-server
  template:
    metadata:
      labels:
        app: demo-server
    spec:
      containers:
      - name: demo-server
        image: tomcat
        ports:
        - containerPort: 8080
```

3. update the SidecarSet , change some fields more than `image` (here I change the `image` and add a `command` field)

```
apiVersion: apps.kruise.io/v1alpha1
kind: SidecarSet
metadata:
  name: demo-sidecarset
spec:
  selector:
    matchLabels:
      app: demo-server
  updateStrategy:
    type: RollingUpdate
  containers:
  - name: sidecar
    image: busybox
    command: [ "/bin/sh", "-c", "touch a.txt && tail -f a.txt"]
```

4. apply  the changed sidecarset, the pods will not be upgraded, using `kubectl  get pod `, we can see the condition info:

```
- lastProbeTime: null
    lastTransitionTime: "2023-06-19T05:41:13Z"
    message: Pod's sidecar set is not upgradable due to changes out of image field
    reason: UpdateImmutableField
    status: "False"
    type: SidecarSetUpgradable
```

5. and the SidecarSet got an event for not upgradable pods

```
Events:
  Type    Reason             Age                From                   Message
  ----    ------             ----               ----                   -------
  Normal  NotUpgradablePods  5s (x5 over 161m)  sidecarset-controller  SidecarSet in-place update detected 2 not upgradable pod(s) in this round, will skip them.
```

### Ⅳ. Special notes for reviews

