### PR TITLE
add status.labelSelector field to unitedDeployment to support scale sub-resource

### DIFF
--- a/apis/apps/v1alpha1/uniteddeployment_types.go
+++ b/apis/apps/v1alpha1/uniteddeployment_types.go
@@ -17,11 +17,12 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"github.com/openkruise/kruise/apis/apps/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/openkruise/kruise/apis/apps/v1beta1"
 )
 
 // UpdateStrategyType is a string enumeration type that enumerates
@@ -230,6 +231,9 @@ type UnitedDeploymentStatus struct {
 	// Records the information of update progress.
 	// +optional
 	UpdateStatus *UpdateStatus `json:"updateStatus,omitempty"`
+
+	// LabelSelector is label selectors for query over pods that should match the replica count used by HPA.
+	LabelSelector string `json:"labelSelector,omitempty"`
 }
 
 // UnitedDeploymentCondition describes current state of a UnitedDeployment.
@@ -267,7 +271,7 @@ type UpdateStatus struct {
 // +k8s:openapi-gen=true
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.selector
+// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.labelSelector
 // +kubebuilder:resource:shortName=ud
 // +kubebuilder:printcolumn:name="DESIRED",type="integer",JSONPath=".spec.replicas",description="The desired number of pods."
 // +kubebuilder:printcolumn:name="CURRENT",type="integer",JSONPath=".status.replicas",description="The number of currently all pods."

--- a/config/crd/bases/apps.kruise.io_uniteddeployments.yaml
+++ b/config/crd/bases/apps.kruise.io_uniteddeployments.yaml
@@ -1181,6 +1181,10 @@ spec:
                 description: CurrentRevision, if not empty, indicates the current
                   version of the UnitedDeployment.
                 type: string
+              labelSelector:
+                description: LabelSelector is label selectors for query over pods
+                  that should match the replica count used by HPA.
+                type: string
               observedGeneration:
                 description: ObservedGeneration is the most recent generation observed
                   for this UnitedDeployment. It corresponds to the UnitedDeployment's
@@ -1234,7 +1238,7 @@ spec:
     storage: true
     subresources:
       scale:
-        labelSelectorPath: .status.selector
+        labelSelectorPath: .status.labelSelector
         specReplicasPath: .spec.replicas
         statusReplicasPath: .status.replicas
       status: {}

--- a/pkg/controller/uniteddeployment/uniteddeployment_controller.go
+++ b/pkg/controller/uniteddeployment/uniteddeployment_controller.go
@@ -22,12 +22,6 @@ import (
 	"fmt"
 	"reflect"
 
-	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
-	appsv1beta1 "github.com/openkruise/kruise/apis/apps/v1beta1"
-	"github.com/openkruise/kruise/pkg/controller/uniteddeployment/adapter"
-	utilclient "github.com/openkruise/kruise/pkg/util/client"
-	utildiscovery "github.com/openkruise/kruise/pkg/util/discovery"
-	"github.com/openkruise/kruise/pkg/util/ratelimiter"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -40,6 +34,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
+	appsv1beta1 "github.com/openkruise/kruise/apis/apps/v1beta1"
+	"github.com/openkruise/kruise/pkg/controller/uniteddeployment/adapter"
+	"github.com/openkruise/kruise/pkg/util"
+	utilclient "github.com/openkruise/kruise/pkg/util/client"
+	utildiscovery "github.com/openkruise/kruise/pkg/util/discovery"
+	"github.com/openkruise/kruise/pkg/util/ratelimiter"
 )
 
 func init() {
@@ -231,6 +233,14 @@ func (r *ReconcileUnitedDeployment) Reconcile(_ context.Context, request reconci
 		return reconcile.Result{}, err
 	}
 
+	selector, err := util.ValidatedLabelSelectorAsSelector(instance.Spec.Selector)
+	if err != nil {
+		klog.Errorf("Error converting UnitedDeployment %s selector: %v", request, err)
+		// This is a non-transient error, so don't retry.
+		return reconcile.Result{}, nil
+	}
+	newStatus.LabelSelector = selector.String()
+
 	return r.updateStatus(instance, newStatus, oldStatus, nameToSubset, nextReplicas, nextPartitions, currentRevision, updatedRevision, collisionCount, control)
 }
 
@@ -412,6 +422,7 @@ func (r *ReconcileUnitedDeployment) updateUnitedDeployment(ud *appsv1alpha1.Unit
 		oldStatus.UpdatedReadyReplicas == newStatus.UpdatedReadyReplicas &&
 		oldStatus.CurrentRevision == newStatus.CurrentRevision &&
 		oldStatus.CollisionCount == newStatus.CollisionCount &&
+		oldStatus.LabelSelector == newStatus.LabelSelector &&
 		ud.Generation == newStatus.ObservedGeneration &&
 		reflect.DeepEqual(oldStatus.SubsetReplicas, newStatus.SubsetReplicas) &&
 		reflect.DeepEqual(oldStatus.UpdateStatus, newStatus.UpdateStatus) &&


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Add status.labelSelector field to unitedDeployment to support scale sub-resource

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #1308 
### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

