### PR TITLE
[Bugfix] update CI test image centos:6.7 to centos:7 to support run CI on arm

### DIFF
--- a/test/e2e/framework/pod_probe_marker_util.go
+++ b/test/e2e/framework/pod_probe_marker_util.go
@@ -210,7 +210,7 @@ func (s *PodProbeMarkerTester) NewBaseStatefulSet(namespace, randStr string) *ap
 						},
 						{
 							Name:            "main",
-							Image:           "centos:6.7",
+							Image:           "centos:7",
 							Command:         []string{"sleep", "999d"},
 							ImagePullPolicy: corev1.PullIfNotPresent,
 						},


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Update sts image in CI from centos:6.7 to centos:7 because version 7 is a multi-arch image but 6.7 not.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
Fix issue #1616

### Ⅲ. Describe how to verify it
All github CI should pass, and also this case can run on arm machine.

### Ⅳ. Special notes for reviews

