### PR TITLE
Add support for credential provider plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,9 @@ lint: golangci-lint ## Run golangci-lint against code.
 
 test: generate fmt vet manifests envtest ## Run tests
 	echo $(ENVTEST)
+	go build -o pkg/daemon/criruntime/imageruntime/fake_plugin/fake-credential-plugin pkg/daemon/criruntime/imageruntime/fake_plugin/main.go && chmod +x pkg/daemon/criruntime/imageruntime/fake_plugin/fake-credential-plugin
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./pkg/... -coverprofile cover.out
+	rm pkg/daemon/criruntime/imageruntime/fake_plugin/fake-credential-plugin
 
 coverage-report: ## Generate cover.html from cover.out
 	go tool cover -html=cover.out -o cover.html

--- a/pkg/daemon/criruntime/imageruntime/docker.go
+++ b/pkg/daemon/criruntime/imageruntime/docker.go
@@ -81,26 +81,26 @@ func (d *dockerImageService) PullImage(ctx context.Context, imageName, tag strin
 	fullName := imageName + ":" + tag
 	var ioReader io.ReadCloser
 
-	if len(pullSecrets) > 0 {
-		var authInfos []daemonutil.AuthInfo
-		authInfos, err = secret.ConvertToRegistryAuths(pullSecrets, registry)
-		if err == nil {
-			var pullErrs []error
-			for _, authInfo := range authInfos {
-				var pullErr error
-				klog.V(5).Infof("Pull image %v:%v with user %v", imageName, tag, authInfo.Username)
-				ioReader, pullErr = d.client.ImagePull(ctx, fullName, dockertypes.ImagePullOptions{RegistryAuth: authInfo.EncodeToString()})
-				if pullErr == nil {
-					return newImagePullStatusReader(ioReader), nil
-				}
-				d.handleRuntimeError(pullErr)
-				klog.Warningf("Failed to pull image %v:%v with user %v, err %v", imageName, tag, authInfo.Username, pullErr)
-				pullErrs = append(pullErrs, pullErr)
+	var authInfos []daemonutil.AuthInfo
+	authInfos, err = secret.ConvertToRegistryAuths(pullSecrets, registry)
+	if err == nil {
+		var pullErrs []error
+		for _, authInfo := range authInfos {
+			var pullErr error
+			klog.V(5).Infof("Pull image %v:%v with user %v", imageName, tag, authInfo.Username)
+			ioReader, pullErr = d.client.ImagePull(ctx, fullName, dockertypes.ImagePullOptions{RegistryAuth: authInfo.EncodeToString()})
+			if pullErr == nil {
+				return newImagePullStatusReader(ioReader), nil
 			}
-			if len(pullErrs) > 0 {
-				err = utilerrors.NewAggregate(pullErrs)
-			}
+			d.handleRuntimeError(pullErr)
+			klog.Warningf("Failed to pull image %v:%v with user %v, err %v", imageName, tag, authInfo.Username, pullErr)
+			pullErrs = append(pullErrs, pullErr)
 		}
+		if len(pullErrs) > 0 {
+			err = utilerrors.NewAggregate(pullErrs)
+		}
+	} else {
+		klog.Errorf("Failed to convert to auth info for registry, err %v", err)
 	}
 
 	// Try the default secret

--- a/pkg/daemon/criruntime/imageruntime/fake_plugin/main.go
+++ b/pkg/daemon/criruntime/imageruntime/fake_plugin/main.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"k8s.io/component-base/logs"
+	"k8s.io/klog/v2"
+	"k8s.io/kubelet/pkg/apis/credentialprovider/install"
+	v1 "k8s.io/kubelet/pkg/apis/credentialprovider/v1"
+)
+
+var (
+	scheme = runtime.NewScheme()
+	codecs = serializer.NewCodecFactory(scheme)
+)
+
+func init() {
+	install.Install(scheme)
+}
+
+func getCredentials(ctx context.Context, image string, args []string) (*v1.CredentialProviderResponse, error) {
+	response := &v1.CredentialProviderResponse{
+		CacheKeyType: v1.RegistryPluginCacheKeyType,
+		Auth: map[string]v1.AuthConfig{
+			"registry.plugin.com/test": {
+				Username: "user",
+				Password: "password",
+			},
+		},
+	}
+	return response, nil
+}
+
+func runPlugin(ctx context.Context, r io.Reader, w io.Writer, args []string) error {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return err
+	}
+
+	_, err = json.DefaultMetaFactory.Interpret(data)
+	if err != nil {
+		return err
+	}
+
+	request, err := decodeRequest(data)
+	if err != nil {
+		return err
+	}
+
+	if request.Image == "" {
+		return errors.New("image in plugin request was empty")
+	}
+
+	// Deny all requests except for those where the image URL contains registry.plugin.com
+	// to test whether kruise could get expected auths if plugin fails to run
+	if !strings.Contains(request.Image, "registry.plugin.com") {
+		return errors.New("image in plugin request not supported: " + request.Image)
+	}
+
+	response, err := getCredentials(ctx, request.Image, args)
+	if err != nil {
+		return err
+	}
+
+	if response == nil {
+		return errors.New("CredentialProviderResponse from plugin was nil")
+	}
+
+	encodedResponse, err := encodeResponse(response)
+	if err != nil {
+		return err
+	}
+
+	writer := bufio.NewWriter(w)
+	defer writer.Flush()
+	if _, err := writer.Write(encodedResponse); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func decodeRequest(data []byte) (*v1.CredentialProviderRequest, error) {
+	obj, gvk, err := codecs.UniversalDecoder(v1.SchemeGroupVersion).Decode(data, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if gvk.Kind != "CredentialProviderRequest" {
+		return nil, fmt.Errorf("kind was %q, expected CredentialProviderRequest", gvk.Kind)
+	}
+
+	if gvk.Group != v1.GroupName {
+		return nil, fmt.Errorf("group was %q, expected %s", gvk.Group, v1.GroupName)
+	}
+
+	request, ok := obj.(*v1.CredentialProviderRequest)
+	if !ok {
+		return nil, fmt.Errorf("unable to convert %T to *CredentialProviderRequest", obj)
+	}
+
+	return request, nil
+}
+
+func encodeResponse(response *v1.CredentialProviderResponse) ([]byte, error) {
+	mediaType := "application/json"
+	info, ok := runtime.SerializerInfoForMediaType(codecs.SupportedMediaTypes(), mediaType)
+	if !ok {
+		return nil, fmt.Errorf("unsupported media type %q", mediaType)
+	}
+
+	encoder := codecs.EncoderForVersion(info.Serializer, v1.SchemeGroupVersion)
+	data, err := runtime.Encode(encoder, response)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode response: %v", err)
+	}
+
+	return data, nil
+}
+
+func main() {
+	logs.InitLogs()
+	defer logs.FlushLogs()
+
+	if err := newCredentialProviderCommand().Execute(); err != nil {
+		os.Exit(1)
+	}
+}
+
+func newCredentialProviderCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "acr-credential-provider",
+		Short: "ACR credential provider for kubelet",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := runPlugin(context.TODO(), os.Stdin, os.Stdout, os.Args[1:]); err != nil {
+				klog.Errorf("Error running credential provider plugin: %v", err)
+				os.Exit(1)
+			}
+		},
+	}
+	return cmd
+}

--- a/pkg/daemon/criruntime/imageruntime/fake_plugin/plugin-config.yaml
+++ b/pkg/daemon/criruntime/imageruntime/fake_plugin/plugin-config.yaml
@@ -1,0 +1,9 @@
+apiVersion: kubelet.config.k8s.io/v1
+kind: CredentialProviderConfig
+providers:
+  - name: fake-credential-plugin
+    matchImages:
+      - "registry.plugin.com"
+      - "registry.private.com"
+    defaultCacheDuration: "12h"
+    apiVersion: credentialprovider.kubelet.k8s.io/v1

--- a/pkg/util/secret/parse.go
+++ b/pkg/util/secret/parse.go
@@ -6,6 +6,7 @@ import (
 
 	daemonutil "github.com/openkruise/kruise/pkg/daemon/util"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/credentialprovider"
 	credentialprovidersecrets "k8s.io/kubernetes/pkg/credentialprovider/secrets"
 )
@@ -22,10 +23,19 @@ func AuthInfos(ctx context.Context, imageName, tag string, pullSecrets []corev1.
 }
 
 var (
-	keyring = credentialprovider.NewDockerKeyring()
+	keyring credentialprovider.DockerKeyring
 )
 
+// make and set new docker keyring
+func MakeAndSetKeyring() {
+	klog.Infof("make and set new docker keyring")
+	keyring = credentialprovider.NewDockerKeyring()
+}
+
 func ConvertToRegistryAuths(pullSecrets []corev1.Secret, repo string) (infos []daemonutil.AuthInfo, err error) {
+	if keyring == nil {
+		MakeAndSetKeyring()
+	}
 	keyring, err := credentialprovidersecrets.MakeDockerKeyring(pullSecrets, keyring)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Add support for credential provider plugins, by using this, Kruise can dynamically retrieve credentials for a container image registry using plugins, e.g. using STS tokens to pull image from ECR repositories. You could write your own credential provider plugins or use plugins provided by cloud providers. 

This works the same way as Kubelet does, refer to [Configure a kubelet image credential provider](https://kubernetes.io/docs/tasks/administer-cluster/kubelet-credential-provider/) for more information.

### Ⅱ. Does this pull request fix one issue?
fixes #866

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

