### PR TITLE
[feature] When CloneSet volumeClaimTemplates changed, Pod must ReCreate update

### DIFF
--- a/pkg/controller/cloneset/core/cloneset_core.go
+++ b/pkg/controller/cloneset/core/cloneset_core.go
@@ -142,6 +142,11 @@ func (c *commonControl) GetUpdateOptions() *inplaceupdate.UpdateOptions {
 	if c.Spec.UpdateStrategy.InPlaceUpdateStrategy != nil {
 		opts.GracePeriodSeconds = c.Spec.UpdateStrategy.InPlaceUpdateStrategy.GracePeriodSeconds
 	}
+	// For the InPlaceOnly strategy, ignore the hash comparison of VolumeClaimTemplates.
+	// Consider making changes through a feature gate.
+	if c.Spec.UpdateStrategy.Type == appsv1alpha1.InPlaceOnlyCloneSetUpdateStrategyType {
+		opts.IgnoreVolumeClaimTemplatesHashDiff = true
+	}
 	return opts
 }
 

--- a/pkg/controller/cloneset/core/cloneset_core_test.go
+++ b/pkg/controller/cloneset/core/cloneset_core_test.go
@@ -1,0 +1,74 @@
+package core
+
+import (
+	"reflect"
+	"testing"
+
+	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
+	"github.com/openkruise/kruise/pkg/util/inplaceupdate"
+)
+
+func Test_CommonControl_GetUpdateOptions(t *testing.T) {
+	type fields struct {
+		CloneSet *appsv1alpha1.CloneSet
+	}
+
+	defaultOps := &inplaceupdate.UpdateOptions{}
+	ignoreVCTHashOps := &inplaceupdate.UpdateOptions{IgnoreVolumeClaimTemplatesHashDiff: true}
+	tests := []struct {
+		name   string
+		fields fields
+		want   *inplaceupdate.UpdateOptions
+	}{
+		{
+			name: "inplace only update type",
+			fields: fields{
+				&appsv1alpha1.CloneSet{
+					Spec: appsv1alpha1.CloneSetSpec{
+						UpdateStrategy: appsv1alpha1.CloneSetUpdateStrategy{
+							Type: appsv1alpha1.InPlaceOnlyCloneSetUpdateStrategyType,
+						},
+					},
+				},
+			},
+			want: ignoreVCTHashOps,
+		},
+		{
+			name: "inplace if possible update type",
+			fields: fields{
+				&appsv1alpha1.CloneSet{
+					Spec: appsv1alpha1.CloneSetSpec{
+						UpdateStrategy: appsv1alpha1.CloneSetUpdateStrategy{
+							Type: appsv1alpha1.InPlaceIfPossibleCloneSetUpdateStrategyType,
+						},
+					},
+				},
+			},
+			want: defaultOps,
+		},
+		{
+			// unexpected case: the method should not be called with recreate update strategy type.
+			name: "recreate update type",
+			fields: fields{
+				&appsv1alpha1.CloneSet{
+					Spec: appsv1alpha1.CloneSetSpec{
+						UpdateStrategy: appsv1alpha1.CloneSetUpdateStrategy{
+							Type: appsv1alpha1.InPlaceIfPossibleCloneSetUpdateStrategyType,
+						},
+					},
+				},
+			},
+			want: defaultOps,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &commonControl{
+				CloneSet: tt.fields.CloneSet,
+			}
+			if got := c.GetUpdateOptions(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetUpdateOptions() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/controller/cloneset/revision/cloneset_revision.go
+++ b/pkg/controller/cloneset/revision/cloneset_revision.go
@@ -23,6 +23,8 @@ import (
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
 	clonesetcore "github.com/openkruise/kruise/pkg/controller/cloneset/core"
 	clonesetutils "github.com/openkruise/kruise/pkg/controller/cloneset/utils"
+	"github.com/openkruise/kruise/pkg/util/volumeclaimtemplate"
+
 	apps "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
@@ -69,6 +71,7 @@ func (c *realControl) NewRevision(cs *appsv1alpha1.CloneSet, revision int64, col
 	for key, value := range cs.Annotations {
 		cr.ObjectMeta.Annotations[key] = value
 	}
+	volumeclaimtemplate.PatchVCTemplateHash(cr, cs.Spec.VolumeClaimTemplates)
 	return cr, nil
 }
 

--- a/pkg/controller/cloneset/revision/cloneset_revision_test.go
+++ b/pkg/controller/cloneset/revision/cloneset_revision_test.go
@@ -22,11 +22,13 @@ import (
 	"reflect"
 	"testing"
 
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-
 	"github.com/openkruise/kruise/apis"
 	clonesettest "github.com/openkruise/kruise/pkg/controller/cloneset/test"
+
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/kubernetes/pkg/controller/history"
 )
@@ -103,5 +105,67 @@ func TestApplyRevision(t *testing.T) {
 	}
 	if !reflect.DeepEqual(updateSet.Spec.Template, restoredUpdateSet.Spec.Template) {
 		t.Errorf("want %v got %v", updateSet.Spec.Template, restoredUpdateSet.Spec.Template)
+	}
+}
+
+func TestCreateApplyRevisionWithVCTemplates(t *testing.T) {
+	control := NewRevisionControl()
+	set := clonesettest.NewCloneSet(1)
+	set.Status.CollisionCount = new(int32)
+
+	set.Spec.VolumeClaimTemplates = []v1.PersistentVolumeClaim{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "www-data",
+			},
+			Spec: v1.PersistentVolumeClaimSpec{
+				Resources: v1.ResourceRequirements{
+					Requests: map[v1.ResourceName]resource.Quantity{
+						v1.ResourceStorage: resource.MustParse("1Gi"),
+					},
+				},
+				AccessModes: []v1.PersistentVolumeAccessMode{
+					v1.ReadWriteOnce,
+				},
+			},
+		},
+	}
+
+	revision, err := control.NewRevision(set, 1, set.Status.CollisionCount)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(revision.Annotations) <= 0 {
+		t.Error("missing annotation")
+	}
+	if val, exist := revision.Annotations["kruise.io/cloneset-volumeclaimtemplate-hash"]; !exist || val == "" {
+		t.Error("missing annotation key kruise.io/cloneset-volumeclaimtemplate-hash")
+	}
+
+	set.Spec.Template.Spec.Containers[0].Name = "foo"
+	if set.Annotations == nil {
+		set.Annotations = make(map[string]string)
+	}
+	key := "foo"
+	expectedValue := "bar"
+	set.Annotations[key] = expectedValue
+	restoredSet, err := control.ApplyRevision(set, revision)
+	if err != nil {
+		t.Fatal(err)
+	}
+	restoredRevision, err := control.NewRevision(restoredSet, 2, restoredSet.Status.CollisionCount)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !history.EqualRevision(revision, restoredRevision) {
+		t.Errorf("wanted %v got %v", string(revision.Data.Raw), string(restoredRevision.Data.Raw))
+	}
+	value, ok := restoredRevision.Annotations[key]
+	if !ok {
+		t.Errorf("missing annotation %s", key)
+	}
+	if value != expectedValue {
+		t.Errorf("for annotation %s wanted %s got %s", key, expectedValue, value)
 	}
 }

--- a/pkg/controller/cloneset/sync/cloneset_update.go
+++ b/pkg/controller/cloneset/sync/cloneset_update.go
@@ -249,7 +249,6 @@ func (c *realControl) updatePod(cs *appsv1alpha1.CloneSet, coreControl clonesetc
 				break
 			}
 		}
-
 		if c.inplaceControl.CanUpdateInPlace(oldRevision, updateRevision, coreControl.GetUpdateOptions()) {
 			switch state := lifecycle.GetPodLifecycleState(pod); state {
 			case "", appspub.LifecycleStatePreparingNormal, appspub.LifecycleStateNormal:

--- a/pkg/features/kruise_features.go
+++ b/pkg/features/kruise_features.go
@@ -116,6 +116,9 @@ const (
 
 	// Enables a enhanced livenessProbe solution
 	EnhancedLivenessProbeGate featuregate.Feature = "EnhancedLivenessProbe"
+
+	// RecreatePodWhenChangeVCTInCloneSetGate recreate the pod upon changing volume claim templates in a clone set to ensure PVC consistency.
+	RecreatePodWhenChangeVCTInCloneSetGate featuregate.Feature = "RecreatePodWhenChangeVCTInCloneSetGate"
 )
 
 var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
@@ -145,7 +148,8 @@ var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	ResourceDistributionGate:              {Default: false, PreRelease: featuregate.Alpha},
 	DeletionProtectionForCRDCascadingGate: {Default: false, PreRelease: featuregate.Alpha},
 
-	EnhancedLivenessProbeGate: {Default: false, PreRelease: featuregate.Alpha},
+	EnhancedLivenessProbeGate:              {Default: false, PreRelease: featuregate.Alpha},
+	RecreatePodWhenChangeVCTInCloneSetGate: {Default: false, PreRelease: featuregate.Alpha},
 }
 
 func init() {

--- a/pkg/util/inplaceupdate/inplace_update.go
+++ b/pkg/util/inplaceupdate/inplace_update.go
@@ -59,6 +59,8 @@ type UpdateResult struct {
 }
 
 type UpdateOptions struct {
+	IgnoreVolumeClaimTemplatesHashDiff bool
+
 	GracePeriodSeconds int32
 	AdditionalFuncs    []func(*v1.Pod)
 

--- a/pkg/util/inplaceupdate/inplace_update_defaults_test.go
+++ b/pkg/util/inplaceupdate/inplace_update_defaults_test.go
@@ -18,17 +18,24 @@ package inplaceupdate
 
 import (
 	"encoding/json"
+	"fmt"
+	"reflect"
 	"testing"
 	"time"
 
+	appspub "github.com/openkruise/kruise/apis/apps/pub"
+	"github.com/openkruise/kruise/pkg/features"
+	"github.com/openkruise/kruise/pkg/util"
+	utilfeature "github.com/openkruise/kruise/pkg/util/feature"
+	"github.com/openkruise/kruise/pkg/util/volumeclaimtemplate"
+
+	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	testingclock "k8s.io/utils/clock/testing"
-
-	appspub "github.com/openkruise/kruise/apis/apps/pub"
-	"github.com/openkruise/kruise/pkg/util"
 )
 
 func TestDefaultPatchUpdateSpecToPod(t *testing.T) {
@@ -466,4 +473,450 @@ func TestDefaultPatchUpdateSpecToPod(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_defaultCalculateInPlaceUpdateSpec_VCTHash(t *testing.T) {
+	type args struct {
+		oldRevision *apps.ControllerRevision
+		newRevision *apps.ControllerRevision
+		opts        *UpdateOptions
+	}
+	oldData := `{
+  "spec": {
+    "template": {
+      "$patch": "replace",
+      "metadata": {
+        "creationTimestamp": null,
+        "labels": {
+          "app": "nginx"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "env": [
+              {
+                "name": "version",
+                "value": "v1"
+              }
+            ],
+            "image": "nginx:stable-alpine22",
+            "imagePullPolicy": "Always",
+            "name": "nginx",
+            "resources": {},
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File",
+            "volumeMounts": [
+              {
+                "mountPath": "/usr/share/nginx/html",
+                "name": "www-data"
+              }
+            ]
+          }
+        ],
+        "dnsPolicy": "ClusterFirst",
+        "restartPolicy": "Always",
+        "schedulerName": "default-scheduler",
+        "securityContext": {},
+        "terminationGracePeriodSeconds": 30
+      }
+    }
+  }
+}`
+	newData := `{
+  "spec": {
+    "template": {
+      "$patch": "replace",
+      "metadata": {
+        "creationTimestamp": null,
+        "labels": {
+          "app": "nginx"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "env": [
+              {
+                "name": "version",
+                "value": "v1"
+              }
+            ],
+            "image": "nginx:stable-alpine",
+            "imagePullPolicy": "Always",
+            "name": "nginx",
+            "resources": {},
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File",
+            "volumeMounts": [
+              {
+                "mountPath": "/usr/share/nginx/html",
+                "name": "www-data"
+              }
+            ]
+          }
+        ],
+        "dnsPolicy": "ClusterFirst",
+        "restartPolicy": "Always",
+        "schedulerName": "default-scheduler",
+        "securityContext": {},
+        "terminationGracePeriodSeconds": 30
+      }
+    }
+  }
+}`
+
+	desiredWhenDisableFG := &UpdateSpec{
+		Revision: "new-revision",
+		ContainerImages: map[string]string{
+			"nginx": "nginx:stable-alpine",
+		},
+	}
+	ignoreVCTHashUpdateOpts := &UpdateOptions{IgnoreVolumeClaimTemplatesHashDiff: true}
+	tests := []struct {
+		name string
+		args args
+		want *UpdateSpec
+
+		wantWhenDisable *UpdateSpec
+	}{
+		{
+			name: "both revision annotation is nil=> ignore",
+			args: args{
+				oldRevision: &apps.ControllerRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "old-revision",
+						Annotations: nil,
+					},
+					Data: runtime.RawExtension{
+						Raw: []byte(oldData),
+					},
+				},
+				newRevision: &apps.ControllerRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "new-revision",
+						Annotations: map[string]string{},
+					},
+					Data: runtime.RawExtension{
+						Raw: []byte(newData),
+					},
+				},
+				opts: &UpdateOptions{},
+			},
+			want:            desiredWhenDisableFG,
+			wantWhenDisable: desiredWhenDisableFG,
+		},
+		{
+			name: "old revision annotation is nil=> ignore",
+			args: args{
+				oldRevision: &apps.ControllerRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "old-revision",
+						Annotations: nil,
+					},
+					Data: runtime.RawExtension{
+						Raw: []byte(oldData),
+					},
+				},
+				newRevision: &apps.ControllerRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "new-revision",
+						Annotations: map[string]string{volumeclaimtemplate.HashAnnotation: "balala"},
+					},
+					Data: runtime.RawExtension{
+						Raw: []byte(newData),
+					},
+				},
+				opts: &UpdateOptions{},
+			},
+			want:            desiredWhenDisableFG,
+			wantWhenDisable: desiredWhenDisableFG,
+		},
+		{
+			name: "new revision annotation is nil => ignore",
+			args: args{
+				oldRevision: &apps.ControllerRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "old-revision",
+						Annotations: map[string]string{volumeclaimtemplate.HashAnnotation: "balala"},
+					},
+					Data: runtime.RawExtension{
+						Raw: []byte(oldData),
+					},
+				},
+				newRevision: &apps.ControllerRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "new-revision",
+						Annotations: nil,
+					},
+					Data: runtime.RawExtension{
+						Raw: []byte(newData),
+					},
+				},
+				opts: &UpdateOptions{},
+			},
+			want:            desiredWhenDisableFG,
+			wantWhenDisable: desiredWhenDisableFG,
+		},
+		{
+			name: "revision annotation changes => recreate",
+			args: args{
+				oldRevision: &apps.ControllerRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "old-revision",
+						Annotations: map[string]string{volumeclaimtemplate.HashAnnotation: ""},
+					},
+					Data: runtime.RawExtension{
+						Raw: []byte(oldData),
+					},
+				},
+				newRevision: &apps.ControllerRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "new-revision",
+						Annotations: map[string]string{volumeclaimtemplate.HashAnnotation: "balala"},
+					},
+					Data: runtime.RawExtension{
+						Raw: []byte(newData),
+					},
+				},
+				opts: &UpdateOptions{},
+			},
+			want:            nil,
+			wantWhenDisable: desiredWhenDisableFG,
+		},
+		{
+			name: "the same revision annotation => in-place update",
+			args: args{
+				oldRevision: &apps.ControllerRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "old-revision",
+						Annotations: map[string]string{volumeclaimtemplate.HashAnnotation: "balala"},
+					},
+					Data: runtime.RawExtension{
+						Raw: []byte(oldData),
+					},
+				},
+				newRevision: &apps.ControllerRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "new-revision",
+						Annotations: map[string]string{volumeclaimtemplate.HashAnnotation: "balala"},
+					},
+					Data: runtime.RawExtension{
+						Raw: []byte(newData),
+					},
+				},
+				opts: &UpdateOptions{},
+			},
+			want:            desiredWhenDisableFG,
+			wantWhenDisable: desiredWhenDisableFG,
+		},
+		{
+			name: "both empty revision annotation => in-place update",
+			args: args{
+				oldRevision: &apps.ControllerRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "old-revision",
+						Annotations: map[string]string{volumeclaimtemplate.HashAnnotation: ""},
+					},
+					Data: runtime.RawExtension{
+						Raw: []byte(oldData),
+					},
+				},
+				newRevision: &apps.ControllerRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "new-revision",
+						Annotations: map[string]string{volumeclaimtemplate.HashAnnotation: ""},
+					},
+					Data: runtime.RawExtension{
+						Raw: []byte(newData),
+					},
+				},
+				opts: &UpdateOptions{},
+			},
+			want:            desiredWhenDisableFG,
+			wantWhenDisable: desiredWhenDisableFG,
+		},
+
+		// IgnoreVolumeClaimTemplatesHashDiff is true
+		{
+			name: "IgnoreVolumeClaimTemplatesHashDiff&both revision annotation is nil=> ignore",
+			args: args{
+				oldRevision: &apps.ControllerRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "old-revision",
+						Annotations: nil,
+					},
+					Data: runtime.RawExtension{
+						Raw: []byte(oldData),
+					},
+				},
+				newRevision: &apps.ControllerRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "new-revision",
+						Annotations: map[string]string{},
+					},
+					Data: runtime.RawExtension{
+						Raw: []byte(newData),
+					},
+				},
+				opts: ignoreVCTHashUpdateOpts,
+			},
+			want:            desiredWhenDisableFG,
+			wantWhenDisable: desiredWhenDisableFG,
+		},
+		{
+			name: "IgnoreVolumeClaimTemplatesHashDiff&old revision annotation is nil=> ignore",
+			args: args{
+				oldRevision: &apps.ControllerRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "old-revision",
+						Annotations: nil,
+					},
+					Data: runtime.RawExtension{
+						Raw: []byte(oldData),
+					},
+				},
+				newRevision: &apps.ControllerRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "new-revision",
+						Annotations: map[string]string{volumeclaimtemplate.HashAnnotation: "balala"},
+					},
+					Data: runtime.RawExtension{
+						Raw: []byte(newData),
+					},
+				},
+				opts: ignoreVCTHashUpdateOpts,
+			},
+			want:            desiredWhenDisableFG,
+			wantWhenDisable: desiredWhenDisableFG,
+		},
+		{
+			name: "IgnoreVolumeClaimTemplatesHashDiff&new revision annotation is nil => ignore",
+			args: args{
+				oldRevision: &apps.ControllerRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "old-revision",
+						Annotations: map[string]string{volumeclaimtemplate.HashAnnotation: "balala"},
+					},
+					Data: runtime.RawExtension{
+						Raw: []byte(oldData),
+					},
+				},
+				newRevision: &apps.ControllerRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "new-revision",
+						Annotations: nil,
+					},
+					Data: runtime.RawExtension{
+						Raw: []byte(newData),
+					},
+				},
+				opts: ignoreVCTHashUpdateOpts,
+			},
+			want:            desiredWhenDisableFG,
+			wantWhenDisable: desiredWhenDisableFG,
+		},
+		{
+			name: "IgnoreVolumeClaimTemplatesHashDiff&revision annotation changes => in-place update",
+			args: args{
+				oldRevision: &apps.ControllerRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "old-revision",
+						Annotations: map[string]string{volumeclaimtemplate.HashAnnotation: ""},
+					},
+					Data: runtime.RawExtension{
+						Raw: []byte(oldData),
+					},
+				},
+				newRevision: &apps.ControllerRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "new-revision",
+						Annotations: map[string]string{volumeclaimtemplate.HashAnnotation: "balala"},
+					},
+					Data: runtime.RawExtension{
+						Raw: []byte(newData),
+					},
+				},
+				opts: ignoreVCTHashUpdateOpts,
+			},
+			want:            desiredWhenDisableFG,
+			wantWhenDisable: desiredWhenDisableFG,
+		},
+		{
+			name: "IgnoreVolumeClaimTemplatesHashDiff&the same revision annotation => in-place update",
+			args: args{
+				oldRevision: &apps.ControllerRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "old-revision",
+						Annotations: map[string]string{volumeclaimtemplate.HashAnnotation: "balala"},
+					},
+					Data: runtime.RawExtension{
+						Raw: []byte(oldData),
+					},
+				},
+				newRevision: &apps.ControllerRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "new-revision",
+						Annotations: map[string]string{volumeclaimtemplate.HashAnnotation: "balala"},
+					},
+					Data: runtime.RawExtension{
+						Raw: []byte(newData),
+					},
+				},
+				opts: ignoreVCTHashUpdateOpts,
+			},
+			want:            desiredWhenDisableFG,
+			wantWhenDisable: desiredWhenDisableFG,
+		},
+		{
+			name: "IgnoreVolumeClaimTemplatesHashDiff&both empty revision annotation => in-place update",
+			args: args{
+				oldRevision: &apps.ControllerRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "old-revision",
+						Annotations: map[string]string{volumeclaimtemplate.HashAnnotation: ""},
+					},
+					Data: runtime.RawExtension{
+						Raw: []byte(oldData),
+					},
+				},
+				newRevision: &apps.ControllerRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "new-revision",
+						Annotations: map[string]string{volumeclaimtemplate.HashAnnotation: ""},
+					},
+					Data: runtime.RawExtension{
+						Raw: []byte(newData),
+					},
+				},
+				opts: ignoreVCTHashUpdateOpts,
+			},
+			want:            desiredWhenDisableFG,
+			wantWhenDisable: desiredWhenDisableFG,
+		},
+	}
+
+	testWhenEnable := func(enable bool) {
+		defer utilfeature.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.RecreatePodWhenChangeVCTInCloneSetGate, enable)()
+		for _, tt := range tests {
+			t.Run(fmt.Sprintf("%v-%v", tt.name, enable), func(t *testing.T) {
+				got := defaultCalculateInPlaceUpdateSpec(tt.args.oldRevision, tt.args.newRevision, tt.args.opts)
+				wanted := tt.wantWhenDisable
+				if utilfeature.DefaultFeatureGate.Enabled(features.RecreatePodWhenChangeVCTInCloneSetGate) {
+					wanted = tt.want
+				}
+				if got != nil && wanted != nil {
+					if !reflect.DeepEqual(got.ContainerImages, wanted.ContainerImages) {
+						t.Errorf("defaultCalculateInPlaceUpdateSpec() = %v, want %v", got, wanted)
+					}
+				} else if !(got == nil && wanted == nil) {
+					t.Errorf("defaultCalculateInPlaceUpdateSpec() = %v, want %v", got, wanted)
+				}
+				// got == nil && tt.want == nil => pass
+			})
+		}
+	}
+	testWhenEnable(true)
+	testWhenEnable(false)
+
 }

--- a/pkg/util/volumeclaimtemplate/volume_templates_hash.go
+++ b/pkg/util/volumeclaimtemplate/volume_templates_hash.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2024 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package volumeclaimtemplate
+
+import (
+	"encoding/json"
+	"hash/fnv"
+	"sort"
+	"strconv"
+
+	apps "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	hashutil "k8s.io/kubernetes/pkg/util/hash"
+)
+
+const (
+	// HashAnnotation represents the specs of volumeclaimtemplates hash
+	HashAnnotation = "kruise.io/cloneset-volumeclaimtemplate-hash"
+)
+
+var (
+	// defaultHasher is default VolumeClaimTemplatesHasher
+	defaultHasher VolumeClaimTemplatesHasher
+)
+
+type VolumeClaimTemplatesHasher interface {
+	// GetExpectHash get hash from volume claim templates
+	getExpectHash(templates []v1.PersistentVolumeClaim) uint64
+}
+
+type PVCGetter = func(string) *v1.PersistentVolumeClaim
+
+type volumeClaimTemplatesHasher struct{}
+
+func NewVolumeClaimTemplatesHasher() VolumeClaimTemplatesHasher {
+	return &volumeClaimTemplatesHasher{}
+}
+
+func (h *volumeClaimTemplatesHasher) getExpectHash(templates []v1.PersistentVolumeClaim) uint64 {
+	var pvcs []v1.PersistentVolumeClaim
+	for i := range templates {
+
+		pvcs = append(pvcs, v1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: templates[i].Name,
+			},
+			Spec: templates[i].Spec,
+		})
+	}
+
+	sort.SliceStable(pvcs, func(i, j int) bool {
+		return pvcs[i].Name < pvcs[j].Name
+	})
+	return hashVolumeClaimTemplate(pvcs)
+}
+
+func hashVolumeClaimTemplate(templates []v1.PersistentVolumeClaim) uint64 {
+	hash := fnv.New32a()
+	envsJSON, _ := json.Marshal(templates)
+	hashutil.DeepHashObject(hash, envsJSON)
+	return uint64(hash.Sum32())
+}
+
+func GetVCTemplatesHash(revision *apps.ControllerRevision) (string, bool) {
+	if len(revision.Annotations) > 0 {
+		val, exist := revision.Annotations[HashAnnotation]
+		return val, exist
+	}
+	return "", false
+}
+
+func PatchVCTemplateHash(revision *apps.ControllerRevision, vcTemplates []v1.PersistentVolumeClaim) {
+	if len(revision.Annotations) == 0 {
+		revision.Annotations = make(map[string]string)
+	}
+	if len(vcTemplates) != 0 {
+		// get hash of vct
+		vcTemplateHash := defaultHasher.getExpectHash(vcTemplates)
+		revision.Annotations[HashAnnotation] = strconv.FormatUint(vcTemplateHash, 10)
+	} else {
+		revision.Annotations[HashAnnotation] = ""
+	}
+}
+
+// CanVCTemplateInplaceUpdate
+func CanVCTemplateInplaceUpdate(oldRevision, newRevision *apps.ControllerRevision) bool {
+	newVCTemplatesHash, newExist := GetVCTemplatesHash(newRevision)
+	oldVCTemplatesHash, oldExist := GetVCTemplatesHash(oldRevision)
+	// oldExist = false, pass this case to avoid unnecessary recreate when first open this feature
+	// newExist = false, the hash must exist in normal case, however, corner case may exist:
+	// 1. cloneset A with image 1 vct size 1Gi
+	// 2. kriuse update to new version, next revision will patch hash
+	// 3. 1st update cloneset A with image2 vct size 1Gi -> in-place update and revision hash is not nil
+	// 4. 1st update over
+	// 5. kruise rollback, next revision will not patch hash
+	// 6. 2rd update cloneset A with image3 vct size 1Gi, partition 50% -> in-place update and revision hash is nil
+	// 7. kruise re-update
+	// 8. 2rd update, with partition 0
+	//
+	// In step8 of this case, new revision hash does not exist and old revision exists.
+	// It might be necessary to include a case where the new revision is non-existent as well.
+	if !oldExist || !newExist {
+		return true
+	}
+	return newVCTemplatesHash == oldVCTemplatesHash
+}
+
+func init() {
+	defaultHasher = NewVolumeClaimTemplatesHasher()
+}

--- a/pkg/util/volumeclaimtemplate/volume_templates_hash_test.go
+++ b/pkg/util/volumeclaimtemplate/volume_templates_hash_test.go
@@ -1,0 +1,408 @@
+package volumeclaimtemplate
+
+import (
+	"testing"
+
+	apps "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_vctHasher_GetExpectHash(t *testing.T) {
+	type args struct {
+		templates []v1.PersistentVolumeClaim
+	}
+	tests := []struct {
+		name string
+		args args
+		want uint64
+	}{
+		{
+			name: "zero-pvc",
+			args: args{
+				[]v1.PersistentVolumeClaim{},
+			},
+			want: 86995377,
+		},
+		{
+			name: "nil-pvc",
+			args: args{
+				templates: nil,
+			},
+			want: 86995377,
+		},
+		{
+			name: "single-pvc",
+			args: args{
+				[]v1.PersistentVolumeClaim{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "pvc-1",
+						},
+						Spec: v1.PersistentVolumeClaimSpec{
+							AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+							Resources: v1.ResourceRequirements{
+								Requests: map[v1.ResourceName]resource.Quantity{
+									v1.ResourceStorage: resource.MustParse("1Gi"),
+								},
+								Limits: map[v1.ResourceName]resource.Quantity{
+									v1.ResourceStorage: resource.MustParse("2Gi"),
+								},
+							},
+						},
+					},
+				},
+			},
+			want: 1129974074,
+		},
+		{
+			name: "multi-pvcs",
+			args: args{
+				[]v1.PersistentVolumeClaim{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "pvc-1",
+						},
+						Spec: v1.PersistentVolumeClaimSpec{
+							AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+							Resources: v1.ResourceRequirements{
+								Requests: map[v1.ResourceName]resource.Quantity{
+									v1.ResourceStorage: resource.MustParse("1Gi"),
+								},
+								Limits: map[v1.ResourceName]resource.Quantity{
+									v1.ResourceStorage: resource.MustParse("2Gi"),
+								},
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "pvc-2",
+						},
+						Spec: v1.PersistentVolumeClaimSpec{
+							AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+							Resources: v1.ResourceRequirements{
+								Requests: map[v1.ResourceName]resource.Quantity{
+									v1.ResourceStorage: resource.MustParse("2Gi"),
+								},
+								Limits: map[v1.ResourceName]resource.Quantity{
+									v1.ResourceStorage: resource.MustParse("4Gi"),
+								},
+							},
+						},
+					},
+				},
+			},
+			want: 510584408,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &volumeClaimTemplatesHasher{}
+			if got := h.getExpectHash(tt.args.templates); got != tt.want {
+				t.Errorf("getExpectHash() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPatchVCTemplateHash(t *testing.T) {
+	type args struct {
+		revision    *apps.ControllerRevision
+		vcTemplates []v1.PersistentVolumeClaim
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "base-revision-none-pvc",
+			args: args{
+				&apps.ControllerRevision{},
+				[]v1.PersistentVolumeClaim{},
+			},
+			want: "",
+		},
+		{
+			name: "base-revision-nil-pvc",
+			args: args{
+				&apps.ControllerRevision{},
+				nil,
+			},
+			want: "",
+		},
+		{
+			name: "base-revision-pvc",
+			args: args{
+				&apps.ControllerRevision{},
+				[]v1.PersistentVolumeClaim{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "pvc-1",
+						},
+						Spec: v1.PersistentVolumeClaimSpec{
+							AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+							Resources: v1.ResourceRequirements{
+								Requests: map[v1.ResourceName]resource.Quantity{
+									v1.ResourceStorage: resource.MustParse("1Gi"),
+								},
+								Limits: map[v1.ResourceName]resource.Quantity{
+									v1.ResourceStorage: resource.MustParse("2Gi"),
+								},
+							},
+						},
+					},
+				},
+			},
+			want: "1129974074",
+		},
+		{
+			name: "base-revision-pvcs",
+			args: args{
+				&apps.ControllerRevision{},
+				[]v1.PersistentVolumeClaim{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "pvc-1",
+						},
+						Spec: v1.PersistentVolumeClaimSpec{
+							AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+							Resources: v1.ResourceRequirements{
+								Requests: map[v1.ResourceName]resource.Quantity{
+									v1.ResourceStorage: resource.MustParse("1Gi"),
+								},
+								Limits: map[v1.ResourceName]resource.Quantity{
+									v1.ResourceStorage: resource.MustParse("2Gi"),
+								},
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "pvc-2",
+						},
+						Spec: v1.PersistentVolumeClaimSpec{
+							AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+							Resources: v1.ResourceRequirements{
+								Requests: map[v1.ResourceName]resource.Quantity{
+									v1.ResourceStorage: resource.MustParse("2Gi"),
+								},
+								Limits: map[v1.ResourceName]resource.Quantity{
+									v1.ResourceStorage: resource.MustParse("4Gi"),
+								},
+							},
+						},
+					},
+				},
+			},
+			want: "510584408",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			PatchVCTemplateHash(tt.args.revision, tt.args.vcTemplates)
+			if got, _ := GetVCTemplatesHash(tt.args.revision); got != tt.want {
+				t.Errorf("getExpectHash() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetVCTemplatesHash(t *testing.T) {
+	type args struct {
+		revision *apps.ControllerRevision
+	}
+	tests := []struct {
+		name  string
+		args  args
+		want  string
+		want1 bool
+	}{
+		// TODO: Add test cases.
+		{
+			name: "none-exist hash",
+			args: args{
+				&apps.ControllerRevision{},
+			},
+			want:  "",
+			want1: false,
+		},
+		{
+			name: "empty hash",
+			args: args{
+				&apps.ControllerRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							HashAnnotation: "",
+						},
+					},
+				},
+			},
+			want:  "",
+			want1: true,
+		},
+		{
+			name: "any hash",
+			args: args{
+				&apps.ControllerRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							HashAnnotation: "1129974074",
+						},
+					},
+				},
+			},
+			want:  "1129974074",
+			want1: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1 := GetVCTemplatesHash(tt.args.revision)
+			if got != tt.want {
+				t.Errorf("GetVCTemplatesHash() got = %v, want %v", got, tt.want)
+			}
+			if got1 != tt.want1 {
+				t.Errorf("GetVCTemplatesHash() got1 = %v, want %v", got1, tt.want1)
+			}
+		})
+	}
+}
+
+func TestCanVCTemplateInplaceUpdate(t *testing.T) {
+	type args struct {
+		oldRevision *apps.ControllerRevision
+		newRevision *apps.ControllerRevision
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "both old and new are nil",
+			args: args{
+				&apps.ControllerRevision{},
+				&apps.ControllerRevision{},
+			},
+			want: true,
+		},
+		{
+			name: "old is nil 1",
+			args: args{
+				&apps.ControllerRevision{},
+				&apps.ControllerRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							HashAnnotation: "1129974074",
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "old is nil 2",
+			args: args{
+				&apps.ControllerRevision{},
+				&apps.ControllerRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							HashAnnotation: "",
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "same empty",
+			args: args{
+				&apps.ControllerRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							HashAnnotation: "",
+						},
+					},
+				},
+				&apps.ControllerRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							HashAnnotation: "",
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "same not empty",
+			args: args{
+				&apps.ControllerRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							HashAnnotation: "11",
+						},
+					},
+				},
+				&apps.ControllerRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							HashAnnotation: "11",
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "new is empty",
+			args: args{
+				&apps.ControllerRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							HashAnnotation: "11",
+						},
+					},
+				},
+				&apps.ControllerRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							HashAnnotation: "",
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "different",
+			args: args{
+				&apps.ControllerRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							HashAnnotation: "11",
+						},
+					},
+				},
+				&apps.ControllerRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							HashAnnotation: "22",
+						},
+					},
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CanVCTemplateInplaceUpdate(tt.args.oldRevision, tt.args.newRevision); got != tt.want {
+				t.Errorf("CanVCTemplateInplaceUpdate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/scripts/deploy_kind.sh
+++ b/scripts/deploy_kind.sh
@@ -11,5 +11,5 @@ make kustomize
 KUSTOMIZE=$(pwd)/bin/kustomize
 (cd config/manager && "${KUSTOMIZE}" edit set image controller="${IMG}")
 "${KUSTOMIZE}" build config/default | sed -e 's/imagePullPolicy: Always/imagePullPolicy: IfNotPresent/g' > /tmp/kruise-kustomization.yaml
-echo -e "resources:\n- manager.yaml" > config/manager/kustomization.yaml
+echo -e "# Adds namespace to all resources.\nnamespace: kruise-system\n\nresources:\n- manager.yaml" > config/manager/kustomization.yaml
 kubectl apply -f /tmp/kruise-kustomization.yaml

--- a/test/e2e/apps/cloneset.go
+++ b/test/e2e/apps/cloneset.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/onsi/ginkgo"
@@ -1065,6 +1066,11 @@ var _ = SIGDescribe("CloneSet", func() {
 				return len(updated) == 3 && len(current) == 0 && len(preUpdateIndex) == 0
 			}, 120*time.Second, 3*time.Second).Should(gomega.BeTrue())
 		})
+
+		ginkgo.It(`CloneSet Update with VolumeClaimTemplate changes`, func() {
+			testUpdateVolumeClaimTemplates(tester, randStr, c)
+		})
+
 	})
 
 	framework.KruiseDescribe("CloneSet pre-download images", func() {
@@ -1112,3 +1118,187 @@ var _ = SIGDescribe("CloneSet", func() {
 		})
 	})
 })
+
+func checkPVCsDoRecreate(numsOfPVCs int, recreate bool) func(instanceIds, newInstanceIds, pvcIds sets.String, pods []*v1.Pod, pvcs []*v1.PersistentVolumeClaim) {
+	return func(instanceIds, newInstanceIds, pvcIds sets.String, pods []*v1.Pod, pvcs []*v1.PersistentVolumeClaim) {
+		gomega.Expect(len(pvcs)).Should(gomega.Equal(numsOfPVCs))
+		for _, pvc := range pvcs {
+			id := pvc.Labels[appsv1alpha1.CloneSetInstanceID]
+			gomega.Expect(newInstanceIds.Has(id)).To(gomega.Equal(true))
+			gomega.Expect(instanceIds.Has(id)).To(gomega.Equal(!recreate))
+			gomega.Expect(pvcIds.Has(pvc.Name)).To(gomega.Equal(!recreate))
+		}
+	}
+}
+
+func checkPodsDoRecreate(numsOfPods int, recreate bool) func(instanceIds, newInstanceIds, pvcIds sets.String, pods []*v1.Pod, pvcs []*v1.PersistentVolumeClaim) {
+	return func(instanceIds, newInstanceIds, pvcIds sets.String, pods []*v1.Pod, pvcs []*v1.PersistentVolumeClaim) {
+		gomega.Expect(len(pods)).Should(gomega.Equal(numsOfPods))
+		for _, pod := range pods {
+			gomega.Expect(instanceIds.Has(pod.Labels[appsv1alpha1.CloneSetInstanceID])).To(gomega.Equal(!recreate))
+		}
+	}
+}
+
+func changeCloneSetAndWaitReady(tester *framework.CloneSetTester, cs *appsv1alpha1.CloneSet,
+	fn func(cs *appsv1alpha1.CloneSet), instanceIds, pvcIds sets.String,
+	checkFns ...func(instanceIds, newInstanceIds, pvcIds sets.String, pods []*v1.Pod, pvcs []*v1.PersistentVolumeClaim)) (sets.String, sets.String) {
+	err := tester.UpdateCloneSet(cs.Name, fn)
+
+	replica := *cs.Spec.Replicas
+	ginkgo.By("Wait for replicas satisfied")
+	gomega.Eventually(func() int32 {
+		cs, err = tester.GetCloneSet(cs.Name)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		return cs.Status.Replicas
+	}, 3*time.Second, time.Second).Should(gomega.Equal(replica))
+	time.Sleep(time.Second * 3)
+
+	ginkgo.By("Wait for all pods ready")
+	gomega.Eventually(func() int32 {
+		cs, err = tester.GetCloneSet(cs.Name)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		if cs.Status.ObservedGeneration != cs.Generation {
+			return -1
+		}
+		return cs.Status.UpdatedReadyReplicas
+	}, 120*time.Second, 3*time.Second).Should(gomega.Equal(*cs.Spec.Replicas))
+
+	pods, err := tester.ListPodsForCloneSet(cs.Name)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	gomega.Expect(int32(len(pods))).Should(gomega.Equal(replica))
+	newInstanceIds := sets.NewString()
+	for _, pod := range pods {
+		newInstanceIds.Insert(pod.Labels[appsv1alpha1.CloneSetInstanceID])
+	}
+	pvcs, err := tester.ListPVCForCloneSet()
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	if len(instanceIds) > 0 && len(pvcIds) > 0 {
+		for _, checkFn := range checkFns {
+			checkFn(instanceIds, newInstanceIds, pvcIds, pods, pvcs)
+		}
+	}
+
+	// record new pvcIds
+	newPvcIds := sets.NewString()
+	for _, pvc := range pvcs {
+		gomega.Expect(newInstanceIds.Has(pvc.Labels[appsv1alpha1.CloneSetInstanceID])).Should(gomega.BeTrue())
+		newPvcIds.Insert(pvc.Name)
+	}
+
+	return newInstanceIds, newPvcIds
+}
+
+func testUpdateVolumeClaimTemplates(tester *framework.CloneSetTester, randStr string, c clientset.Interface) {
+	updateStrategy := appsv1alpha1.CloneSetUpdateStrategy{Type: appsv1alpha1.RecreateCloneSetUpdateStrategyType}
+	var replicas int = 4
+	cs := tester.NewCloneSet("clone-"+randStr, int32(replicas), updateStrategy)
+	imageConfig := imageutils.GetConfig(imageutils.Nginx)
+	imageConfig.SetRegistry("docker.io/library")
+	imageConfig.SetVersion("alpine")
+	cs.Spec.Template.Spec.Containers[0].Image = imageConfig.GetE2EImage()
+	cs.Spec.VolumeClaimTemplates = []v1.PersistentVolumeClaim{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "data-vol1"},
+			Spec: v1.PersistentVolumeClaimSpec{
+				AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+				Resources: v1.ResourceRequirements{
+					Requests: v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Gi")},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "data-vol2"},
+			Spec: v1.PersistentVolumeClaimSpec{
+				AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+				Resources: v1.ResourceRequirements{
+					Requests: v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Gi")},
+				},
+			},
+		},
+	}
+	cs, err := tester.CreateCloneSet(cs)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	gomega.Expect(cs.Spec.UpdateStrategy.Type).To(gomega.Equal(appsv1alpha1.RecreateCloneSetUpdateStrategyType))
+
+	instanceIds, pvcIds := changeCloneSetAndWaitReady(tester, cs, func(cs *appsv1alpha1.CloneSet) {}, nil, nil)
+
+	numsOfPVCs := replicas * 2
+	checkPVCSize1 := func(instanceIds, newInstanceIds, pvcIds sets.String, pods []*v1.Pod, pvcs []*v1.PersistentVolumeClaim) {
+		gomega.Expect(len(pvcs)).Should(gomega.Equal(numsOfPVCs))
+		for _, pvc := range pvcs {
+			id := pvc.Labels[appsv1alpha1.CloneSetInstanceID]
+			gomega.Expect(newInstanceIds.Has(id)).To(gomega.Equal(true))
+			req := "1Gi"
+			if strings.Contains(pvc.Name, "data-vol1") {
+				req = "2Gi"
+			}
+			gomega.Expect(pvc.Spec.Resources.Requests.Storage().String()).To(gomega.Equal(req))
+		}
+	}
+	// update cloneSet image + vct size
+	ginkgo.By("Update cloneSet image and volumeClaimTemplates")
+	updateImageAndVCTFn := func(cs *appsv1alpha1.CloneSet) {
+		imageConfig = imageutils.GetConfig(imageutils.NginxNew)
+		cs.Spec.Template.Spec.Containers[0].Image = imageConfig.GetE2EImage()
+		cs.Spec.VolumeClaimTemplates[0].Spec.Resources.Requests = v1.ResourceList{v1.ResourceStorage: resource.MustParse("2Gi")}
+		cs.Spec.UpdateStrategy = appsv1alpha1.CloneSetUpdateStrategy{Type: appsv1alpha1.InPlaceIfPossibleCloneSetUpdateStrategyType}
+	}
+	instanceIds, pvcIds = changeCloneSetAndWaitReady(tester, cs, updateImageAndVCTFn,
+		instanceIds, pvcIds, checkPodsDoRecreate(replicas, true),
+		checkPVCsDoRecreate(replicas*2, true), checkPVCSize1)
+
+	// update cloneSet only size
+	ginkgo.By("Update cloneSet only volumeClaimTemplates")
+	updateVCTOnly := func(cs *appsv1alpha1.CloneSet) {
+		cs.Spec.VolumeClaimTemplates[1].Spec.Resources.Requests = v1.ResourceList{v1.ResourceStorage: resource.MustParse("2Gi")}
+		cs.Spec.UpdateStrategy = appsv1alpha1.CloneSetUpdateStrategy{Type: appsv1alpha1.InPlaceIfPossibleCloneSetUpdateStrategyType}
+	}
+	instanceIds, pvcIds = changeCloneSetAndWaitReady(tester, cs, updateVCTOnly,
+		instanceIds, pvcIds, checkPodsDoRecreate(replicas, false),
+		checkPVCsDoRecreate(replicas*2, false), checkPVCSize1)
+
+	checkPVCSize2 := func(instanceIds, newInstanceIds, pvcIds sets.String, pods []*v1.Pod, pvcs []*v1.PersistentVolumeClaim) {
+		gomega.Expect(len(pvcs)).Should(gomega.Equal(numsOfPVCs))
+		for _, pvc := range pvcs {
+			id := pvc.Labels[appsv1alpha1.CloneSetInstanceID]
+			gomega.Expect(newInstanceIds.Has(id)).To(gomega.Equal(true))
+			req := "2Gi"
+			gomega.Expect(pvc.Spec.Resources.Requests.Storage().String()).To(gomega.Equal(req))
+		}
+	}
+
+	// update cloneSet image
+	ginkgo.By("Update cloneSet image and vct size changed in previous step")
+	updateImageOnly := func(cs *appsv1alpha1.CloneSet) {
+		imageConfig = imageutils.GetConfig(imageutils.Redis)
+		cs.Spec.Template.Spec.Containers[0].Image = imageConfig.GetE2EImage()
+		cs.Spec.UpdateStrategy = appsv1alpha1.CloneSetUpdateStrategy{Type: appsv1alpha1.InPlaceIfPossibleCloneSetUpdateStrategyType}
+	}
+	instanceIds, pvcIds = changeCloneSetAndWaitReady(tester, cs, updateImageOnly,
+		instanceIds, pvcIds, checkPodsDoRecreate(replicas, true),
+		checkPVCsDoRecreate(replicas*2, true), checkPVCSize2)
+
+	// inplace-only update strategy with image change
+	inplaceOnlyWithImage := func(cs *appsv1alpha1.CloneSet) {
+		imageConfig = imageutils.GetConfig(imageutils.Httpd)
+		cs.Spec.Template.Spec.Containers[0].Image = imageConfig.GetE2EImage()
+		cs.Spec.UpdateStrategy = appsv1alpha1.CloneSetUpdateStrategy{Type: appsv1alpha1.InPlaceOnlyCloneSetUpdateStrategyType}
+	}
+	instanceIds, pvcIds = changeCloneSetAndWaitReady(tester, cs, inplaceOnlyWithImage,
+		instanceIds, pvcIds, checkPodsDoRecreate(replicas, false),
+		checkPVCsDoRecreate(replicas*2, false), checkPVCSize2)
+
+	// inplace-only update strategy with image and vct changes -> in-place update with pvc no changes
+	inplaceOnlyWithImageAndVCT := func(cs *appsv1alpha1.CloneSet) {
+		imageConfig = imageutils.GetConfig(imageutils.Redis)
+		cs.Spec.Template.Spec.Containers[0].Image = imageConfig.GetE2EImage()
+		cs.Spec.VolumeClaimTemplates[0].Spec.Resources.Requests = v1.ResourceList{v1.ResourceStorage: resource.MustParse("3Gi")}
+		cs.Spec.VolumeClaimTemplates[1].Spec.Resources.Requests = v1.ResourceList{v1.ResourceStorage: resource.MustParse("3Gi")}
+		cs.Spec.UpdateStrategy = appsv1alpha1.CloneSetUpdateStrategy{Type: appsv1alpha1.InPlaceOnlyCloneSetUpdateStrategyType}
+	}
+	instanceIds, pvcIds = changeCloneSetAndWaitReady(tester, cs, inplaceOnlyWithImageAndVCT,
+		instanceIds, pvcIds, checkPodsDoRecreate(replicas, false),
+		checkPVCsDoRecreate(replicas*2, false), checkPVCSize2)
+}

--- a/test/e2e/framework/cloneset_util.go
+++ b/test/e2e/framework/cloneset_util.go
@@ -102,6 +102,10 @@ func (t *CloneSetTester) ListPodsForCloneSet(name string) (pods []*v1.Pod, err e
 	}
 	for i := range podList.Items {
 		pod := &podList.Items[i]
+		// ignore deleting pod
+		if pod.DeletionTimestamp != nil {
+			continue
+		}
 		if owner := metav1.GetControllerOf(pod); owner != nil && owner.Name == name {
 			pods = append(pods, pod)
 		}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

Implemented "When volumeClaimTemplates are modified, the pod must ReCreate update"

1. If both the volumeClaimTemplates spec and the image are modified -> recreate.
2. If only the volumeClaimTemplates spec is modified -> no changes util next template spec changes
3. next modification of the image or other configurations -> recreate update
4. To prevent unnecessary pod recreate update, the initial upgrade of CloneSets that previously utilized the volumeClaimTemplates feature will bypass the comparison of historical revisions lacking hash values after the Kruise upgrade.
    - Abandoned the implementation of calculating the hash from pod volumes and existing PVCs: some PVCs have inherent fields that do not exist in volumeClaimTemplates, leading to calculated hash values that are inconsistent with the hash values calculated based on volumeClaimTemplates.

#### Corner case in 4
  1. Before the Kruise upgrade, CloneSet with image 1 and vcTemplates size 1Mi.
  2. After the Kruise upgrade, an update was applied to use image 2 and vcTemplate size 10Mi.  However, due to the absence of hash values for historical revisions, this update will not trigger a recreation, and the actual pod will be like image 2 and vcTemplate size 1Mi. The revision will incorrectly record the hash value for the 10Mi size. Future updates in this situation need to be cautious.
  4. It is recommended not to modify the vcTemplate during the first update after the Kruise upgrade.


 detail in #1536

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

detail in #1536
### Ⅲ. Describe how to verify it

detail case in #1536
#### Main test cases:

 1. image 1, vctemplate size of 1MB.
 2. Image 2, vcTemplate size of 1MB.
 3. Image 3, vcTemplate size of 1MB. (in function testUpdate)
 5. Image 4, vcTemplate size of 10MB => recreate.
 6. Image 2, vcTemplate size of 10MB => (expected in-place upgrade)
    --- Although the history revision hash is consistent, the vct hash is not, update history revision id and hash value
 7. Image 4, vcTemplate size of 10MB => in-place upgrade --- Update history revision.
 8. Image 4, vcTemplate size of 100MB => (temporarily unchanged) --- Do not generate a new revision.
 9. Image 5, vcTemplate size of 100MB => recreate.

### Ⅳ. Special notes for reviews

