### PR TITLE
fix: find workload spec.replicas

### DIFF
--- a/pkg/util/controllerfinder/controller_finder.go
+++ b/pkg/util/controllerfinder/controller_finder.go
@@ -439,11 +439,18 @@ func (r *ControllerFinder) getPodStatefulSetLike(ref ControllerReference, namesp
 			UID:         workload.GetUID(),
 		},
 	}
-	obj := workload.UnstructuredContent()
-	if val, found, err := unstructured.NestedInt64(obj, "spec.replicas"); err == nil && found {
-		scaleSelector.Scale = int32(val)
+	if val, err := getSpecReplicas(workload); err == nil {
+		scaleSelector.Scale = val
 	}
 	return scaleSelector, nil
+}
+
+func getSpecReplicas(workload *unstructured.Unstructured) (int32, error) {
+	obj := workload.UnstructuredContent()
+	if val, found, err := unstructured.NestedInt64(obj, "spec", "replicas"); err == nil && found {
+		return int32(val), nil
+	}
+	return 0, nil
 }
 
 func (r *ControllerFinder) getScaleController(ref ControllerReference, namespace string) (*ScaleAndSelector, error) {

--- a/pkg/util/controllerfinder/controller_finder_test.go
+++ b/pkg/util/controllerfinder/controller_finder_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2021 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllerfinder
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func Test_getSpecReplicas(t *testing.T) {
+	type args struct {
+		workload *unstructured.Unstructured
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    int32
+		wantErr bool
+	}{
+		{
+			name: "replicas exist",
+			args: args{
+				workload: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"spec": map[string]interface{}{
+							"replicas": int64(3),
+						},
+					},
+				},
+			},
+			want:    3,
+			wantErr: false,
+		},
+		{
+			name: "replicas do not exist",
+			args: args{
+				workload: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"spec": map[string]interface{}{},
+					},
+				},
+			},
+			want:    0,
+			wantErr: false,
+		},
+		{
+			name: "spec does not exist",
+			args: args{
+				workload: &unstructured.Unstructured{
+					Object: map[string]interface{}{},
+				},
+			},
+			want:    0,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getSpecReplicas(tt.args.workload)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getSpecReplicas() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("getSpecReplicas() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
fix get `spec.replicas` from unstructured object.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
`unstructured.NestedInt64(obj, "spec.replicas")` can not get replicas from like:
```yaml
apiVersion: apps.tkestack.io/v1
kind: TApp
metadata:
  annotations:
    kruise.io/auto-generate-persistent-pod-state: "true"
    kruise.io/preferred-persistent-topology: kubernetes.io/hostname
  creationTimestamp: "2023-11-28T14:25:14Z"
  generation: 6
  labels:
    app: example-tapp
  name: example-tapp
  namespace: kruise-system
  resourceVersion: "226631180"
  selfLink: /apis/apps.tkestack.io/v1/namespaces/kruise-system/tapps/example-tapp
  uid: a6c71435-b382-489c-ab5a-f55cc7de0a28
spec:
  defaultTemplateName: default
  replicas: 2
  selector:
    matchLabels:
      app: example-tapp
```

### Ⅲ. Describe how to verify it
test it use TApp https://github.com/tkestack/tapp.

1. install TApp operator;
2. use TApp above, add annotations `    kruise.io/auto-generate-persistent-pod-state: "true"`, `kruise.io/preferred-persistent-topology: kubernetes.io/hostname`
3. get ersistentpodstates
```yaml
apiVersion: apps.kruise.io/v1alpha1
kind: PersistentPodState
metadata:
  creationTimestamp: "2023-11-28T14:25:14Z"
  generation: 1
  name: example-tapp
  namespace: kruise-system
  ownerReferences:
  - apiVersion: apps.tkestack.io/v1
    controller: true
    kind: TApp
    name: example-tapp
    uid: a6c71435-b382-489c-ab5a-f55cc7de0a28
  resourceVersion: "226654296"
  selfLink: /apis/apps.kruise.io/v1alpha1/namespaces/kruise-system/persistentpodstates/example-tapp
  uid: 9484791e-ee7f-46bb-a659-39ea859fbd6c
spec:
  preferredPersistentTopology:
  - preference:
      nodeTopologyKeys:
      - kubernetes.io/hostname
    weight: 100
  targetRef:
    apiVersion: apps.tkestack.io/v1
    kind: TApp
    name: example-tapp
status:
  observedGeneration: 1
  podStates:
    example-tapp-0:
      nodeName: 9.134.111.49
      nodeTopologyLabels:
        kubernetes.io/hostname: 9.134.111.49
    example-tapp-1:
      nodeName: 9.134.111.49
      nodeTopologyLabels:
        kubernetes.io/hostname: 9.134.111.49
```
4. delete pod `example-tapp-0` and recreate example-tapp-0, get pod yam, nodeAffinity injectedl:
```
apiVersion: v1
kind: Pod
metadata:
  annotations:
    kruise.io/injected-persistent-pod-state: example-tapp
  creationTimestamp: "2023-11-29T02:36:55Z"
  generateName: example-tapp-
  labels:
    app: example-tapp
    tapp_instance_key: "0"
    tapp_template_hash_key: "506133740347201105"
    tapp_uniq_hash_key: "6441391112236715516"
  name: example-tapp-0
  namespace: default
  ownerReferences:
  - apiVersion: apps.tkestack.io/v1
    controller: true
    kind: TApp
    name: example-tapp
    uid: 5c50a01a-5940-49bb-9a17-f2f516aabf08
  resourceVersion: "226693884"
  selfLink: /api/v1/namespaces/default/pods/example-tapp-0
  uid: d6545108-abd2-4ef5-b7a7-e67102145cd6
spec:
  affinity:
    nodeAffinity:
      preferredDuringSchedulingIgnoredDuringExecution:
      - preference:
          matchExpressions:
          - key: kubernetes.io/hostname
            operator: In
            values:
            - 9.134.111.49
        weight: 100
  containers:
  - command:
    - sleep
    - "3600"
    image: nginx:1.7.9
    imagePullPolicy: IfNotPresent
    name: nginx1
    resources:
```

### Ⅳ. Special notes for reviews

