### PR TITLE
【BUG】fix only initContainers without hash problem

### DIFF
--- a/pkg/webhook/pod/mutating/sidecarset.go
+++ b/pkg/webhook/pod/mutating/sidecarset.go
@@ -357,6 +357,7 @@ func buildSidecars(isUpdated bool, pod *corev1.Pod, oldPod *corev1.Pod, matchedS
 			SidecarSetName:  sidecarSet.Name,
 		}
 
+		isInjecting := false
 		//process initContainers
 		//only when created pod, inject initContainer and pullSecrets
 		if !isUpdated {
@@ -381,7 +382,7 @@ func buildSidecars(isUpdated bool, pod *corev1.Pod, oldPod *corev1.Pod, matchedS
 				initContainer.Env = append(initContainer.Env, corev1.EnvVar{Name: sidecarcontrol.SidecarEnvKey, Value: "true"})
 				// merged Env from sidecar.Env and transfer envs
 				initContainer.Env = util.MergeEnvVar(initContainer.Env, transferEnvs)
-
+				isInjecting = true
 				sidecarInitContainers = append(sidecarInitContainers, initContainer)
 			}
 			//process imagePullSecrets
@@ -389,7 +390,6 @@ func buildSidecars(isUpdated bool, pod *corev1.Pod, oldPod *corev1.Pod, matchedS
 		}
 
 		sidecarList := sets.NewString()
-		isInjecting := false
 		//process containers
 		for i := range sidecarSet.Spec.Containers {
 			sidecarContainer := &sidecarSet.Spec.Containers[i]


### PR DESCRIPTION
Signed-off-by: chrisdeng chrisdeng@futunn.com

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
fix pod sidecarSet-hash and sidecarSet-hash-without-image is empty when only initContainers sidecarSet apply in the cluster


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes https://github.com/openkruise/kruise/pull/1101

### Ⅲ. Describe how to verify it
①：apply a initContainer sidecarSet in cluster
②：create a pod associating the above sidecarSet
③：Observe if there is a hash on the pod


