### PR TITLE
Remove the WaitReady useless judgment  

### DIFF
--- a/main.go
+++ b/main.go
@@ -213,10 +213,7 @@ func main() {
 
 	go func() {
 		setupLog.Info("wait webhook ready")
-		if err = webhook.WaitReady(); err != nil {
-			setupLog.Error(err, "unable to wait webhook ready")
-			os.Exit(1)
-		}
+		_ = webhook.WaitReady()
 
 		setupLog.Info("setup controllers")
 		if err = controller.SetupWithManager(mgr); err != nil {


### PR DESCRIPTION
```
As you can see from the WaitReady snippet, there is only one return, and that is nil.
The outer nonempty judgment has no need to exist
```



```
func WaitReady() error {
	startTS := time.Now()
	var err error
	for {
		duration := time.Since(startTS)
		if err = Checker(nil); err == nil {
			return nil
		}

		if duration > time.Second*5 {
			klog.Warningf("Failed to wait webhook ready over %s: %v", duration, err)
		}
		time.Sleep(time.Second * 2)
	}

}
```