### PR TITLE
chores: use golang standard errors

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ on:
 env:
   # Common versions
   GO_VERSION: '1.19'
-  GOLANGCI_VERSION: 'v1.51'
+  GOLANGCI_VERSION: 'v1.55.2'
   DOCKER_BUILDX_VERSION: 'v0.4.2'
 
   # Common users. We can't run a step 'if secrets.AWS_USR != ""' but we can run
@@ -53,7 +53,7 @@ jobs:
         run: |
           make generate
       - name: Lint golang code
-        uses: golangci/golangci-lint-action@v3.5.0
+        uses: golangci/golangci-lint-action@v4.0.0
         with:
           version: ${{ env.GOLANGCI_VERSION }}
           args: --verbose

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -66,6 +66,12 @@ linters-settings:
     locale: default
     #ignore-words:
     #  - someword
+  depguard:
+    rules:
+      forbid-pkg-errors:
+        deny:
+        - pkg: "github.com/pkg/errors"
+          dsc: Should be replaced with standard lib errors or fmt.Errorf
 
 linters:
   fast: false
@@ -80,6 +86,7 @@ linters:
     - vet
     - unconvert
     - unused
+    - depguard
 issues:
   exclude:
     # staticcheck

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/onsi/gomega v1.19.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.0-rc3
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.1
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/pflag v1.0.5
@@ -113,6 +112,7 @@ require (
 	github.com/opencontainers/runc v1.1.6 // indirect
 	github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417 // indirect
 	github.com/opencontainers/selinux v1.10.0 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect

--- a/pkg/controller/statefulset/stateful_set_control_test.go
+++ b/pkg/controller/statefulset/stateful_set_control_test.go
@@ -19,6 +19,7 @@ package statefulset
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/rand"
 	"reflect"
@@ -29,7 +30,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"

--- a/pkg/daemon/criruntime/imageruntime/cri.go
+++ b/pkg/daemon/criruntime/imageruntime/cri.go
@@ -15,6 +15,7 @@ package imageruntime
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"reflect"
 	"time"
@@ -22,7 +23,6 @@ import (
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
 	daemonutil "github.com/openkruise/kruise/pkg/daemon/util"
 	"github.com/openkruise/kruise/pkg/util/secret"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 	v1 "k8s.io/api/core/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -189,7 +189,7 @@ func (c *commonCRIImageService) pullImageV1(ctx context.Context, imageName, tag 
 	// Anonymous pull
 	_, err = c.criImageClient.PullImage(ctx, pullImageReq)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Failed to pull image reference %q", fullImageName)
+		return nil, fmt.Errorf("Failed to pull image reference %q: %w", fullImageName, err)
 	}
 	pipeW.CloseWithError(io.EOF)
 	return newImagePullStatusReader(pipeR), nil
@@ -309,7 +309,7 @@ func (c *commonCRIImageService) pullImageV1alpha2(ctx context.Context, imageName
 	// Anonymous pull
 	_, err = c.criImageClientV1alpha2.PullImage(ctx, pullImageReq)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Failed to pull image reference %q", fullImageName)
+		return nil, fmt.Errorf("Failed to pull image reference %q: %w", fullImageName, err)
 	}
 	pipeW.CloseWithError(io.EOF)
 	return newImagePullStatusReader(pipeR), nil

--- a/pkg/daemon/util/error.go
+++ b/pkg/daemon/util/error.go
@@ -22,8 +22,6 @@ import (
 	"os"
 	"strings"
 	"syscall"
-
-	"github.com/pkg/errors"
 )
 
 // FilterCloseErr rewrites EOF and EPIPE errors to bool. Use when
@@ -34,7 +32,7 @@ func FilterCloseErr(err error) bool {
 	switch {
 	case err == io.EOF:
 		return true
-	case errors.Cause(err) == io.EOF:
+	case strings.Contains(err.Error(), io.EOF.Error()):
 		return true
 	case strings.Contains(err.Error(), "use of closed network connection"):
 		return true

--- a/pkg/daemon/util/error_test.go
+++ b/pkg/daemon/util/error_test.go
@@ -18,6 +18,7 @@ package util
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"testing"
 )
@@ -29,7 +30,7 @@ func TestFilterCloseErr(t *testing.T) {
 		t.Errorf("FilterCloseErr true")
 	}
 
-	ret = FilterCloseErr(errors.Join(err, io.EOF))
+	ret = FilterCloseErr(fmt.Errorf("%s: %w", err.Error(), io.EOF))
 	if ret == false {
 		t.Errorf("FilterCloseErr false")
 	}

--- a/pkg/daemon/util/error_test.go
+++ b/pkg/daemon/util/error_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2024 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+)
+
+func TestFilterCloseErr(t *testing.T) {
+	err := errors.New("abc")
+	ret := FilterCloseErr(errors.New("abc"))
+	if ret == true {
+		t.Errorf("FilterCloseErr true")
+	}
+
+	ret = FilterCloseErr(errors.Join(err, io.EOF))
+	if ret == false {
+		t.Errorf("FilterCloseErr false")
+	}
+}

--- a/pkg/daemon/util/error_test.go
+++ b/pkg/daemon/util/error_test.go
@@ -19,7 +19,6 @@ package util
 import (
 	"errors"
 	"io"
-	"net/http"
 	"testing"
 )
 

--- a/test/e2e/framework/provider.go
+++ b/test/e2e/framework/provider.go
@@ -22,8 +22,6 @@ import (
 	"os"
 	"sync"
 
-	"github.com/pkg/errors"
-
 	v1 "k8s.io/api/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
 )
@@ -71,7 +69,7 @@ func SetupProviderConfig(providerName string) (ProviderInterface, error) {
 	defer mutex.Unlock()
 	factory, ok := providers[providerName]
 	if !ok {
-		return nil, errors.Wrapf(os.ErrNotExist, "The provider %s is unknown.", providerName)
+		return nil, fmt.Errorf("The provider %s is unknown.: %w", providerName, os.ErrNotExist)
 	}
 	provider, err := factory()
 

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -18,8 +18,10 @@ limitations under the License.
 package framework
 
 import (
+	"errors"
 	"flag"
 	"fmt"
+	"io/fs"
 	"os"
 	"time"
 
@@ -367,7 +369,7 @@ func AfterReadingAllFlags(t *TestContextType) {
 	if err == nil {
 		return
 	}
-	if !os.IsNotExist(errors.Cause(err)) {
+	if errors.Is(err, fs.ErrNotExist) {
 		Failf("Failed to setup provider config: %v", err)
 	}
 	// We allow unknown provider parameters for historic reasons. At least log a

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/onsi/ginkgo/config"
-	"github.com/pkg/errors"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
https://github.com/pkg/errors has been archived and is no longer maintained.

Use the [errors](https://pkg.go.dev/errors) and fmt package from the standard Go library.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

Add a `depguard` rule in the golang-cilint configuration to prevent future use of `github.com/pkg/errors`.

### Ⅳ. Special notes for reviews

