### PR TITLE
add prometheus for pub and deletion protection

### DIFF
--- a/main.go
+++ b/main.go
@@ -41,6 +41,7 @@ import (
 	appsv1beta1 "github.com/openkruise/kruise/apis/apps/v1beta1"
 	policyv1alpha1 "github.com/openkruise/kruise/apis/policy/v1alpha1"
 	extclient "github.com/openkruise/kruise/pkg/client"
+	"github.com/openkruise/kruise/pkg/control/pubcontrol"
 	"github.com/openkruise/kruise/pkg/controller"
 	"github.com/openkruise/kruise/pkg/features"
 	"github.com/openkruise/kruise/pkg/util"
@@ -186,6 +187,7 @@ func main() {
 		setupLog.Error(err, "unable to start ControllerFinder")
 		os.Exit(1)
 	}
+	pubcontrol.InitPubControl(mgr.GetClient(), mgr.GetEventRecorderFor("pub-controller"))
 
 	setupLog.Info("register field index")
 	if err := fieldindex.RegisterFieldIndexes(mgr.GetCache()); err != nil {

--- a/pkg/control/pubcontrol/api.go
+++ b/pkg/control/pubcontrol/api.go
@@ -20,10 +20,16 @@ import (
 	policyv1alpha1 "github.com/openkruise/kruise/apis/policy/v1alpha1"
 	"github.com/openkruise/kruise/pkg/util/controllerfinder"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-type PubControl interface {
+var PubControl pubControl
+var recorder record.EventRecorder
+var kclient client.Client
+
+type pubControl interface {
 	// IsPodReady indicates whether pod is fully ready
 	// 1. pod.Status.Phase == v1.PodRunning
 	// 2. pod.condition PodReady == true
@@ -41,9 +47,12 @@ type PubControl interface {
 	IsPodUnavailableChanged(oldPod, newPod *corev1.Pod) bool
 	// get pub for pod
 	GetPubForPod(pod *corev1.Pod) (*policyv1alpha1.PodUnavailableBudget, error)
+	// get pod controller of
+	GetPodControllerOf(pod *corev1.Pod) *metav1.OwnerReference
 }
 
-func NewPubControl(client client.Client) PubControl {
-	controllerFinder := controllerfinder.Finder
-	return &commonControl{controllerFinder: controllerFinder, Client: client}
+func InitPubControl(cli client.Client, rec record.EventRecorder) {
+	recorder = rec
+	kclient = cli
+	PubControl = &commonControl{controllerFinder: controllerfinder.Finder, Client: cli}
 }

--- a/pkg/control/pubcontrol/pub_control.go
+++ b/pkg/control/pubcontrol/pub_control.go
@@ -31,6 +31,7 @@ import (
 	"github.com/openkruise/kruise/pkg/util/inplaceupdate"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 	kubecontroller "k8s.io/kubernetes/pkg/controller"
@@ -166,6 +167,10 @@ func (c *commonControl) GetPubForPod(pod *corev1.Pod) (*policyv1alpha1.PodUnavai
 		return nil, err
 	}
 	return pub, nil
+}
+
+func (c *commonControl) GetPodControllerOf(pod *corev1.Pod) *metav1.OwnerReference {
+	return metav1.GetControllerOf(pod)
 }
 
 func getSidecarSetsInPod(pod *corev1.Pod) (sidecarSets, containers sets.String) {

--- a/pkg/control/pubcontrol/pub_control_utils_test.go
+++ b/pkg/control/pubcontrol/pub_control_utils_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/tools/record"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	utilpointer "k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -276,8 +277,8 @@ func TestPodUnavailableBudgetValidatePod(t *testing.T) {
 	for _, cs := range cases {
 		t.Run(cs.name, func(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cs.getPub()).Build()
-			control := NewPubControl(fakeClient)
-			allow, _, err := PodUnavailableBudgetValidatePod(fakeClient, control, cs.getPod(), cs.operation, false)
+			InitPubControl(fakeClient, record.NewFakeRecorder(10))
+			allow, _, err := PodUnavailableBudgetValidatePod(cs.getPod(), cs.operation, "fake-user", false)
 			if err != nil {
 				t.Fatalf("PodUnavailableBudgetValidatePod failed: %s", err.Error())
 			}
@@ -383,9 +384,9 @@ func TestGetPodUnavailableBudgetForPod(t *testing.T) {
 	for _, cs := range cases {
 		t.Run(cs.name, func(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cs.getDeployment(), cs.getReplicaSet(), cs.getPub()).Build()
-			control := NewPubControl(fakeClient)
+			InitPubControl(fakeClient, record.NewFakeRecorder(10))
 			pod := cs.getPod()
-			pub, err := control.GetPubForPod(pod)
+			pub, err := PubControl.GetPubForPod(pod)
 			if err != nil {
 				t.Fatalf("GetPubForPod failed: %s", err.Error())
 			}

--- a/pkg/controller/cloneset/sync/api.go
+++ b/pkg/controller/cloneset/sync/api.go
@@ -18,7 +18,6 @@ package sync
 
 import (
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
-	"github.com/openkruise/kruise/pkg/control/pubcontrol"
 	clonesetutils "github.com/openkruise/kruise/pkg/controller/cloneset/utils"
 	"github.com/openkruise/kruise/pkg/util/controllerfinder"
 	"github.com/openkruise/kruise/pkg/util/inplaceupdate"
@@ -49,7 +48,6 @@ type realControl struct {
 	inplaceControl   inplaceupdate.Interface
 	recorder         record.EventRecorder
 	controllerFinder *controllerfinder.ControllerFinder
-	pubControl       pubcontrol.PubControl
 }
 
 func New(c client.Client, recorder record.EventRecorder) Interface {
@@ -59,6 +57,5 @@ func New(c client.Client, recorder record.EventRecorder) Interface {
 		lifecycleControl: lifecycle.New(c),
 		recorder:         recorder,
 		controllerFinder: controllerfinder.Finder,
-		pubControl:       pubcontrol.NewPubControl(c),
 	}
 }

--- a/pkg/controller/cloneset/sync/cloneset_update.go
+++ b/pkg/controller/cloneset/sync/cloneset_update.go
@@ -24,13 +24,9 @@ import (
 
 	appspub "github.com/openkruise/kruise/apis/apps/pub"
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
-	policyv1alpha1 "github.com/openkruise/kruise/apis/policy/v1alpha1"
-	"github.com/openkruise/kruise/pkg/control/pubcontrol"
 	clonesetcore "github.com/openkruise/kruise/pkg/controller/cloneset/core"
 	clonesetutils "github.com/openkruise/kruise/pkg/controller/cloneset/utils"
-	"github.com/openkruise/kruise/pkg/features"
 	"github.com/openkruise/kruise/pkg/util"
-	utilfeature "github.com/openkruise/kruise/pkg/util/feature"
 	"github.com/openkruise/kruise/pkg/util/inplaceupdate"
 	"github.com/openkruise/kruise/pkg/util/lifecycle"
 	"github.com/openkruise/kruise/pkg/util/specifieddelete"
@@ -133,7 +129,7 @@ func (c *realControl) Update(cs *appsv1alpha1.CloneSet,
 	for _, idx := range waitUpdateIndexes {
 		pod := pods[idx]
 		// Determine the pub before updating the pod
-		if utilfeature.DefaultFeatureGate.Enabled(features.PodUnavailableBudgetUpdateGate) {
+		/*if utilfeature.DefaultFeatureGate.Enabled(features.PodUnavailableBudgetUpdateGate) {
 			allowed, _, err := pubcontrol.PodUnavailableBudgetValidatePod(c.Client, c.pubControl, pod, policyv1alpha1.PubUpdateOperation, false)
 			if err != nil {
 				return err
@@ -142,7 +138,7 @@ func (c *realControl) Update(cs *appsv1alpha1.CloneSet,
 				clonesetutils.DurationStore.Push(key, time.Second)
 				return nil
 			}
-		}
+		}*/
 		duration, err := c.updatePod(cs, coreControl, targetRevision, revisions, pod, pvcs)
 		if duration > 0 {
 			clonesetutils.DurationStore.Push(key, duration)

--- a/pkg/controller/cloneset/sync/cloneset_update_test.go
+++ b/pkg/controller/cloneset/sync/cloneset_update_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/openkruise/kruise/apis"
 	appspub "github.com/openkruise/kruise/apis/apps/pub"
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
-	"github.com/openkruise/kruise/pkg/control/pubcontrol"
 	clonesetcore "github.com/openkruise/kruise/pkg/controller/cloneset/core"
 	clonesetutils "github.com/openkruise/kruise/pkg/controller/cloneset/utils"
 	"github.com/openkruise/kruise/pkg/features"
@@ -957,7 +956,6 @@ func TestUpdate(t *testing.T) {
 				inplaceupdate.New(fakeClient, clonesetutils.RevisionAdapterImpl),
 				record.NewFakeRecorder(10),
 				&controllerfinder.ControllerFinder{Client: fakeClient},
-				pubcontrol.NewPubControl(fakeClient),
 			}
 			currentRevision := mc.updateRevision
 			if len(mc.revisions) > 0 {

--- a/pkg/controller/podunavailablebudget/pub_controller_test.go
+++ b/pkg/controller/podunavailablebudget/pub_controller_test.go
@@ -1148,13 +1148,12 @@ func TestPubReconcile(t *testing.T) {
 			for _, obj := range cs.getReplicaSet() {
 				_ = fakeClient.Create(context.TODO(), obj)
 			}
-
+			pubcontrol.InitPubControl(fakeClient, record.NewFakeRecorder(10))
 			controllerfinder.Finder = &controllerfinder.ControllerFinder{Client: fakeClient}
 			reconciler := ReconcilePodUnavailableBudget{
 				Client:           fakeClient,
 				recorder:         record.NewFakeRecorder(10),
 				controllerFinder: &controllerfinder.ControllerFinder{Client: fakeClient},
-				pubControl:       pubcontrol.NewPubControl(fakeClient),
 			}
 			_, err := reconciler.syncPodUnavailableBudget(pub)
 			if err != nil {

--- a/pkg/webhook/builtinworkloads/validating/builtin_handlers.go
+++ b/pkg/webhook/builtinworkloads/validating/builtin_handlers.go
@@ -79,6 +79,7 @@ func (h *WorkloadHandler) Handle(ctx context.Context, req admission.Request) adm
 	}
 
 	if err := deletionprotection.ValidateWorkloadDeletion(metaObj, replicas); err != nil {
+		deletionprotection.WorkloadDeletionProtectionMetrics.WithLabelValues(req.Kind.Kind, metaObj.GetName(), req.UserInfo.Username).Add(1)
 		return admission.Errored(http.StatusForbidden, err)
 	}
 	return admission.ValidationResponse(true, "")

--- a/pkg/webhook/cloneset/validating/cloneset_create_update_handler.go
+++ b/pkg/webhook/cloneset/validating/cloneset_create_update_handler.go
@@ -74,6 +74,7 @@ func (h *CloneSetCreateUpdateHandler) Handle(ctx context.Context, req admission.
 			return admission.Errored(http.StatusBadRequest, err)
 		}
 		if err := deletionprotection.ValidateWorkloadDeletion(oldObj, oldObj.Spec.Replicas); err != nil {
+			deletionprotection.WorkloadDeletionProtectionMetrics.WithLabelValues(req.Kind.Kind, oldObj.GetName(), req.UserInfo.Username).Add(1)
 			return admission.Errored(http.StatusForbidden, err)
 		}
 	}

--- a/pkg/webhook/customresourcedefinition/validating/crd_handler.go
+++ b/pkg/webhook/customresourcedefinition/validating/crd_handler.go
@@ -85,6 +85,7 @@ func (h *CRDHandler) Handle(ctx context.Context, req admission.Request) admissio
 	}
 
 	if err := deletionprotection.ValidateCRDDeletion(h.Client, metaObj, gvk); err != nil {
+		deletionprotection.CRDDeletionProtectionMetrics.WithLabelValues(metaObj.GetName(), req.UserInfo.Username).Add(1)
 		return admission.Errored(http.StatusForbidden, err)
 	}
 	return admission.ValidationResponse(true, "")

--- a/pkg/webhook/pod/validating/pod_create_update_handler.go
+++ b/pkg/webhook/pod/validating/pod_create_update_handler.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/openkruise/kruise/pkg/control/pubcontrol"
 	"github.com/openkruise/kruise/pkg/features"
 	"github.com/openkruise/kruise/pkg/util/controllerfinder"
 	utilfeature "github.com/openkruise/kruise/pkg/util/feature"
@@ -42,8 +41,7 @@ type PodCreateHandler struct {
 	// Decoder decodes objects
 	Decoder *admission.Decoder
 
-	finders    *controllerfinder.ControllerFinder
-	pubControl pubcontrol.PubControl
+	finders *controllerfinder.ControllerFinder
 }
 
 func (h *PodCreateHandler) validatingPodFn(ctx context.Context, req admission.Request) (allowed bool, reason string, err error) {
@@ -91,7 +89,6 @@ var _ inject.Client = &PodCreateHandler{}
 func (h *PodCreateHandler) InjectClient(c client.Client) error {
 	h.Client = c
 	h.finders = controllerfinder.Finder
-	h.pubControl = pubcontrol.NewPubControl(c)
 	return nil
 }
 

--- a/pkg/webhook/pod/validating/pod_unavailable_budget.go
+++ b/pkg/webhook/pod/validating/pod_unavailable_budget.go
@@ -58,7 +58,7 @@ func (p *PodCreateHandler) podUnavailableBudgetValidatingPod(ctx context.Context
 			return false, "", err
 		}
 		// the change will not cause pod unavailability, then pass
-		if !p.pubControl.IsPodUnavailableChanged(oldPod, newPod) {
+		if !pubcontrol.PubControl.IsPodUnavailableChanged(oldPod, newPod) {
 			klog.V(6).Infof("validate pod(%s/%s) changed can not cause unavailability, then don't need check pub", newPod.Namespace, newPod.Name)
 			return true, "", nil
 		}
@@ -122,5 +122,5 @@ func (p *PodCreateHandler) podUnavailableBudgetValidatingPod(ctx context.Context
 	if checkPod.Annotations[pubcontrol.PodRelatedPubAnnotation] == "" {
 		return true, "", nil
 	}
-	return pubcontrol.PodUnavailableBudgetValidatePod(p.Client, p.pubControl, checkPod, operation, dryRun)
+	return pubcontrol.PodUnavailableBudgetValidatePod(checkPod, operation, req.UserInfo.Username, dryRun)
 }

--- a/pkg/webhook/pod/validating/pod_unavailable_budget_test.go
+++ b/pkg/webhook/pod/validating/pod_unavailable_budget_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/tools/record"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/apis/policy"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -473,10 +474,10 @@ func TestValidateUpdatePodForPub(t *testing.T) {
 			decoder, _ := admission.NewDecoder(scheme)
 			fClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cs.pub()).Build()
 			podHandler := PodCreateHandler{
-				Client:     fClient,
-				Decoder:    decoder,
-				pubControl: pubcontrol.NewPubControl(fClient),
+				Client:  fClient,
+				Decoder: decoder,
 			}
+			pubcontrol.InitPubControl(fClient, record.NewFakeRecorder(10))
 			oldPodRaw := runtime.RawExtension{
 				Raw: []byte(util.DumpJSON(cs.oldPod())),
 			}
@@ -668,10 +669,10 @@ func TestValidateEvictPodForPub(t *testing.T) {
 			decoder, _ := admission.NewDecoder(scheme)
 			fClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cs.pub(), cs.newPod()).Build()
 			podHandler := PodCreateHandler{
-				Client:     fClient,
-				Decoder:    decoder,
-				pubControl: pubcontrol.NewPubControl(fClient),
+				Client:  fClient,
+				Decoder: decoder,
 			}
+			pubcontrol.InitPubControl(fClient, record.NewFakeRecorder(10))
 			evictionRaw := runtime.RawExtension{
 				Raw: []byte(util.DumpJSON(cs.eviction())),
 			}
@@ -824,10 +825,10 @@ func TestValidateDeletePodForPub(t *testing.T) {
 			decoder, _ := admission.NewDecoder(scheme)
 			fClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cs.pub(), cs.newPod()).Build()
 			podHandler := PodCreateHandler{
-				Client:     fClient,
-				Decoder:    decoder,
-				pubControl: pubcontrol.NewPubControl(fClient),
+				Client:  fClient,
+				Decoder: decoder,
 			}
+			pubcontrol.InitPubControl(fClient, record.NewFakeRecorder(10))
 			deletionRaw := runtime.RawExtension{
 				Raw: []byte(util.DumpJSON(cs.deletion())),
 			}

--- a/pkg/webhook/statefulset/validating/statefulset_create_update_handler.go
+++ b/pkg/webhook/statefulset/validating/statefulset_create_update_handler.go
@@ -86,6 +86,7 @@ func (h *StatefulSetCreateUpdateHandler) Handle(ctx context.Context, req admissi
 			return admission.Errored(http.StatusBadRequest, err)
 		}
 		if err := deletionprotection.ValidateWorkloadDeletion(oldObj, oldObj.Spec.Replicas); err != nil {
+			deletionprotection.WorkloadDeletionProtectionMetrics.WithLabelValues(req.Kind.Kind, oldObj.GetName(), req.UserInfo.Username).Add(1)
 			return admission.Errored(http.StatusForbidden, err)
 		}
 	}

--- a/pkg/webhook/uniteddeployment/validating/uniteddeployment_create_update_handler.go
+++ b/pkg/webhook/uniteddeployment/validating/uniteddeployment_create_update_handler.go
@@ -76,6 +76,7 @@ func (h *UnitedDeploymentCreateUpdateHandler) Handle(ctx context.Context, req ad
 			return admission.Errored(http.StatusBadRequest, err)
 		}
 		if err := deletionprotection.ValidateWorkloadDeletion(oldObj, oldObj.Spec.Replicas); err != nil {
+			deletionprotection.WorkloadDeletionProtectionMetrics.WithLabelValues(req.Kind.Kind, oldObj.GetName(), req.UserInfo.Username).Add(1)
 			return admission.Errored(http.StatusForbidden, err)
 		}
 	}

--- a/pkg/webhook/util/deletionprotection/prometheus.go
+++ b/pkg/webhook/util/deletionprotection/prometheus.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deletionprotection
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	NamespaceDeletionProtectionMetrics = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "namespace_deletion_protection",
+			Help: "Namespace Deletion Protection",
+		}, []string{"name", "username"},
+	)
+
+	CRDDeletionProtectionMetrics = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "crd_deletion_protection",
+			Help: "CustomResourceDefinition Deletion Protection",
+		}, []string{"name", "username"},
+	)
+
+	WorkloadDeletionProtectionMetrics = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "workload_deletion_protection",
+			Help: "Workload Deletion Protection",
+		}, []string{"kind", "name", "username"},
+	)
+)
+
+func init() {
+	metrics.Registry.MustRegister(NamespaceDeletionProtectionMetrics)
+	metrics.Registry.MustRegister(CRDDeletionProtectionMetrics)
+	metrics.Registry.MustRegister(WorkloadDeletionProtectionMetrics)
+}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Add prometheus for pub and deletion protection.
- namespace_deletion_protection{name='test-ns', username='kubernetes-admin'}
- crd_deletion_protection{name='advancedcronjobs.apps.kruise.io', username='kubernetes-admin'}
- workload_deletion_protection{kind='CloneSet', name='web-server', username='kubernetes-admin'}
- pod_unavailable_budget{kind='CloneSet', name='web-server', username='kubernetes-admin'}

Add event in pod for pub.
- Warning  PubPreventPodDeletion  7s (x2 over 33m)  pub-controller     openkruise pub prevents pod deletion
