### PR TITLE
update pub readiness check in pub validating

### DIFF
--- a/pkg/control/pubcontrol/pub_control_utils.go
+++ b/pkg/control/pubcontrol/pub_control_utils.go
@@ -64,9 +64,9 @@ func PodUnavailableBudgetValidatePod(pod *corev1.Pod, operation policyv1alpha1.P
 	if pod.Annotations[policyv1alpha1.PodPubNoProtectionAnnotation] == "true" {
 		klog.V(3).Infof("pod(%s/%s) contains annotations[%s]=true, then don't need check pub", pod.Namespace, pod.Name, policyv1alpha1.PodPubNoProtectionAnnotation)
 		return true, "", nil
-		// If the pod is not ready, it doesn't count towards healthy and we should not decrement
-	} else if !PubControl.IsPodReady(pod) {
-		klog.V(3).Infof("pod(%s/%s) is not ready, then don't need check pub", pod.Namespace, pod.Name)
+		// If the pod is not ready or state is inconsistent, it doesn't count towards healthy and we should not decrement
+	} else if !PubControl.IsPodReady(pod) || !PubControl.IsPodStateConsistent(pod) {
+		klog.V(3).Infof("pod(%s/%s) is not ready or state is inconsistent, then don't need check pub", pod.Namespace, pod.Name)
 		return true, "", nil
 	}
 

--- a/pkg/control/pubcontrol/pub_control_utils_test.go
+++ b/pkg/control/pubcontrol/pub_control_utils_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/openkruise/kruise/apis/apps/pub"
 	appspub "github.com/openkruise/kruise/apis/apps/pub"
 	policyv1alpha1 "github.com/openkruise/kruise/apis/policy/v1alpha1"
 	"github.com/openkruise/kruise/pkg/util/controllerfinder"
@@ -273,6 +274,34 @@ func TestPodUnavailableBudgetValidatePod(t *testing.T) {
 				pubStatus := pubDemo.Status.DeepCopy()
 				return pubStatus
 			},
+		},
+		{
+			name: "valid delete pod, pod state is inconsistent(inplace update not completed yet), ignore",
+			getPod: func() *corev1.Pod {
+				pod := podDemo.DeepCopy()
+				pod.Annotations[pub.InPlaceUpdateStateKey] = `{"nextContainerImages":{"main":"nginx:v2"}}`
+				return pod
+			},
+			getPub: func() *policyv1alpha1.PodUnavailableBudget {
+				pub := pubDemo.DeepCopy()
+				return pub
+			},
+			operation:   policyv1alpha1.PubDeleteOperation,
+			expectAllow: true,
+		},
+		{
+			name: "valid delete pod, pod declared no protect , ignore",
+			getPod: func() *corev1.Pod {
+				pod := podDemo.DeepCopy()
+				pod.Annotations[policyv1alpha1.PodPubNoProtectionAnnotation] = "true"
+				return pod
+			},
+			getPub: func() *policyv1alpha1.PodUnavailableBudget {
+				pub := pubDemo.DeepCopy()
+				return pub
+			},
+			operation:   policyv1alpha1.PubDeleteOperation,
+			expectAllow: true,
 		},
 	}
 


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

Add PodStateConsistent check condition in PUB validating.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

How to check whether Pod is available is inconsistent in PUB controllers and webhooks.  

https://github.com/openkruise/kruise/blob/5421ee7c8e9e54ec38c1c1e20f4deb4a722f47a7/pkg/controller/podunavailablebudget/podunavailablebudget_controller.go#L380

https://github.com/openkruise/kruise/blob/5421ee7c8e9e54ec38c1c1e20f4deb4a722f47a7/pkg/control/pubcontrol/pub_control_utils.go#L68

### Ⅲ. Describe how to verify it

Make rolling update using inplace-update, delete Pod when inplace-update is not completed, which is supposed to be successful.

### Ⅳ. Special notes for reviews

