### PR TITLE
[Enhance] Use utilruntime.Must enhanced check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ kustomize: ## Download kustomize locally if necessary.
 
 GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
 golangci-lint: ## Download golangci-lint locally if necessary.
-	$(call go-get-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint@v1.42.1)
+	$(call go-get-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.2)
 
 GINKGO = $(shell pwd)/bin/ginkgo
 ginkgo: ## Download ginkgo locally if necessary.

--- a/main.go
+++ b/main.go
@@ -25,6 +25,8 @@ import (
 	"time"
 	_ "time/tzdata" // for AdvancedCronJob Time Zone support
 
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
 	"github.com/spf13/pflag"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -69,13 +71,13 @@ var (
 )
 
 func init() {
-	_ = clientgoscheme.AddToScheme(scheme)
-	_ = appsv1alpha1.AddToScheme(clientgoscheme.Scheme)
-	_ = appsv1beta1.AddToScheme(clientgoscheme.Scheme)
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(appsv1alpha1.AddToScheme(clientgoscheme.Scheme))
+	utilruntime.Must(appsv1beta1.AddToScheme(clientgoscheme.Scheme))
 
-	_ = appsv1alpha1.AddToScheme(scheme)
-	_ = appsv1beta1.AddToScheme(scheme)
-	_ = policyv1alpha1.AddToScheme(scheme)
+	utilruntime.Must(appsv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(appsv1beta1.AddToScheme(scheme))
+	utilruntime.Must(policyv1alpha1.AddToScheme(scheme))
 	scheme.AddUnversionedTypes(metav1.SchemeGroupVersion, &metav1.UpdateOptions{}, &metav1.DeleteOptions{}, &metav1.CreateOptions{})
 	// +kubebuilder:scaffold:scheme
 }

--- a/pkg/control/pubcontrol/pub_control_utils_test.go
+++ b/pkg/control/pubcontrol/pub_control_utils_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
 	appspub "github.com/openkruise/kruise/apis/apps/pub"
 	policyv1alpha1 "github.com/openkruise/kruise/apis/policy/v1alpha1"
 	apps "k8s.io/api/apps/v1"
@@ -36,9 +38,9 @@ import (
 
 func init() {
 	scheme = runtime.NewScheme()
-	_ = policyv1alpha1.AddToScheme(scheme)
-	_ = corev1.AddToScheme(scheme)
-	_ = apps.AddToScheme(scheme)
+	utilruntime.Must(policyv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(corev1.AddToScheme(scheme))
+	utilruntime.Must(apps.AddToScheme(scheme))
 }
 
 var (

--- a/pkg/control/sidecarcontrol/util_test.go
+++ b/pkg/control/sidecarcontrol/util_test.go
@@ -22,6 +22,8 @@ import (
 	"reflect"
 	"testing"
 
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
 	"github.com/openkruise/kruise/pkg/util"
 	"github.com/openkruise/kruise/pkg/util/configuration"
@@ -34,7 +36,7 @@ import (
 
 func init() {
 	sch = runtime.NewScheme()
-	_ = corev1.AddToScheme(sch)
+	utilruntime.Must(corev1.AddToScheme(sch))
 }
 
 var (

--- a/pkg/controller/advancedcronjob/advancedcronjob_controller_test.go
+++ b/pkg/controller/advancedcronjob/advancedcronjob_controller_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
 	"github.com/robfig/cron/v3"
 	"github.com/stretchr/testify/assert"
@@ -105,8 +107,8 @@ func TestScheduleWithTimeZone(t *testing.T) {
 // Test scenario:
 func TestReconcileAdvancedJobCreateBroadcastJob(t *testing.T) {
 	scheme := runtime.NewScheme()
-	_ = appsv1alpha1.AddToScheme(scheme)
-	_ = v1.AddToScheme(scheme)
+	utilruntime.Must(appsv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(v1.AddToScheme(scheme))
 
 	// A job
 	job1 := createJob("job1", broadcastJobTemplate())
@@ -142,9 +144,9 @@ func TestReconcileAdvancedJobCreateBroadcastJob(t *testing.T) {
 
 func TestReconcileAdvancedJobCreateJob(t *testing.T) {
 	scheme := runtime.NewScheme()
-	_ = appsv1alpha1.AddToScheme(scheme)
-	_ = batchv1.AddToScheme(scheme)
-	_ = v1.AddToScheme(scheme)
+	utilruntime.Must(appsv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(batchv1.AddToScheme(scheme))
+	utilruntime.Must(v1.AddToScheme(scheme))
 
 	// A job
 	job1 := createJob("job2", jobTemplate())

--- a/pkg/controller/broadcastjob/broadcastjob_controller_suite_test.go
+++ b/pkg/controller/broadcastjob/broadcastjob_controller_suite_test.go
@@ -22,7 +22,7 @@ package broadcastjob
 	//t := &envtest.Environment{
 	//	CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
 	//}
-	//apis.AddToScheme(scheme.Scheme)
+	//utilruntime.Must(apis.AddToScheme(scheme.Scheme))
 	//
 	//var err error
 	//if cfg, err = t.Start(); err != nil {

--- a/pkg/controller/broadcastjob/broadcastjob_controller_test.go
+++ b/pkg/controller/broadcastjob/broadcastjob_controller_test.go
@@ -22,6 +22,8 @@ import (
 	"reflect"
 	"testing"
 
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
@@ -90,8 +92,8 @@ func TestGetNodeToPodMap(t *testing.T) {
 // 1 new pod created on 1 node
 func TestReconcileJobCreatePodAbsolute(t *testing.T) {
 	scheme := runtime.NewScheme()
-	_ = appsv1alpha1.AddToScheme(scheme)
-	_ = v1.AddToScheme(scheme)
+	utilruntime.Must(appsv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(v1.AddToScheme(scheme))
 
 	p := intstr.FromInt(2)
 	// A job
@@ -146,8 +148,8 @@ func TestReconcileJobCreatePodAbsolute(t *testing.T) {
 // 1 new pod created on 1 node
 func TestReconcileJobCreatePodPercentage(t *testing.T) {
 	scheme := runtime.NewScheme()
-	_ = appsv1alpha1.AddToScheme(scheme)
-	_ = v1.AddToScheme(scheme)
+	utilruntime.Must(appsv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(v1.AddToScheme(scheme))
 
 	p := intstr.FromString("40%")
 	// A job
@@ -204,8 +206,8 @@ func TestReconcileJobCreatePodPercentage(t *testing.T) {
 // Check only 1 pod is created because the other node is unschedulable
 func TestPodsOnUnschedulableNodes(t *testing.T) {
 	scheme := runtime.NewScheme()
-	_ = appsv1alpha1.AddToScheme(scheme)
-	_ = v1.AddToScheme(scheme)
+	utilruntime.Must(appsv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(v1.AddToScheme(scheme))
 
 	p := intstr.FromInt(2)
 	// A job
@@ -250,8 +252,8 @@ func TestPodsOnUnschedulableNodes(t *testing.T) {
 // 10 pods created with slow start
 func TestReconcileJobMultipleBatches(t *testing.T) {
 	scheme := runtime.NewScheme()
-	_ = appsv1alpha1.AddToScheme(scheme)
-	_ = v1.AddToScheme(scheme)
+	utilruntime.Must(appsv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(v1.AddToScheme(scheme))
 
 	p := intstr.FromInt(20)
 	// A job
@@ -295,8 +297,8 @@ func TestReconcileJobMultipleBatches(t *testing.T) {
 // Check job state is failed
 func TestJobFailed(t *testing.T) {
 	scheme := runtime.NewScheme()
-	_ = appsv1alpha1.AddToScheme(scheme)
-	_ = v1.AddToScheme(scheme)
+	utilruntime.Must(appsv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(v1.AddToScheme(scheme))
 
 	// A job
 	p := intstr.FromInt(10)
@@ -347,8 +349,8 @@ func TestJobFailed(t *testing.T) {
 // check job phase is running
 func TestJobFailurePolicyTypeContinue(t *testing.T) {
 	scheme := runtime.NewScheme()
-	_ = appsv1alpha1.AddToScheme(scheme)
-	_ = v1.AddToScheme(scheme)
+	utilruntime.Must(appsv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(v1.AddToScheme(scheme))
 
 	// A job
 	p := intstr.FromInt(10)
@@ -394,8 +396,8 @@ func TestJobFailurePolicyTypeContinue(t *testing.T) {
 // check job phase is failed
 func TestJobFailurePolicyTypeFailFast(t *testing.T) {
 	scheme := runtime.NewScheme()
-	_ = appsv1alpha1.AddToScheme(scheme)
-	_ = v1.AddToScheme(scheme)
+	utilruntime.Must(appsv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(v1.AddToScheme(scheme))
 
 	// A job
 	p := intstr.FromInt(10)
@@ -441,8 +443,8 @@ func TestJobFailurePolicyTypeFailFast(t *testing.T) {
 // check job phase is paused
 func TestJobFailurePolicyPause(t *testing.T) {
 	scheme := runtime.NewScheme()
-	_ = appsv1alpha1.AddToScheme(scheme)
-	_ = v1.AddToScheme(scheme)
+	utilruntime.Must(appsv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(v1.AddToScheme(scheme))
 
 	// A job
 	p := intstr.FromInt(10)
@@ -489,8 +491,8 @@ func TestJobFailurePolicyPause(t *testing.T) {
 // check job phase is paused, and no new pod is created.
 func TestJobSetPaused(t *testing.T) {
 	scheme := runtime.NewScheme()
-	_ = appsv1alpha1.AddToScheme(scheme)
-	_ = v1.AddToScheme(scheme)
+	utilruntime.Must(appsv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(v1.AddToScheme(scheme))
 
 	p := intstr.FromString("50%")
 	// A job
@@ -532,8 +534,8 @@ func TestJobSetPaused(t *testing.T) {
 // The job should fail after activeDeadline, and active pods will be deleted
 func TestJobFailedAfterActiveDeadline(t *testing.T) {
 	scheme := runtime.NewScheme()
-	_ = appsv1alpha1.AddToScheme(scheme)
-	_ = v1.AddToScheme(scheme)
+	utilruntime.Must(appsv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(v1.AddToScheme(scheme))
 
 	// A job
 	p := intstr.FromInt(10)

--- a/pkg/controller/cloneset/cloneset_controller_suite_test.go
+++ b/pkg/controller/cloneset/cloneset_controller_suite_test.go
@@ -26,6 +26,8 @@ import (
 	"sync"
 	"testing"
 
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
 	"github.com/onsi/gomega"
 	"github.com/openkruise/kruise/apis"
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
@@ -46,8 +48,8 @@ import (
 
 func init() {
 	testscheme = k8sruntime.NewScheme()
-	_ = corev1.AddToScheme(testscheme)
-	_ = appsv1alpha1.AddToScheme(testscheme)
+	utilruntime.Must(corev1.AddToScheme(testscheme))
+	utilruntime.Must(appsv1alpha1.AddToScheme(testscheme))
 }
 
 var testscheme *k8sruntime.Scheme
@@ -59,7 +61,7 @@ func TestMain(m *testing.M) {
 	t := &envtest.Environment{
 		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
 	}
-	apis.AddToScheme(scheme.Scheme)
+	utilruntime.Must(apis.AddToScheme(scheme.Scheme))
 
 	var err error
 	if cfg, err = t.Start(); err != nil {

--- a/pkg/controller/cloneset/revision/cloneset_revision_test.go
+++ b/pkg/controller/cloneset/revision/cloneset_revision_test.go
@@ -21,6 +21,8 @@ import (
 	"reflect"
 	"testing"
 
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
 	"github.com/openkruise/kruise/apis"
 	clonesettest "github.com/openkruise/kruise/pkg/controller/cloneset/test"
 	v1 "k8s.io/api/core/v1"
@@ -29,7 +31,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	_ = apis.AddToScheme(scheme.Scheme)
+	utilruntime.Must(apis.AddToScheme(scheme.Scheme))
 }
 
 func TestCreateApplyRevision(t *testing.T) {

--- a/pkg/controller/cloneset/sync/cloneset_update_test.go
+++ b/pkg/controller/cloneset/sync/cloneset_update_test.go
@@ -23,6 +23,8 @@ import (
 	"testing"
 	"time"
 
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
 	"github.com/openkruise/kruise/apis"
 	appspub "github.com/openkruise/kruise/apis/apps/pub"
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
@@ -81,7 +83,7 @@ func getInt32Pointer(i int32) *int32 {
 }
 
 func TestUpdate(t *testing.T) {
-	apis.AddToScheme(scheme.Scheme)
+	utilruntime.Must(apis.AddToScheme(scheme.Scheme))
 	now := metav1.NewTime(time.Unix(time.Now().Add(-time.Hour).Unix(), 0))
 	cases := []manageCase{
 		{

--- a/pkg/controller/daemonset/daemonset_controller_test.go
+++ b/pkg/controller/daemonset/daemonset_controller_test.go
@@ -25,6 +25,8 @@ import (
 	"testing"
 	"time"
 
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
 	"github.com/openkruise/kruise/apis"
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
 	kruiseclientset "github.com/openkruise/kruise/pkg/client/clientset/versioned"
@@ -64,7 +66,7 @@ var (
 )
 
 func init() {
-	_ = apis.AddToScheme(scheme.Scheme)
+	utilruntime.Must(apis.AddToScheme(scheme.Scheme))
 }
 
 func newDaemonSet(name string) *appsv1alpha1.DaemonSet {

--- a/pkg/controller/imagelistpulljob/imagelistpulljob_controller_test.go
+++ b/pkg/controller/imagelistpulljob/imagelistpulljob_controller_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"testing"
 
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -43,8 +45,8 @@ var (
 
 func init() {
 	testscheme = k8sruntime.NewScheme()
-	_ = corev1.AddToScheme(testscheme)
-	_ = appsv1alpha1.AddToScheme(testscheme)
+	utilruntime.Must(corev1.AddToScheme(testscheme))
+	utilruntime.Must(appsv1alpha1.AddToScheme(testscheme))
 }
 
 func TestReconcile(t *testing.T) {

--- a/pkg/controller/nodepodprobe/node_pod_probe_controller_test.go
+++ b/pkg/controller/nodepodprobe/node_pod_probe_controller_test.go
@@ -21,6 +21,8 @@ import (
 	"reflect"
 	"testing"
 
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
 	"github.com/openkruise/kruise/pkg/util/controllerfinder"
 	corev1 "k8s.io/api/core/v1"
@@ -34,8 +36,8 @@ import (
 
 func init() {
 	scheme = runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	_ = appsv1alpha1.AddToScheme(scheme)
+	utilruntime.Must(corev1.AddToScheme(scheme))
+	utilruntime.Must(appsv1alpha1.AddToScheme(scheme))
 }
 
 var (

--- a/pkg/controller/persistentpodstate/persistent_pod_state_controller_test.go
+++ b/pkg/controller/persistentpodstate/persistent_pod_state_controller_test.go
@@ -23,6 +23,8 @@ import (
 	"testing"
 	"time"
 
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
 	appsv1beta1 "github.com/openkruise/kruise/apis/apps/v1beta1"
 	"github.com/openkruise/kruise/pkg/util/controllerfinder"
@@ -154,10 +156,10 @@ var (
 
 func init() {
 	scheme = runtime.NewScheme()
-	_ = appsv1alpha1.AddToScheme(scheme)
-	_ = corev1.AddToScheme(scheme)
-	_ = appsv1.AddToScheme(scheme)
-	_ = appsv1beta1.AddToScheme(scheme)
+	utilruntime.Must(appsv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(corev1.AddToScheme(scheme))
+	utilruntime.Must(appsv1.AddToScheme(scheme))
+	utilruntime.Must(appsv1beta1.AddToScheme(scheme))
 }
 
 func TestReconcilePersistentPodState(t *testing.T) {

--- a/pkg/controller/podprobemarker/pod_probe_marker_controller_test.go
+++ b/pkg/controller/podprobemarker/pod_probe_marker_controller_test.go
@@ -21,6 +21,8 @@ import (
 	"reflect"
 	"testing"
 
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
 	"github.com/openkruise/kruise/pkg/util/controllerfinder"
 	corev1 "k8s.io/api/core/v1"
@@ -34,8 +36,8 @@ import (
 
 func init() {
 	scheme = runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	_ = appsv1alpha1.AddToScheme(scheme)
+	utilruntime.Must(corev1.AddToScheme(scheme))
+	utilruntime.Must(appsv1alpha1.AddToScheme(scheme))
 }
 
 var (

--- a/pkg/controller/podunavailablebudget/pub_controller_test.go
+++ b/pkg/controller/podunavailablebudget/pub_controller_test.go
@@ -23,6 +23,8 @@ import (
 	"testing"
 	"time"
 
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
 	policyv1alpha1 "github.com/openkruise/kruise/apis/policy/v1alpha1"
 	"github.com/openkruise/kruise/pkg/control/pubcontrol"
 	"github.com/openkruise/kruise/pkg/util"
@@ -42,9 +44,9 @@ import (
 
 func init() {
 	scheme = runtime.NewScheme()
-	_ = policyv1alpha1.AddToScheme(scheme)
-	_ = corev1.AddToScheme(scheme)
-	_ = apps.AddToScheme(scheme)
+	utilruntime.Must(policyv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(corev1.AddToScheme(scheme))
+	utilruntime.Must(apps.AddToScheme(scheme))
 }
 
 var (

--- a/pkg/controller/sidecarset/sidecarset_controller_test.go
+++ b/pkg/controller/sidecarset/sidecarset_controller_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
 	"github.com/openkruise/kruise/pkg/control/sidecarcontrol"
 
@@ -130,11 +132,11 @@ var (
 
 func init() {
 	scheme = runtime.NewScheme()
-	_ = clientgoscheme.AddToScheme(scheme)
-	_ = appsv1alpha1.AddToScheme(clientgoscheme.Scheme)
-	_ = appsv1.AddToScheme(scheme)
-	_ = appsv1alpha1.AddToScheme(scheme)
-	_ = corev1.AddToScheme(scheme)
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(appsv1alpha1.AddToScheme(clientgoscheme.Scheme))
+	utilruntime.Must(appsv1.AddToScheme(scheme))
+	utilruntime.Must(appsv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(corev1.AddToScheme(scheme))
 }
 
 func getLatestPod(client client.Client, pod *corev1.Pod) (*corev1.Pod, error) {

--- a/pkg/controller/sidecarterminator/sidecar_terminator_controller_test.go
+++ b/pkg/controller/sidecarterminator/sidecar_terminator_controller_test.go
@@ -22,6 +22,8 @@ import (
 	"reflect"
 	"testing"
 
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -174,8 +176,8 @@ var (
 
 func init() {
 	scheme = runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	_ = appsv1alpha1.AddToScheme(scheme)
+	utilruntime.Must(corev1.AddToScheme(scheme))
+	utilruntime.Must(appsv1alpha1.AddToScheme(scheme))
 }
 
 func sidecarContainerFactory(name string, strategy string) corev1.Container {

--- a/pkg/controller/statefulset/statefulset_controller_suite_test.go
+++ b/pkg/controller/statefulset/statefulset_controller_suite_test.go
@@ -22,6 +22,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -35,7 +37,7 @@ func TestMain(m *testing.M) {
 	t := &envtest.Environment{
 		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
 	}
-	apis.AddToScheme(scheme.Scheme)
+	utilruntime.Must(apis.AddToScheme(scheme.Scheme))
 
 	var err error
 	if cfg, err = t.Start(); err != nil {

--- a/pkg/controller/uniteddeployment/uniteddeployment_controller_suite_test.go
+++ b/pkg/controller/uniteddeployment/uniteddeployment_controller_suite_test.go
@@ -24,6 +24,8 @@ import (
 	"sync"
 	"testing"
 
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
 	"github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -40,7 +42,7 @@ func TestMain(m *testing.M) {
 	t := &envtest.Environment{
 		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
 	}
-	apis.AddToScheme(scheme.Scheme)
+	utilruntime.Must(apis.AddToScheme(scheme.Scheme))
 
 	var err error
 	if cfg, err = t.Start(); err != nil {

--- a/pkg/controller/workloadspread/workloadspread_controller_test.go
+++ b/pkg/controller/workloadspread/workloadspread_controller_test.go
@@ -25,6 +25,8 @@ import (
 	"testing"
 	"time"
 
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -150,8 +152,8 @@ var (
 
 func init() {
 	scheme = runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	_ = appsv1alpha1.AddToScheme(scheme)
+	utilruntime.Must(corev1.AddToScheme(scheme))
+	utilruntime.Must(appsv1alpha1.AddToScheme(scheme))
 }
 
 func TestSubsetPodDeletionCost(t *testing.T) {

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -23,6 +23,8 @@ import (
 	"net/http"
 	"sync"
 
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
 	kruiseapis "github.com/openkruise/kruise/apis"
 	"github.com/openkruise/kruise/pkg/client"
 	"github.com/openkruise/kruise/pkg/daemon/containermeta"
@@ -57,8 +59,8 @@ var (
 )
 
 func init() {
-	_ = clientgoscheme.AddToScheme(scheme)
-	_ = kruiseapis.AddToScheme(scheme)
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(kruiseapis.AddToScheme(scheme))
 }
 
 // Runnable allows a component to be started.

--- a/pkg/util/discovery/discovery.go
+++ b/pkg/util/discovery/discovery.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"time"
 
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
 	"github.com/openkruise/kruise/apis"
 	"github.com/openkruise/kruise/pkg/client"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -43,7 +45,7 @@ var (
 )
 
 func init() {
-	_ = apis.AddToScheme(internalScheme)
+	utilruntime.Must(apis.AddToScheme(internalScheme))
 }
 
 func DiscoverGVK(gvk schema.GroupVersionKind) bool {

--- a/pkg/util/imagejob/imagejob_reader_test.go
+++ b/pkg/util/imagejob/imagejob_reader_test.go
@@ -24,6 +24,8 @@ import (
 	"sync"
 	"testing"
 
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
 	"github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -49,7 +51,7 @@ func TestMain(m *testing.M) {
 	t := &envtest.Environment{
 		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
 	}
-	apis.AddToScheme(clientgoscheme.Scheme)
+	utilruntime.Must(apis.AddToScheme(clientgoscheme.Scheme))
 
 	var err error
 	if cfg, err = t.Start(); err != nil {

--- a/pkg/util/workloadspread/workloadspread_test.go
+++ b/pkg/util/workloadspread/workloadspread_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 	"time"
 
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -341,10 +343,10 @@ var (
 
 func init() {
 	scheme = runtime.NewScheme()
-	_ = appsv1alpha1.AddToScheme(scheme)
-	_ = appsv1beta1.AddToScheme(scheme)
-	_ = appsv1.AddToScheme(scheme)
-	_ = corev1.AddToScheme(scheme)
+	utilruntime.Must(appsv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(appsv1beta1.AddToScheme(scheme))
+	utilruntime.Must(appsv1.AddToScheme(scheme))
+	utilruntime.Must(corev1.AddToScheme(scheme))
 }
 
 func TestWorkloadSpreadCreatePodWithoutFullName(t *testing.T) {

--- a/pkg/webhook/broadcastjob/mutating/broadcastjob_create_update_handler_test.go
+++ b/pkg/webhook/broadcastjob/mutating/broadcastjob_create_update_handler_test.go
@@ -6,6 +6,8 @@ import (
 	"sort"
 	"testing"
 
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
 	"github.com/openkruise/kruise/apis"
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
 	"gomodules.xyz/jsonpatch/v2"
@@ -16,7 +18,7 @@ import (
 )
 
 func TestHandle(t *testing.T) {
-	_ = apis.AddToScheme(scheme.Scheme)
+	utilruntime.Must(apis.AddToScheme(scheme.Scheme))
 
 	oldBroadcastJobStr := `{
     "metadata": {

--- a/pkg/webhook/persistentpodstate/validating/persistent_validating_test.go
+++ b/pkg/webhook/persistentpodstate/validating/persistent_validating_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"testing"
 
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
 	corev1 "k8s.io/api/core/v1"
 
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
@@ -31,8 +33,8 @@ import (
 
 func init() {
 	scheme = runtime.NewScheme()
-	_ = appsv1alpha1.AddToScheme(scheme)
-	_ = corev1.AddToScheme(scheme)
+	utilruntime.Must(appsv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(corev1.AddToScheme(scheme))
 }
 
 var (

--- a/pkg/webhook/pod/mutating/sidecarset_test.go
+++ b/pkg/webhook/pod/mutating/sidecarset_test.go
@@ -24,6 +24,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
 	"github.com/openkruise/kruise/apis"
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
 	"github.com/openkruise/kruise/pkg/control/sidecarcontrol"
@@ -50,7 +52,7 @@ func TestMain(m *testing.M) {
 	t := &envtest.Environment{
 		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "config", "crds")},
 	}
-	apis.AddToScheme(scheme.Scheme)
+	utilruntime.Must(apis.AddToScheme(scheme.Scheme))
 
 	code := m.Run()
 	t.Stop()

--- a/pkg/webhook/pod/validating/pod_unavailable_budget_test.go
+++ b/pkg/webhook/pod/validating/pod_unavailable_budget_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 	"time"
 
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
 	appspub "github.com/openkruise/kruise/apis/apps/pub"
 	policyv1alpha1 "github.com/openkruise/kruise/apis/policy/v1alpha1"
 	"github.com/openkruise/kruise/pkg/control/pubcontrol"
@@ -43,8 +45,8 @@ import (
 
 func init() {
 	scheme = runtime.NewScheme()
-	_ = policyv1alpha1.AddToScheme(scheme)
-	_ = corev1.AddToScheme(scheme)
+	utilruntime.Must(policyv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(corev1.AddToScheme(scheme))
 }
 
 var (

--- a/pkg/webhook/podprobemarker/validating/probe_validating_test.go
+++ b/pkg/webhook/podprobemarker/validating/probe_validating_test.go
@@ -19,6 +19,8 @@ package validating
 import (
 	"testing"
 
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,7 +31,7 @@ import (
 
 func init() {
 	scheme = runtime.NewScheme()
-	_ = appsv1alpha1.AddToScheme(scheme)
+	utilruntime.Must(appsv1alpha1.AddToScheme(scheme))
 }
 
 var (

--- a/pkg/webhook/podunavailablebudget/validating/pub_validating_test.go
+++ b/pkg/webhook/podunavailablebudget/validating/pub_validating_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"testing"
 
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
 	policyv1alpha1 "github.com/openkruise/kruise/apis/policy/v1alpha1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,7 +33,7 @@ import (
 
 func init() {
 	scheme = runtime.NewScheme()
-	_ = policyv1alpha1.AddToScheme(scheme)
+	utilruntime.Must(policyv1alpha1.AddToScheme(scheme))
 }
 
 var (

--- a/pkg/webhook/sidecarset/validating/sidecarset_validating_test.go
+++ b/pkg/webhook/sidecarset/validating/sidecarset_validating_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"testing"
 
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
 	"github.com/openkruise/kruise/pkg/features"
 	"github.com/openkruise/kruise/pkg/util"
@@ -49,8 +51,8 @@ var (
 
 func init() {
 	testScheme = runtime.NewScheme()
-	apps.AddToScheme(testScheme)
-	corev1.AddToScheme(testScheme)
+	utilruntime.Must(apps.AddToScheme(testScheme))
+	utilruntime.Must(corev1.AddToScheme(testScheme))
 }
 
 func TestValidateSidecarSet(t *testing.T) {

--- a/pkg/webhook/util/crd/crd.go
+++ b/pkg/webhook/util/crd/crd.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"reflect"
 
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apiextensionslisters "k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1"
@@ -38,7 +40,7 @@ var (
 )
 
 func init() {
-	_ = apis.AddToScheme(kruiseScheme)
+	utilruntime.Must(apis.AddToScheme(kruiseScheme))
 }
 
 func Ensure(client apiextensionsclientset.Interface, lister apiextensionslisters.CustomResourceDefinitionLister, caBundle []byte) error {

--- a/pkg/webhook/workloadspread/validating/workloadspread_validation_test.go
+++ b/pkg/webhook/workloadspread/validating/workloadspread_validation_test.go
@@ -19,6 +19,8 @@ import (
 	"strconv"
 	"testing"
 
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -108,7 +110,7 @@ var (
 
 func init() {
 	scheme = runtime.NewScheme()
-	_ = appsv1alpha1.AddToScheme(scheme)
+	utilruntime.Must(appsv1alpha1.AddToScheme(scheme))
 }
 
 func TestValidateWorkloadSpreadCreate(t *testing.T) {

--- a/test/e2e/apps/persistent_pod_state.go
+++ b/test/e2e/apps/persistent_pod_state.go
@@ -19,10 +19,11 @@ package apps
 import (
 	"context"
 	"fmt"
+	"time"
+
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
-	"time"
 
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 	"time"
 
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
 	// Never, ever remove the line with "/ginkgo". Without it,
 	// the ginkgo test runner will not detect that this
 	// directory contains a Ginkgo test suite.
@@ -73,10 +75,7 @@ func TestMain(m *testing.M) {
 
 func TestE2E(t *testing.T) {
 
-	err := kruiseapis.AddToScheme(scheme.Scheme)
-	if err != nil {
-		t.Fatal(err)
-	}
+	utilruntime.Must(kruiseapis.AddToScheme(scheme.Scheme))
 
 	klog.Infof("Args: %v", os.Args)
 	RunE2ETests(t)

--- a/test/e2e/framework/persistent_pod_state_util.go
+++ b/test/e2e/framework/persistent_pod_state_util.go
@@ -21,6 +21,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
+
 	kruiseappsv1beta1 "github.com/openkruise/kruise/apis/apps/v1beta1"
 	"github.com/openkruise/kruise/pkg/util/configuration"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -31,7 +33,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
-	"time"
 
 	"github.com/onsi/gomega"
 	kruiseclientset "github.com/openkruise/kruise/pkg/client/clientset/versioned"

--- a/tools/src/kind/pin.go
+++ b/tools/src/kind/pin.go
@@ -16,5 +16,3 @@
 // +build pin
 
 package ignore
-
-import "sigs.k8s.io/kind"


### PR DESCRIPTION
- 1. To ensure the correctness of AddToScheme
- 2. Consistency with official code style.

So use  `utilruntime.Must` verifies the result




`make test` use `golangci-lint@v1.42.1`
`ci.yaml` use golangci/golangci-lint-action@v3.5.0   <--> `golangci-lint@v1.51.2`
Now unified to version 1.51.2
 


  