### PR TITLE
optimize webhook patchResponse function

### DIFF
--- a/pkg/webhook/pod/mutating/pod_create_update_handler.go
+++ b/pkg/webhook/pod/mutating/pod_create_update_handler.go
@@ -58,7 +58,7 @@ func (h *PodCreateHandler) Handle(ctx context.Context, req admission.Request) ad
 	if obj.Namespace == "" {
 		obj.Namespace = req.Namespace
 	}
-
+	oriObj := obj.DeepCopy()
 	var changed bool
 
 	if skip := injectPodReadinessGate(req, obj); !skip {
@@ -110,7 +110,11 @@ func (h *PodCreateHandler) Handle(ctx context.Context, req admission.Request) ad
 	if err != nil {
 		return admission.Errored(http.StatusInternalServerError, err)
 	}
-	return admission.PatchResponseFromRaw(req.AdmissionRequest.Object.Raw, marshalled)
+	original, err := json.Marshal(oriObj)
+	if err != nil {
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+	return admission.PatchResponseFromRaw(original, marshalled)
 }
 
 var _ inject.Client = &PodCreateHandler{}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
There is a risk that the current webhook patch method will cause some fields to be lost if the rollout references a low version of the api. For example, k8s 1.26 adds a new field topologySpreadConstraint.minDomains, the field will be lost after the webhook.
