### PR TITLE
Add dependabot config for auto-update github-actions.

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,17 @@
+# This YAML configuration file is used to enable Dependabot for automated dependency management.
+# Dependabot helps keep the project's dependencies up-to-date by automatically creating pull requests
+# for outdated dependencies based on the version constraints defined in your project.
+# For more information and customization options, please refer to the Dependabot documentation:
+# Documentation: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically
+# Configuration options: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  # Allow up to 10 open pull requests for update github-actions
+  # 5 by default
+  # see https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit
+  open-pull-requests-limit: 10
+  schedule:
+    # Check for updates to GitHub Actions every week
+    interval: "weekly"


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

Let dependabot work for auto update github-actions to get rid of deprecated github actions.

/assign @zmberg   
/assign @furykerry



### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

Today, github action have some alert:
```shell
<html>
<body>
<!--StartFragment-->
Analyze (go)Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, github/codeql-action/init@v2, github/codeql-action/autobuild@v2, github/codeql-action/analyze@v2. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.Show more
--
Analyze (go)CodeQL Action v2 will be deprecated on December 5th, 2024. Please update all occurrences of the CodeQL Action in your workflow files to v3. For more information, see https://github.blog/changelog/2024-01-12-code-sca

<!--EndFragment-->
</body>
</html>
```