### PR TITLE
use "leases" by default

### DIFF
--- a/main.go
+++ b/main.go
@@ -113,8 +113,8 @@ func main() {
 		"leader-election-lease-duration is the duration that non-leader candidates will wait to force acquire leadership. This is measured against time of last observed ack. Default is 15 seconds.")
 	flag.DurationVar(&renewDeadLine, "leader-election-renew-deadline", defaultRenewDeadline,
 		"leader-election-renew-deadline is the duration that the acting controlplane will retry refreshing leadership before giving up. Default is 10 seconds.")
-	flag.StringVar(&leaderElectionResourceLock, "leader-election-resource-lock", resourcelock.ConfigMapsLeasesResourceLock,
-		"leader-election-resource-lock determines which resource lock to use for leader election, defaults to \"configmapsleases\".")
+	flag.StringVar(&leaderElectionResourceLock, "leader-election-resource-lock", resourcelock.LeasesResourceLock,
+		"leader-election-resource-lock determines which resource lock to use for leader election, defaults to \"leases\".")
 	flag.StringVar(&leaderElectionId, "leader-election-id", "kruise-manager",
 		"leader-election-id determines the name of the resource that leader election will use for holding the leader lock, Default is kruise-manager.")
 	flag.DurationVar(&retryPeriod, "leader-election-retry-period", defaultRetryPeriod,


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
LeaderElectionResourceLock  use "leases" by default

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

### Ⅲ. Describe how to verify it
NONE

### Ⅳ. Special notes for reviews

https://github.com/kubernetes/kubernetes/issues/80289
