### PR TITLE
Feat:  DaemonSet support pre-download image after a few new Pods have been updated ready.

### DIFF
--- a/pkg/controller/daemonset/daemonset_controller.go
+++ b/pkg/controller/daemonset/daemonset_controller.go
@@ -415,11 +415,11 @@ func (dsc *ReconcileDaemonSet) syncDaemonSet(ctx context.Context, request reconc
 					klog.Errorf("Failed to GetScaledValueFromIntOrPercent of minUpdatedReadyPods for %s: %v", request, err)
 				}
 			}
-			// todo: check whether the updatedReadyPodsCount greater than minUpdatedReadyPodsCount
-			_ = minUpdatedReadyPodsCount
-			// pre-download images for new revision
-			if err := dsc.createImagePullJobsForInPlaceUpdate(ds, old, cur); err != nil {
-				klog.Errorf("Failed to create ImagePullJobs for %s: %v", request, err)
+			if minUpdatedReadyPodsCount <= int(ds.Status.UpdatedNumberScheduled) {
+				// pre-download images for new revision
+				if err := dsc.createImagePullJobsForInPlaceUpdate(ds, old, cur); err != nil {
+					klog.Errorf("Failed to create ImagePullJobs for %s: %v", request, err)
+				}
 			}
 		} else {
 			// delete ImagePullJobs if revisions have been consistent


### PR DESCRIPTION

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

Add apps.kruise.io/image-predownload-min-updated-ready-pods annotations to make to make sure the new image starting pre-download after a few new Pods have been updated ready.


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

