### PR TITLE
SidecarSet add upgrade state in pod annotation (#1312)

### DIFF
--- a/pkg/controller/sidecarset/sidecarset_strategy_test.go
+++ b/pkg/controller/sidecarset/sidecarset_strategy_test.go
@@ -93,7 +93,7 @@ func factoryPodsCommon(count, upgraded int, sidecarSet *appsv1alpha1.SidecarSet)
 	}
 	for i := 0; i < upgraded; i++ {
 		pods[i].Spec.Containers[1].Image = "test-image:v2"
-		sidecarcontrol.UpdatePodSidecarSetHash(pods[i], control.GetSidecarset())
+		sidecarcontrol.UpdatePodSidecarSetHash(pods[i], control.GetSidecarset(), sidecarcontrol.SidecarSetUpgradeStateUpdating)
 		control.UpdatePodAnnotationsInUpgrade([]string{"test-sidecar"}, pods[i])
 	}
 	return pods

--- a/pkg/webhook/pod/mutating/sidecarset.go
+++ b/pkg/webhook/pod/mutating/sidecarset.go
@@ -358,6 +358,7 @@ func buildSidecars(isUpdated bool, pod *corev1.Pod, oldPod *corev1.Pod, matchedS
 			SidecarSetHash:               sidecarcontrol.GetSidecarSetRevision(sidecarSet),
 			SidecarSetName:               sidecarSet.Name,
 			SidecarSetControllerRevision: sidecarSet.Status.LatestRevision,
+			State:                        sidecarcontrol.SidecarSetUpgradeStateNormal,
 		}
 		setUpgrade2 := sidecarcontrol.SidecarSetUpgradeSpec{
 			UpdateTimestamp: metav1.Now(),

--- a/pkg/webhook/pod/mutating/sidecarset_test.go
+++ b/pkg/webhook/pod/mutating/sidecarset_test.go
@@ -1202,12 +1202,14 @@ func TestInjectInitContainer(t *testing.T) {
 					SidecarSetHash:  "sidecarset-1-hash",
 					SidecarSetName:  "sidecarset-1",
 					SidecarList:     []string{"init-1"},
+					State:           sidecarcontrol.SidecarSetUpgradeStateNormal,
 				}
 				sidecarSetHash["sidecarset-2"] = sidecarcontrol.SidecarSetUpgradeSpec{
 					UpdateTimestamp: metav1.Now(),
 					SidecarSetHash:  "sidecarset-2-hash",
 					SidecarSetName:  "sidecarset-2",
 					SidecarList:     []string{"hot-init"},
+					State:           sidecarcontrol.SidecarSetUpgradeStateNormal,
 				}
 				sidecarSetHashWithoutImage["sidecarset-1"] = sidecarcontrol.SidecarSetUpgradeSpec{
 					UpdateTimestamp: metav1.Now(),


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
SidecarSet add upgrade state in pod annotation

### Ⅱ. Does this pull request fix one issue?
fixes #1312 

### Ⅲ. Describe how to verify it
Update SidecarSet in batches, modifies the images, and monitors the state changes of the corresponding SidecarSet in the annotation "kruise.io/sidecarset-hash". It will first change to "Updating" and then change to "Normal".

### Ⅳ. Special notes for reviews

