### PR TITLE
fix: sidecarset's metadata.name follow community norms

### DIFF
--- a/pkg/webhook/sidecarset/validating/sidecarset_create_update_handler.go
+++ b/pkg/webhook/sidecarset/validating/sidecarset_create_update_handler.go
@@ -48,7 +48,10 @@ import (
 )
 
 const (
-	sidecarSetNameMaxLen = 63
+	// 按照社区的规范, 资源名最大长度为 253 个字符
+	//
+	// https://kubernetes.io/zh-cn/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names
+	sidecarSetNameMaxLen = 253
 )
 
 var validDownwardAPIFieldPathExpressions = sets.NewString(


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

in the community, cr name max length is 253, we should follow this rule.

https://kubernetes.io/zh-cn/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #1420 

### Ⅲ. Describe how to verify it

create a sidecarset which name length is 100

