### PR TITLE
the CloneSet pod lifecycle can be transformed to Normal only if ContainerReady is true

### DIFF
--- a/apis/apps/pub/lifecycle.go
+++ b/apis/apps/pub/lifecycle.go
@@ -21,7 +21,7 @@ const (
 	LifecycleTimestampKey = "lifecycle.apps.kruise.io/timestamp"
 
 	// LifecycleStatePreparingNormal means the Pod is created but unavailable.
-	// It will translate to Normal state if Lifecycle.PreNormal is hooked.
+	// It will translate to Normal state if Lifecycle.PreNormal is hooked and pod condition ContainerReady is true.
 	LifecycleStatePreparingNormal LifecycleStateType = "PreparingNormal"
 	// LifecycleStateNormal is a necessary condition for Pod to be available.
 	LifecycleStateNormal LifecycleStateType = "Normal"

--- a/pkg/controller/cloneset/sync/cloneset_update.go
+++ b/pkg/controller/cloneset/sync/cloneset_update.go
@@ -169,9 +169,12 @@ func (c *realControl) refreshPodState(cs *appsv1alpha1.CloneSet, coreControl clo
 	var state appspub.LifecycleStateType
 	switch lifecycle.GetPodLifecycleState(pod) {
 	case appspub.LifecycleStatePreparingNormal:
-		if cs.Spec.Lifecycle == nil ||
-			cs.Spec.Lifecycle.PreNormal == nil ||
-			lifecycle.IsPodAllHooked(cs.Spec.Lifecycle.PreNormal, pod) {
+		// 1.the pod lifecycle can be transformed from PreparingNormal to Normal only if ContainerReady is true.
+		// If lifecycle transformed from PreparingNormal to Normal immediately after pod created,
+		// it may trigger a BUG of old version kube-scheduler with some probability.  https://github.com/openkruise/kruise/issues/1485
+		// 2.the semantic of this hook, let's leave it as it is:
+		// PreNormalHook: only if all hooks are hooked (or no hook), the pod can be transformed to Normal
+		if util.IsRunningAndContainerReady(pod) && lifecycle.IsPreNormalHookNilOrAllHooked(cs.Spec.Lifecycle, pod) {
 			state = appspub.LifecycleStateNormal
 		}
 	case appspub.LifecycleStatePreparingUpdate:

--- a/pkg/controller/cloneset/sync/cloneset_update_test.go
+++ b/pkg/controller/cloneset/sync/cloneset_update_test.go
@@ -592,6 +592,7 @@ func TestUpdate(t *testing.T) {
 					Spec: v1.PodSpec{ReadinessGates: []v1.PodReadinessGate{{ConditionType: appspub.InPlaceUpdateReady}}},
 					Status: v1.PodStatus{Phase: v1.PodRunning, Conditions: []v1.PodCondition{
 						{Type: v1.PodReady, Status: v1.ConditionFalse},
+						{Type: v1.ContainersReady, Status: v1.ConditionTrue},
 						{Type: appspub.InPlaceUpdateReady, Status: v1.ConditionTrue},
 					}},
 				},
@@ -606,6 +607,7 @@ func TestUpdate(t *testing.T) {
 					Spec: v1.PodSpec{ReadinessGates: []v1.PodReadinessGate{{ConditionType: appspub.InPlaceUpdateReady}}},
 					Status: v1.PodStatus{Phase: v1.PodRunning, Conditions: []v1.PodCondition{
 						{Type: v1.PodReady, Status: v1.ConditionFalse},
+						{Type: v1.ContainersReady, Status: v1.ConditionTrue},
 						{Type: appspub.InPlaceUpdateReady, Status: v1.ConditionTrue},
 					}},
 				},
@@ -669,6 +671,7 @@ func TestUpdate(t *testing.T) {
 					Spec: v1.PodSpec{ReadinessGates: []v1.PodReadinessGate{{ConditionType: appspub.InPlaceUpdateReady}}},
 					Status: v1.PodStatus{Phase: v1.PodRunning, Conditions: []v1.PodCondition{
 						{Type: v1.PodReady, Status: v1.ConditionFalse},
+						{Type: v1.ContainersReady, Status: v1.ConditionTrue},
 						{Type: appspub.InPlaceUpdateReady, Status: v1.ConditionTrue},
 					}},
 				},
@@ -684,6 +687,7 @@ func TestUpdate(t *testing.T) {
 					Spec: v1.PodSpec{ReadinessGates: []v1.PodReadinessGate{{ConditionType: appspub.InPlaceUpdateReady}}},
 					Status: v1.PodStatus{Phase: v1.PodRunning, Conditions: []v1.PodCondition{
 						{Type: v1.PodReady, Status: v1.ConditionFalse},
+						{Type: v1.ContainersReady, Status: v1.ConditionTrue},
 						{Type: appspub.InPlaceUpdateReady, Status: v1.ConditionTrue},
 					}},
 				},
@@ -843,6 +847,7 @@ func TestUpdate(t *testing.T) {
 						Phase: v1.PodRunning,
 						Conditions: []v1.PodCondition{
 							{Type: v1.PodReady, Status: v1.ConditionTrue},
+							{Type: v1.ContainersReady, Status: v1.ConditionTrue},
 							{Type: appspub.InPlaceUpdateReady, Status: v1.ConditionTrue, LastTransitionTime: now},
 						},
 						ContainerStatuses: []v1.ContainerStatus{{Name: "c1", ImageID: "image-id-xyz"}},
@@ -867,6 +872,7 @@ func TestUpdate(t *testing.T) {
 						Phase: v1.PodRunning,
 						Conditions: []v1.PodCondition{
 							{Type: v1.PodReady, Status: v1.ConditionTrue},
+							{Type: v1.ContainersReady, Status: v1.ConditionTrue},
 							{Type: appspub.InPlaceUpdateReady, Status: v1.ConditionTrue, LastTransitionTime: now},
 						},
 						ContainerStatuses: []v1.ContainerStatus{{Name: "c1", ImageID: "image-id-xyz"}},
@@ -942,6 +948,41 @@ func TestUpdate(t *testing.T) {
 						},
 						ContainerStatuses: []v1.ContainerStatus{{Name: "c1", ImageID: "image-id-xyz"}},
 					},
+				},
+			},
+		},
+		{
+			name:           "create: preparingNormal->Normal without hook, pod not ready",
+			cs:             &appsv1alpha1.CloneSet{Spec: appsv1alpha1.CloneSetSpec{Replicas: getInt32Pointer(1)}},
+			updateRevision: &apps.ControllerRevision{ObjectMeta: metav1.ObjectMeta{Name: "rev_new"}},
+			pods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "pod-0", Labels: map[string]string{
+						apps.ControllerRevisionHashLabelKey:  "rev_new",
+						apps.DefaultDeploymentUniqueLabelKey: "rev_new",
+						appspub.LifecycleStateKey:            string(appspub.LifecycleStatePreparingNormal),
+					}},
+					Spec: v1.PodSpec{ReadinessGates: []v1.PodReadinessGate{{ConditionType: appspub.InPlaceUpdateReady}}},
+					Status: v1.PodStatus{Phase: v1.PodRunning, Conditions: []v1.PodCondition{
+						{Type: v1.PodReady, Status: v1.ConditionFalse},
+						{Type: v1.ContainersReady, Status: v1.ConditionFalse},
+						{Type: appspub.InPlaceUpdateReady, Status: v1.ConditionTrue},
+					}},
+				},
+			},
+			expectedPods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "pod-0", Labels: map[string]string{
+						apps.ControllerRevisionHashLabelKey:  "rev_new",
+						apps.DefaultDeploymentUniqueLabelKey: "rev_new",
+						appspub.LifecycleStateKey:            string(appspub.LifecycleStatePreparingNormal),
+					}},
+					Spec: v1.PodSpec{ReadinessGates: []v1.PodReadinessGate{{ConditionType: appspub.InPlaceUpdateReady}}},
+					Status: v1.PodStatus{Phase: v1.PodRunning, Conditions: []v1.PodCondition{
+						{Type: v1.PodReady, Status: v1.ConditionFalse},
+						{Type: v1.ContainersReady, Status: v1.ConditionFalse},
+						{Type: appspub.InPlaceUpdateReady, Status: v1.ConditionTrue},
+					}},
 				},
 			},
 		},

--- a/pkg/util/lifecycle/lifecycle_utils.go
+++ b/pkg/util/lifecycle/lifecycle_utils.go
@@ -237,6 +237,15 @@ func IsPodAllHooked(hook *appspub.LifecycleHook, pod *v1.Pod) bool {
 	return true
 }
 
+// IsPreNormalHookNilOrAllHooked
+// pod lifecycle can be transformed to Normal only if no hook or all hooks are hooked
+func IsPreNormalHookNilOrAllHooked(hooks *appspub.Lifecycle, pod *v1.Pod) bool {
+	// nothing changed, but avoiding excessive complexity in if conditions
+	return hooks == nil ||
+		hooks.PreNormal == nil ||
+		IsPodAllHooked(hooks.PreNormal, pod)
+}
+
 func getReadinessMessage(key string) podreadiness.Message {
 	return podreadiness.Message{UserAgent: "Lifecycle", Key: key}
 }

--- a/pkg/util/pods.go
+++ b/pkg/util/pods.go
@@ -204,6 +204,10 @@ func IsRunningAndReady(pod *v1.Pod) bool {
 	return pod.Status.Phase == v1.PodRunning && podutil.IsPodReady(pod) && pod.DeletionTimestamp.IsZero()
 }
 
+func IsRunningAndContainerReady(pod *v1.Pod) bool {
+	return pod.Status.Phase == v1.PodRunning && podutil.IsContainersReadyConditionTrue(pod.Status) && pod.DeletionTimestamp.IsZero()
+}
+
 func GetPodContainerImageIDs(pod *v1.Pod) map[string]string {
 	cImageIDs := make(map[string]string, len(pod.Status.ContainerStatuses))
 	for i := range pod.Status.ContainerStatuses {


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
#### The CloneSet pod lifecycle can be transformed to Normal only if ContainerReady is true.
Sorry for being late. 
Last week After I created issue #1485, I appreciate that the Kruise team replied quickly and pointed out that it may be better "to Normal after Pod Ready"  @zmberg 
I've been thinking about this issue these days. I believe using the 'PodReady'(k8s.io/api/core/v1.PodReady, 'Ready' in yaml, same as below) condition may not be appropriate. Consider the scenario with the 'markPodNotReady' set: the Pod's lifecycle can only be transformed to 'Normal' if 'PodReady' is true. On the other hand, the 'PodReady' condition will be set to false at preparingDelete/preparingUpdate state. This bidirectional influence adds complexity and can make the lifecycle confusing. 
So I suggest that we can use the "ContainerReady" condition, it would be simple enough.
A pod's lifecycle will be transformed from PreparingNormal to Normal only if its containers are all ready.
Furthermore, it is ok that a pod's lifecycle will be transformed to Normal only if its containers are all ready.

### Ⅱ. Does this pull request fix one issue?
fixes #1485

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

