### PR TITLE
fix: fix miss makezero bug

### DIFF
--- a/pkg/util/imagejob/imagejob_reader.go
+++ b/pkg/util/imagejob/imagejob_reader.go
@@ -55,7 +55,7 @@ func PopCachedNodeImagesForJob(job *appsv1alpha1.ImagePullJob) []string {
 }
 
 func writeCache(job *appsv1alpha1.ImagePullJob, nodeImages []*appsv1alpha1.NodeImage) {
-	names := make([]string, len(nodeImages))
+	names := make([]string, 0, len(nodeImages))
 	for _, n := range nodeImages {
 		names = append(names, n.Name)
 	}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

I was running github actions to run linter [makezero](https://github.com/ashanbrown/makezero) for top github golang repos.

see issues https://github.com/alingse/go-linter-runner/issues/1

and the github actions output https://github.com/alingse/go-linter-runner/actions/runs/9242658768/job/25425757534 

```
====================================================================================================
append to slice `names` with non-zero initialized length at https://github.com/openkruise/kruise/blob/master/pkg/util/imagejob/imagejob_reader.go#L60:11
====================================================================================================
```
 

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

the names no need empty string value


### Ⅳ. Special notes for reviews

