### PR TITLE
Make CloneSet and StatefulSet Support the generateName setting

### DIFF
--- a/apis/apps/defaults/v1alpha1.go
+++ b/apis/apps/defaults/v1alpha1.go
@@ -254,6 +254,9 @@ func SetDefaultsUnitedDeployment(obj *v1alpha1.UnitedDeployment, injectTemplateD
 
 // SetDefaults_CloneSet set default values for CloneSet.
 func SetDefaultsCloneSet(obj *v1alpha1.CloneSet, injectTemplateDefaults bool) {
+	if obj.GenerateName == "" {
+		obj.GenerateName = obj.Name
+	}
 	if obj.Spec.Replicas == nil {
 		obj.Spec.Replicas = utilpointer.Int32Ptr(1)
 	}

--- a/apis/apps/defaults/v1beta1.go
+++ b/apis/apps/defaults/v1beta1.go
@@ -28,6 +28,10 @@ import (
 
 // SetDefaultsStatefulSet set default values for StatefulSet.
 func SetDefaultsStatefulSet(obj *v1beta1.StatefulSet, injectTemplateDefaults bool) {
+	if obj.GenerateName == "" {
+		obj.GenerateName = obj.Name
+	}
+
 	if len(obj.Spec.PodManagementPolicy) == 0 {
 		obj.Spec.PodManagementPolicy = appsv1.OrderedReadyPodManagement
 	}

--- a/pkg/controller/cloneset/cloneset_controller.go
+++ b/pkg/controller/cloneset/cloneset_controller.go
@@ -256,7 +256,7 @@ func (r *ReconcileCloneSet) doReconcile(request reconcile.Request) (res reconcil
 		}
 	}
 
-	//release Pods ownerRef
+	// release Pods ownerRef
 	filteredPods, err = r.claimPods(instance, filteredPods)
 	if err != nil {
 		return reconcile.Result{}, err

--- a/pkg/controller/cloneset/cloneset_controller_test.go
+++ b/pkg/controller/cloneset/cloneset_controller_test.go
@@ -60,7 +60,7 @@ import (
 var c client.Client
 
 var (
-	expectedRequest = reconcile.Request{NamespacedName: types.NamespacedName{Name: "foo", Namespace: "default"}}
+	expectedRequest = reconcile.Request{NamespacedName: types.NamespacedName{Name: "foooo", Namespace: "default"}}
 	images          = []string{"nginx:1.9.1", "nginx:1.9.2", "nginx:1.9.3", "nginx:1.9.2-alphine", "nginx:1.9.3-alphine"}
 	clonesetUID     = "123"
 	productionLabel = map[string]string{"type": "production"}
@@ -72,7 +72,7 @@ var (
 func TestReconcile(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	instance := &appsv1alpha1.CloneSet{
-		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"},
+		ObjectMeta: metav1.ObjectMeta{Name: "foooo", GenerateName: "foo", Namespace: "default"},
 		Spec: appsv1alpha1.CloneSetSpec{
 			Replicas: getInt32(1),
 			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}},
@@ -101,7 +101,7 @@ func TestReconcile(t *testing.T) {
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	c = utilclient.NewClientFromManager(mgr, "test-cloneset-controller")
 
-	//recFn, requests := SetupTestReconcile(newReconciler(mgr))
+	// recFn, requests := SetupTestReconcile(newReconciler(mgr))
 	g.Expect(add(mgr, newReconciler(mgr))).NotTo(gomega.HaveOccurred())
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/controller/cloneset/core/cloneset_core.go
+++ b/pkg/controller/cloneset/core/cloneset_core.go
@@ -95,7 +95,7 @@ func (c *commonControl) newVersionedPods(cs *appsv1alpha1.CloneSet, revision str
 		}
 		clonesetutils.WriteRevisionHash(pod, revision)
 
-		pod.Name = fmt.Sprintf("%s-%s", cs.Name, id)
+		pod.Name = fmt.Sprintf("%s-%s", cs.GenerateName, id)
 		pod.Namespace = cs.Namespace
 		pod.Labels[appsv1alpha1.CloneSetInstanceID] = id
 

--- a/pkg/controller/cloneset/test/test.go
+++ b/pkg/controller/cloneset/test/test.go
@@ -84,9 +84,10 @@ func NewCloneSetWithVolumes(replicas int, name string, petMounts []v1.VolumeMoun
 			APIVersion: "apps.kruise.io/v1alpha1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: v1.NamespaceDefault,
-			UID:       types.UID("test"),
+			Name:         name,
+			GenerateName: name,
+			Namespace:    v1.NamespaceDefault,
+			UID:          types.UID("test"),
 		},
 		Spec: appsv1alpha1.CloneSetSpec{
 			Selector: &metav1.LabelSelector{

--- a/pkg/controller/cloneset/utils/cloneset_utils.go
+++ b/pkg/controller/cloneset/utils/cloneset_utils.go
@@ -183,7 +183,7 @@ func GetInstanceID(obj metav1.Object) string {
 }
 
 // GetPersistentVolumeClaims gets a map of PersistentVolumeClaims to their template names, as defined in set. The
-// returned PersistentVolumeClaims are each constructed with a the name specific to the Pod. This name is determined
+// returned PersistentVolumeClaims are each constructed with the name specific to the Pod. This name is determined
 // by getPersistentVolumeClaimName.
 func GetPersistentVolumeClaims(cs *appsv1alpha1.CloneSet, pod *v1.Pod) map[string]v1.PersistentVolumeClaim {
 	templates := cs.Spec.VolumeClaimTemplates
@@ -211,7 +211,7 @@ func GetPersistentVolumeClaims(cs *appsv1alpha1.CloneSet, pod *v1.Pod) map[strin
 // getPersistentVolumeClaimName gets the name of PersistentVolumeClaim for a Pod with an instance id. claim
 // must be a PersistentVolumeClaim from set's VolumeClaims template.
 func getPersistentVolumeClaimName(cs *appsv1alpha1.CloneSet, claim *v1.PersistentVolumeClaim, id string) string {
-	return fmt.Sprintf("%s-%s-%s", claim.Name, cs.Name, id)
+	return fmt.Sprintf("%s-%s-%s", claim.Name, cs.GenerateName, id)
 }
 
 // DoItSlowly tries to call the provided function a total of 'count' times,

--- a/pkg/controller/statefulset/stateful_pod_control_test.go
+++ b/pkg/controller/statefulset/stateful_pod_control_test.go
@@ -637,6 +637,7 @@ func TestPodClaimIsStale(t *testing.T) {
 	for _, tc := range testCases {
 		set := appsv1beta1.StatefulSet{}
 		set.Name = "set"
+		set.GenerateName = "set"
 		set.Namespace = "default"
 		set.Spec.PersistentVolumeClaimRetentionPolicy = &appsv1beta1.StatefulSetPersistentVolumeClaimRetentionPolicy{
 			WhenDeleted: appsv1beta1.RetainPersistentVolumeClaimRetentionPolicyType,

--- a/pkg/controller/statefulset/stateful_set_utils.go
+++ b/pkg/controller/statefulset/stateful_set_utils.go
@@ -66,7 +66,7 @@ func getParentNameAndOrdinal(pod *v1.Pod) (string, int) {
 	return parent, ordinal
 }
 
-// getParentName gets the name of pod's parent StatefulSet. If pod has not parent, the empty string is returned.
+// getParentName gets the name of pod's parent StatefulSet. If pod has no parent, the empty string is returned.
 func getParentName(pod *v1.Pod) string {
 	parent, _ := getParentNameAndOrdinal(pod)
 	return parent
@@ -80,26 +80,26 @@ func getOrdinal(pod *v1.Pod) int {
 
 // getPodName gets the name of set's child Pod with an ordinal index of ordinal
 func getPodName(set *appsv1beta1.StatefulSet, ordinal int) string {
-	return fmt.Sprintf("%s-%d", set.Name, ordinal)
+	return fmt.Sprintf("%s-%d", set.GenerateName, ordinal)
 }
 
 // getPersistentVolumeClaimName gets the name of PersistentVolumeClaim for a Pod with an ordinal index of ordinal. claim
 // must be a PersistentVolumeClaim from set's VolumeClaims template.
 func getPersistentVolumeClaimName(set *appsv1beta1.StatefulSet, claim *v1.PersistentVolumeClaim, ordinal int) string {
 	// NOTE: This name format is used by the heuristics for zone spreading in ChooseZoneForVolume
-	return fmt.Sprintf("%s-%s-%d", claim.Name, set.Name, ordinal)
+	return fmt.Sprintf("%s-%s-%d", claim.Name, set.GenerateName, ordinal)
 }
 
 // isMemberOf tests if pod is a member of set.
 func isMemberOf(set *appsv1beta1.StatefulSet, pod *v1.Pod) bool {
-	return getParentName(pod) == set.Name
+	return getParentName(pod) == set.GenerateName
 }
 
 // identityMatches returns true if pod has a valid identity and network identity for a member of set.
 func identityMatches(set *appsv1beta1.StatefulSet, pod *v1.Pod) bool {
 	parent, ordinal := getParentNameAndOrdinal(pod)
 	return ordinal >= 0 &&
-		set.Name == parent &&
+		set.GenerateName == parent &&
 		pod.Name == getPodName(set, ordinal) &&
 		pod.Namespace == set.Namespace &&
 		pod.Labels[apps.StatefulSetPodNameLabel] == pod.Name

--- a/pkg/controller/statefulset/stateful_set_utils_test.go
+++ b/pkg/controller/statefulset/stateful_set_utils_test.go
@@ -79,7 +79,7 @@ func (o overlappingStatefulSets) Less(i, j int) bool {
 func TestGetParentNameAndOrdinal(t *testing.T) {
 	set := newStatefulSet(3)
 	pod := newStatefulSetPod(set, 1)
-	if parent, ordinal := getParentNameAndOrdinal(pod); parent != set.Name {
+	if parent, ordinal := getParentNameAndOrdinal(pod); parent != set.GenerateName {
 		t.Errorf("Extracted the wrong parent name expected %s found %s", set.Name, parent)
 	} else if ordinal != 1 {
 		t.Errorf("Extracted the wrong ordinal expected %d found %d", 1, ordinal)
@@ -118,6 +118,7 @@ func TestIsMemberOf(t *testing.T) {
 	set := newStatefulSet(3)
 	set2 := newStatefulSet(3)
 	set2.Name = "foo2"
+	set2.GenerateName = "foo2-gen"
 	pod := newStatefulSetPod(set, 1)
 	if !isMemberOf(set, pod) {
 		t.Error("isMemberOf returned false negative")
@@ -801,7 +802,7 @@ func newPVC(name string) corev1.PersistentVolumeClaim {
 	}
 }
 
-func newStatefulSetWithVolumes(replicas int, name string, petMounts []corev1.VolumeMount, podMounts []corev1.VolumeMount) *appsv1beta1.StatefulSet {
+func newStatefulSetWithVolumes(replicas int, name string, generateName string, petMounts []corev1.VolumeMount, podMounts []corev1.VolumeMount) *appsv1beta1.StatefulSet {
 	mounts := append(petMounts, podMounts...)
 	claims := []corev1.PersistentVolumeClaim{}
 	for _, m := range petMounts {
@@ -841,9 +842,10 @@ func newStatefulSetWithVolumes(replicas int, name string, petMounts []corev1.Vol
 			APIVersion: "apps.kruise.io/v1beta1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: corev1.NamespaceDefault,
-			UID:       "test",
+			Name:         name,
+			GenerateName: generateName,
+			Namespace:    corev1.NamespaceDefault,
+			UID:          "test",
 		},
 		Spec: appsv1beta1.StatefulSetSpec{
 			Selector: &metav1.LabelSelector{
@@ -873,5 +875,5 @@ func newStatefulSet(replicas int) *appsv1beta1.StatefulSet {
 	podMounts := []corev1.VolumeMount{
 		{Name: "home", MountPath: "/home"},
 	}
-	return newStatefulSetWithVolumes(replicas, "foo", petMounts, podMounts)
+	return newStatefulSetWithVolumes(replicas, "foo", "foo-gen", petMounts, podMounts)
 }


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
- Support `generateName` setting for CloneSet and StatefulSet.
- Use `generateName` as prefix of the name of owned pod/pvc, rather using `name` like before. And if user doesn't declare `generateName`, `generateName` will be set the same value of `name` in webhook.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
- This PR closes https://github.com/openkruise/kruise/issues/1627
### Ⅲ. Describe how to verify it
- Manually test locally (kind cluster).
- Modify some UT, set different `name` and `generateName` to verify pod/pvc using `generateName` can work well during doReconcile (like cloneset_controller_test:TestReconcile, stateful_set_utils_test.go:newStatefulSet).

### Ⅳ. Special notes for reviews
- TODO: update doc

