### PR TITLE
Fix tools/kind are lost

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,8 @@ rm -rf $$TMP_DIR ;\
 }
 endef
 
+include tools/tools.mk
+
 # create-cluster creates a kube cluster with kind.
 .PHONY: create-cluster
 create-cluster: $(tools/kind)
@@ -141,7 +143,6 @@ run-kruise-e2e-test:
 	@echo -e "\n\033[36mRunning kruise e2e tests...\033[0m"
 	tools/hack/run-kruise-e2e-test.sh
 
-include tools/tools.mk
 
 # kruise-e2e-test runs kruise e2e tests.
 .PHONY: kruise-e2e-test


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
```
When I pull down the source code, running make create-cluster reports a kind of unfound error.

The makefile specifies that tools/kind will be executed first, but this command is not actually executed.
The reason is that tools/tools.mk was introduced relatively late
 

```
  
### Ⅲ. Describe how to verify it
```
 ⚙  ~/Desktop/code/openkruise/kruise   master  make create-cluster
tools/hack/create-cluster.sh
v1.24.2
ci-testing
tools/hack/create-cluster.sh: line 26: tools/bin/kind: No such file or directory
make: *** [create-cluster] Error 127

```

after change 
```
 ⚙  ~/Desktop/code/openkruise/kruise   master ✚  make create-cluster
cd tools/src/kind && GOOS= GOARCH= go build -o /Users/acejilam/Desktop/code/openkruise/kruise/tools/bin/kind $(sed -En 's,^import "(.*)".*,\1,p' pin.go)
tools/hack/create-cluster.sh
v1.24.2
ci-testing
Creating cluster "ci-testing" ...
⢎⡰ Ensuring node image (kindest/node:v1.24.2) 🖼 ^Z



```
 

