### PR TITLE
Add permission of security-events write for ghaction golangci-lint.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,6 +37,8 @@ jobs:
 
   golangci-lint:
     runs-on: ubuntu-20.04
+    permissions:
+      security-events: write
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

Fix permission problem of golangci-lint, broken from https://github.com/openkruise/kruise/pull/1523 , check https://github.com/openkruise/kruise/actions/runs/8705720546/job/23876728653

I have verifyed on my fork repo:  https://github.com/liangyuanpeng/kruise/actions/runs/8707280251/job/23881898537 with below config:

```diff
  push:
    branches:
      - master
      - release-*
+    - fix_ghaction_permission
```

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

