### PR TITLE
change hot upgrade type

### DIFF
--- a/pkg/control/sidecarcontrol/sidecarset_control.go
+++ b/pkg/control/sidecarcontrol/sidecarset_control.go
@@ -161,7 +161,6 @@ func (c *commonControl) UpdatePodAnnotationsInUpgrade(changedContainers []string
 	}
 	by, _ = json.Marshal(mainContainerStatuses)
 	pod.Annotations[SidecarSetBeforeHotUpgradeStateKey] = string(by)
-	return
 }
 
 // only check sidecar container is consistent

--- a/pkg/control/sidecarcontrol/util.go
+++ b/pkg/control/sidecarcontrol/util.go
@@ -64,6 +64,8 @@ const (
 
 	// SidecarSetUpgradable is a pod condition to indicate whether the pod's sidecarset is upgradable
 	SidecarSetUpgradable corev1.PodConditionType = "SidecarSetUpgradable"
+
+	SidecarSetBeforeHotUpgradeStateKey = "kruise.io/sidecarset-before-hotupgrade-main-container-state"
 )
 
 var (

--- a/pkg/controller/sidecarset/sidecarset_hotupgrade.go
+++ b/pkg/controller/sidecarset/sidecarset_hotupgrade.go
@@ -119,7 +119,7 @@ func getPreviousMainContainerStatus(pod *corev1.Pod) map[string]bool {
 	tmp := make(SidecarsetMainContainerStatus)
 	err := json.Unmarshal([]byte(v), &tmp)
 	if err != nil {
-		klog.Errorf("error unmarshaling pod(%s.%s)'s previous main container status, return nil", pod.Namespace, pod.Name)
+		klog.Errorf("error unmarshalling pod(%s/%s)'s previous main container status, return nil", pod.Namespace, pod.Name)
 		return nil
 	}
 	for k, v := range tmp {

--- a/pkg/features/kruise_features.go
+++ b/pkg/features/kruise_features.go
@@ -76,6 +76,9 @@ const (
 	// If TemplateNoDefaults is false, webhook should inject default fields only when the template changed.
 	TemplateNoDefaults featuregate.Feature = "TemplateNoDefaults"
 
+	// Controls whether hotupgrading process could be done when sidecarset pod are not ready at start.
+	SidecarsetHotupgradeIgnoreMainContainerReadyStatus featuregate.Feature = "SidecarsetHotupgradeIgnoreMainContainerReadyStatus"
+
 	// InPlaceUpdateEnvFromMetadata enables Kruise to in-place update a container in Pod
 	// when its env from labels/annotations changed and pod is in-place updating.
 	InPlaceUpdateEnvFromMetadata featuregate.Feature = "InPlaceUpdateEnvFromMetadata"
@@ -112,23 +115,24 @@ var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	KruiseDaemon:      {Default: true, PreRelease: featuregate.Beta},
 	DaemonWatchingPod: {Default: true, PreRelease: featuregate.Beta},
 
-	CloneSetShortHash:                         {Default: false, PreRelease: featuregate.Alpha},
-	KruisePodReadinessGate:                    {Default: false, PreRelease: featuregate.Alpha},
-	PreDownloadImageForInPlaceUpdate:          {Default: false, PreRelease: featuregate.Alpha},
-	CloneSetPartitionRollback:                 {Default: false, PreRelease: featuregate.Alpha},
-	ResourcesDeletionProtection:               {Default: true, PreRelease: featuregate.Alpha},
-	WorkloadSpread:                            {Default: true, PreRelease: featuregate.Alpha},
-	PodUnavailableBudgetDeleteGate:            {Default: true, PreRelease: featuregate.Alpha},
-	PodUnavailableBudgetUpdateGate:            {Default: false, PreRelease: featuregate.Alpha},
-	TemplateNoDefaults:                        {Default: false, PreRelease: featuregate.Alpha},
-	InPlaceUpdateEnvFromMetadata:              {Default: true, PreRelease: featuregate.Alpha},
-	StatefulSetAutoDeletePVC:                  {Default: true, PreRelease: featuregate.Alpha},
-	SidecarSetPatchPodMetadataDefaultsAllowed: {Default: false, PreRelease: featuregate.Alpha},
-	SidecarTerminator:                         {Default: false, PreRelease: featuregate.Alpha},
-	PodProbeMarkerGate:                        {Default: true, PreRelease: featuregate.Alpha},
-	PreDownloadImageForDaemonSetUpdate:        {Default: false, PreRelease: featuregate.Alpha},
-	CloneSetEventHandlerOptimization:          {Default: false, PreRelease: featuregate.Alpha},
-	PreparingUpdateAsUpdate:                   {Default: false, PreRelease: featuregate.Alpha},
+	CloneSetShortHash:                                  {Default: false, PreRelease: featuregate.Alpha},
+	KruisePodReadinessGate:                             {Default: false, PreRelease: featuregate.Alpha},
+	PreDownloadImageForInPlaceUpdate:                   {Default: false, PreRelease: featuregate.Alpha},
+	CloneSetPartitionRollback:                          {Default: false, PreRelease: featuregate.Alpha},
+	ResourcesDeletionProtection:                        {Default: true, PreRelease: featuregate.Alpha},
+	WorkloadSpread:                                     {Default: true, PreRelease: featuregate.Alpha},
+	PodUnavailableBudgetDeleteGate:                     {Default: true, PreRelease: featuregate.Alpha},
+	PodUnavailableBudgetUpdateGate:                     {Default: false, PreRelease: featuregate.Alpha},
+	TemplateNoDefaults:                                 {Default: false, PreRelease: featuregate.Alpha},
+	SidecarsetHotupgradeIgnoreMainContainerReadyStatus: {Default: false, PreRelease: featuregate.Alpha},
+	InPlaceUpdateEnvFromMetadata:                       {Default: true, PreRelease: featuregate.Alpha},
+	StatefulSetAutoDeletePVC:                           {Default: true, PreRelease: featuregate.Alpha},
+	SidecarSetPatchPodMetadataDefaultsAllowed:          {Default: false, PreRelease: featuregate.Alpha},
+	SidecarTerminator:                                  {Default: false, PreRelease: featuregate.Alpha},
+	PodProbeMarkerGate:                                 {Default: true, PreRelease: featuregate.Alpha},
+	PreDownloadImageForDaemonSetUpdate:                 {Default: false, PreRelease: featuregate.Alpha},
+	CloneSetEventHandlerOptimization:                   {Default: false, PreRelease: featuregate.Alpha},
+	PreparingUpdateAsUpdate:                            {Default: false, PreRelease: featuregate.Alpha},
 }
 
 func init() {


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
In our specific situation, we need to hotupgrade a pod even this pod has a notready container.But when a main container converts from ready status to notready status we consider it caused by the hotupgrade process and it cannot be successfully updated.
1. We set it as a configurable feature. It can be enabled in config or cmd.
2. We add judgement on whether a pod can be successfully hotupgraded.
### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

### Ⅲ. Describe how to verify it
We have added some unit tests to verify the whole process.

### Ⅳ. Special notes for reviews

