### PR TITLE
[fix] nil status panic

### DIFF
--- a/pkg/daemon/podprobe/pod_probe_controller.go
+++ b/pkg/daemon/podprobe/pod_probe_controller.go
@@ -404,6 +404,10 @@ func (c *Controller) fetchLatestPodContainer(podUID, name string) (*runtimeapi.C
 	if container != nil {
 		containerStatus, err = runtimeService.ContainerStatus(container.Id, false)
 	}
+	if containerStatus == nil && err == nil {
+		klog.Infof("NodePodProbe pod(%s) get container(%s) status failed", podUID, name)
+		return nil, err
+	}
 	return containerStatus.Status, err
 }
 


### PR DESCRIPTION
<img width="1311" alt="image" src="https://github.com/openkruise/kruise/assets/38821215/e02dc02b-1555-4a5e-8070-e5ce7a32f18d">

```
apiVersion: apps.kruise.io/v1alpha1
kind: PodProbeMarker
metadata:
  name: game-server-probe
spec:
  selector:
    matchLabels:
      app: game-server-probe
  probes:
  - name: Idle
    containerName: game-server
    probe:
      exec:
        command:
        - telnet 127.0.0.1 8080
      initialDelaySeconds: 10
      timeoutSeconds: 3
      periodSeconds: 10
      successThreshold: 1
      failureThreshold: 3
    markerPolicy:
    - state: Succeeded
      labels:
        gameserver-idle: 'true'
      annotations:
        controller.kubernetes.io/pod-deletion-cost: '-10'
    - state: Failed
      labels:
        gameserver-idle: 'false'
      annotations:
        controller.kubernetes.io/pod-deletion-cost: '10'
    podConditionType: game.io/idle
---
apiVersion: v1
kind: Pod
metadata:
  name: game-server-probe
  labels:
    app: game-server-probe
spec:
  containers:
  - name: game-server-probe
    image: centos:7
    command:
    - "/bin/sh"
    - "-c"
    - "sleep 1d"
    imagePullPolicy: IfNotPresent
  restartPolicy: Always

```

The cluster does not have the image.
Both containerStatus and err are nil
 