### PR TITLE
[Fix] Index overshoot

### DIFF
--- a/pkg/util/containerlaunchpriority/container_launch_prirotiy.go
+++ b/pkg/util/containerlaunchpriority/container_launch_prirotiy.go
@@ -44,7 +44,7 @@ func ExistsPriorities(pod *v1.Pod) bool {
 
 func GetContainerPriority(c *v1.Container) *int {
 	for _, e := range c.Env {
-		if e.Name == appspub.ContainerLaunchBarrierEnvName {
+		if e.Name == appspub.ContainerLaunchBarrierEnvName && len(e.ValueFrom.ConfigMapKeyRef.Key) >= priorityStartIndex {
 			p, _ := strconv.Atoi(e.ValueFrom.ConfigMapKeyRef.Key[priorityStartIndex:])
 			return &p
 		}


### PR DESCRIPTION
When I try to manually specify a key in configmap, the controller panics
 
<img width="1230" alt="image" src="https://github.com/openkruise/kruise/assets/38821215/78939942-f1be-451e-a046-45058dbc0fb7">


```
apiVersion: v1
kind: Pod
metadata:
  name: test
spec:
  containers:
    - name: main
      image: centos:7
      command:
        - "/bin/sh"
        - "-c"
        - "sleep 1d"
    - name: sidecar
      image: centos:7
      command:
        - "/bin/sh"
        - "-c"
        - "sleep 1d"
      env:
        - name: KRUISE_CONTAINER_PRIORITY
          value: "1"
        - name: KRUISE_CONTAINER_BARRIER
          valueFrom:
            configMapKeyRef:
              name: x
              key: "p"
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: x
data:
  p: "1"
```


