### PR TITLE
:pencil2: Fix the location of apps.kruise.io/container-launch-priorit…

### DIFF
--- a/docs/proposals/20210809-containerlaunchpriority.md
+++ b/docs/proposals/20210809-containerlaunchpriority.md
@@ -75,7 +75,8 @@ Or you can set the annotation in Pod to declare it needs ordered by containers s
 ```yaml
 apiVersion: v1
 kind: Pod
-  labels:
+metadata:
+  annotations:
     apps.kruise.io/container-launch-priority: Ordered
 spec:
   containers:


### PR DESCRIPTION
`
When I looked through kruise's documentation on container startup priorities, I only found a bit in the proposal that told me to set a kv in the label. But when I tried it, it didn't work.
After looking at the code, I know that it is in the declaration.

So I changed the kv position in the proposal to help others a little.
 
`
![image](https://github.com/openkruise/kruise/assets/38821215/5d16ba42-9b08-41e1-b45f-cce3dc962b13)