### PR TITLE
On pod creation, if a new pod matches the SidecarSet update strategy …

### DIFF
--- a/apis/apps/v1alpha1/sidecarset_types.go
+++ b/apis/apps/v1alpha1/sidecarset_types.go
@@ -242,11 +242,17 @@ type SidecarSetUpdateStrategy struct {
 	Type SidecarSetUpdateStrategyType `json:"type,omitempty"`
 
 	// Paused indicates that the SidecarSet is paused to update the injected pods,
-	// but it don't affect the webhook inject sidecar container into the newly created pods.
-	// default is false
+	// For the impact on the injection behavior for newly created Pods, please refer to the comments of Selector.
 	Paused bool `json:"paused,omitempty"`
 
 	// If selector is not nil, this upgrade will only update the selected pods.
+	//
+	// Starting from Kruise 1.8.0, the updateStrategy.Selector affects the version of the Sidecar container
+	// injected into newly created Pods by a SidecarSet configured with an injectionStrategy.
+	// In most cases, all newly created Pods are injected with the specified Sidecar version as configured in injectionStrategy.revision,
+	// which is consistent with previous versions.
+	// Now, if updateStrategy.Selector is  also configured and the updateStrategy.paused field is set to false,
+	// then Pods matching the selector will be injected with the latest version of the Sidecar container.
 	Selector *metav1.LabelSelector `json:"selector,omitempty"`
 
 	// Partition is the desired number of pods in old revisions. It means when partition

--- a/config/crd/bases/apps.kruise.io_sidecarsets.yaml
+++ b/config/crd/bases/apps.kruise.io_sidecarsets.yaml
@@ -414,8 +414,7 @@ spec:
                   paused:
                     description: |-
                       Paused indicates that the SidecarSet is paused to update the injected pods,
-                      but it don't affect the webhook inject sidecar container into the newly created pods.
-                      default is false
+                      For the impact on the injection behavior for newly created Pods, please refer to the comments of Selector.
                     type: boolean
                   priorityStrategy:
                     description: |-
@@ -527,8 +526,16 @@ spec:
                       type: object
                     type: array
                   selector:
-                    description: If selector is not nil, this upgrade will only update
-                      the selected pods.
+                    description: |-
+                      If selector is not nil, this upgrade will only update the selected pods.
+
+
+                      Starting from Kruise 1.8.0, the updateStrategy.Selector affects the version of the Sidecar container
+                      injected into newly created Pods by a SidecarSet configured with an injectionStrategy.
+                      In most cases, all newly created Pods are injected with the specified Sidecar version as configured in injectionStrategy.revision,
+                      which is consistent with previous versions.
+                      Now, if updateStrategy.Selector is  also configured and the updateStrategy.paused field is set to false,
+                      then Pods matching the selector will be injected with the latest version of the Sidecar container.
                     properties:
                       matchExpressions:
                         description: matchExpressions is a list of label selector

--- a/test/e2e/apps/sidecarset.go
+++ b/test/e2e/apps/sidecarset.go
@@ -42,6 +42,7 @@ import (
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/controller/history"
 	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 var _ = SIGDescribe("SidecarSet", func() {
@@ -1575,6 +1576,116 @@ var _ = SIGDescribe("SidecarSet", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(hash[sidecarSetIn.Name].SidecarSetControllerRevision).To(gomega.Equal(list[5].Name))
 			ginkgo.By("sidecarSet InjectionStrategy.Revision check done")
+		})
+
+		framework.ConformanceIt("sidecarSet inject pod sidecar during canary upgrades", func() {
+			// create sidecarSet
+			nginxName := func(tag string) string {
+				return fmt.Sprintf("nginx:%s", tag)
+			}
+			stableTag, canaryTag := "1.20.1", "1.21.1"
+			sidecarSetIn := tester.NewBaseSidecarSet(ns)
+			sidecarSetIn.Labels = map[string]string{
+				appsv1alpha1.SidecarSetCustomVersionLabel: "0",
+			}
+			sidecarSetIn.SetName("e2e-test-for-canary-upgrade")
+			sidecarSetIn.Spec.Containers[0].Image = nginxName(stableTag)
+			sidecarSetIn.Spec.UpdateStrategy.Type = appsv1alpha1.RollingUpdateSidecarSetStrategyType
+			ginkgo.By(fmt.Sprintf("Creating SidecarSet %s", sidecarSetIn.Name))
+			sidecarSetIn, _ = tester.CreateSidecarSet(sidecarSetIn)
+			time.Sleep(time.Second)
+
+			// create deployment
+			deploymentStable, deploymentCanary := tester.NewBaseDeployment(ns), tester.NewBaseDeployment(ns)
+			deploymentStable.Name += "-stable"
+			deploymentStable.Spec.Replicas = ptr.To(int32(1))
+			deploymentStable.Spec.Template.Labels["version"] = "stable"
+			deploymentStable.Spec.Template.Spec.Containers[0].ImagePullPolicy = corev1.PullIfNotPresent
+			deploymentStable.Spec.Template.Spec.TerminationGracePeriodSeconds = ptr.To(int64(0))
+			ginkgo.By(fmt.Sprintf("Creating Deployment(%s.%s)", deploymentStable.Namespace, deploymentStable.Name))
+			deploymentCanary.Name += "-canary"
+			deploymentCanary.Spec.Replicas = ptr.To(int32(1))
+			deploymentCanary.Spec.Template.Labels["version"] = "canary"
+			deploymentCanary.Spec.Template.Spec.Containers[0].ImagePullPolicy = corev1.PullIfNotPresent
+			deploymentCanary.Spec.Template.Spec.TerminationGracePeriodSeconds = ptr.To(int64(0))
+			ginkgo.By(fmt.Sprintf("Creating Deployment(%s.%s)", deploymentCanary.Namespace, deploymentCanary.Name))
+			tester.CreateDeployment(deploymentStable)
+			tester.CreateDeployment(deploymentCanary)
+			tester.WaitForDeploymentRunning(deploymentStable)
+			tester.WaitForDeploymentRunning(deploymentCanary)
+
+			calculateSidecarImages := func(pods []*corev1.Pod) (stableNum, canaryNum int) {
+				for _, pod := range pods {
+					for _, container := range pod.Spec.Containers {
+						if container.Image == nginxName(stableTag) {
+							stableNum++
+						}
+						if container.Image == nginxName(canaryTag) {
+							canaryNum++
+						}
+					}
+				}
+				return
+			}
+			var stableNum, canaryNum int
+
+			// check sidecar original revisions
+			podStable, err := tester.GetSelectorPods(ns, &metav1.LabelSelector{MatchLabels: deploymentStable.Spec.Template.Labels})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(podStable).To(gomega.HaveLen(1))
+			stableNum, canaryNum = calculateSidecarImages(podStable)
+			gomega.Expect(stableNum).To(gomega.Equal(1))
+			gomega.Expect(canaryNum).To(gomega.Equal(0))
+			podCanary, err := tester.GetSelectorPods(ns, &metav1.LabelSelector{MatchLabels: deploymentCanary.Spec.Template.Labels})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(podCanary).To(gomega.HaveLen(1))
+			stableNum, canaryNum = calculateSidecarImages(podCanary)
+			gomega.Expect(stableNum).To(gomega.Equal(1))
+			gomega.Expect(canaryNum).To(gomega.Equal(0))
+			ginkgo.By(fmt.Sprintf("All pods are injected with a stable sidecar"))
+
+			// canary update sidecarSet
+			sidecarSetIn.Spec.Containers[0].Image = nginxName(canaryTag)
+			sidecarSetIn.Spec.Containers[0].Env = []corev1.EnvVar{{Name: "SOME_ENV", Value: "SOME_VAL"}} // make in-place upgrade impossible
+			sidecarSetIn.Spec.UpdateStrategy.Selector = &metav1.LabelSelector{
+				MatchLabels: map[string]string{"version": "canary"},
+			}
+			sidecarSetIn.Spec.InjectionStrategy.Revision = &appsv1alpha1.SidecarSetInjectRevision{CustomVersion: ptr.To("0")}
+			sidecarSetIn.Labels = map[string]string{
+				appsv1alpha1.SidecarSetCustomVersionLabel: "1",
+			}
+			tester.UpdateSidecarSet(sidecarSetIn)
+			expect := &appsv1alpha1.SidecarSetStatus{
+				MatchedPods:      2,
+				UpdatedPods:      0,
+				UpdatedReadyPods: 0,
+				ReadyPods:        2,
+			}
+			tester.WaitForSidecarSetUpgradeComplete(sidecarSetIn, expect)
+			ginkgo.By(fmt.Sprintf("Sidecarset Updated"))
+
+			// scale up deployments
+			deploymentStable.Spec.Replicas = ptr.To(int32(2))
+			deploymentCanary.Spec.Replicas = ptr.To(int32(2))
+			tester.UpdateDeployment(deploymentStable)
+			tester.UpdateDeployment(deploymentCanary)
+			tester.WaitForDeploymentRunning(deploymentStable)
+			tester.WaitForDeploymentRunning(deploymentCanary)
+
+			// check sidecar versions
+			podStable, err = tester.GetSelectorPods(ns, &metav1.LabelSelector{MatchLabels: deploymentStable.Spec.Template.Labels})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(podStable).To(gomega.HaveLen(2))
+			stableNum, canaryNum = calculateSidecarImages(podStable)
+			gomega.Expect(stableNum).To(gomega.Equal(2))
+			gomega.Expect(canaryNum).To(gomega.Equal(0))
+			podCanary, err = tester.GetSelectorPods(ns, &metav1.LabelSelector{MatchLabels: deploymentCanary.Spec.Template.Labels})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(podCanary).To(gomega.HaveLen(2))
+			stableNum, canaryNum = calculateSidecarImages(podCanary)
+			gomega.Expect(stableNum).To(gomega.Equal(1))
+			gomega.Expect(canaryNum).To(gomega.Equal(1))
+			ginkgo.By(fmt.Sprintf("All pods are injected with a suitable sidecar"))
 		})
 	})
 })


### PR DESCRIPTION
…selector, the latest revision rather than that specified in the sidecarset.spec.injectionStrategy will be injected.

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

When a Pod is created, the SidecarSet's Webhook will first determine through the UpdateStrategy whether the Pod is undergoing a Sidecar canary upgrade. If so, it will directly inject the latest Sidecar and skip the logic of selecting a specified revision of the SidecarSet based on the InjectionStrategy.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #1539 

### Ⅲ. Describe how to verify it

1. create the sidecarset
    ```yaml
    # sidecarset.yaml
    apiVersion: apps.kruise.io/v1alpha1
    kind: SidecarSet
    metadata:
      name: test-sidecarset
    spec:
      selector:
        matchLabels:
          app: sleep
      updateStrategy:
        type: RollingUpdate
        maxUnavailable: 1
        selector:
          matchLabels:
            canary: "true"
      containers:
        - name: sidecar
          image: curlimages/curl:8.8.0
          command: ["/bin/sleep", "infinity"]
    ```
2. deploy the demo app
    ```yaml
    apiVersion: apps/v1
    kind: Deployment
    metadata:
      name: sleep-canary
    spec:
      replicas: 1
      selector:
        matchLabels:
          name: sleep-canary
          app: sleep
      template:
        metadata:
          labels:
            app: sleep
            canary: "true"
            name: sleep-canary
        spec:
          terminationGracePeriodSeconds: 0
          containers:
            - name: sleep
              image: curlimages/curl:8.8.0
              command: ["/bin/sleep", "infinity"]
              imagePullPolicy: IfNotPresent
    ---
    apiVersion: apps/v1
    kind: Deployment
    metadata:
      name: sleep
    spec:
      replicas: 1
      selector:
        matchLabels:
          name: sleep
      template:
        metadata:
          labels:
            name: sleep
            app: sleep
        spec:
          terminationGracePeriodSeconds: 0
          containers:
            - name: sleep
              image: curlimages/curl:8.8.0
              command: ["/bin/sleep", "infinity"]
              imagePullPolicy: IfNotPresent
    ```
3. upgrade the sidecarset. because of env is changed, all pods will be skipped, nothing will happen
    ```yaml
    # upgrade.yaml
    apiVersion: apps.kruise.io/v1alpha1
    kind: SidecarSet
    metadata:
      name: test-sidecarset
    spec:
      selector:
        matchLabels:
          app: sleep
      updateStrategy:
        type: RollingUpdate
        maxUnavailable: 1
        selector:
          matchLabels:
            canary: "true"
      containers:
        - name: sidecar
          image: curlimages/curl:8.9.0
          command: ["/bin/sleep", "infinity"]
          env:
            - name: SOME_ENV
              value: "some-value"
      injectionStrategy:
        revision:
          revisionName: test-sidecarset-7dcd95bc8f # may need to be edited based on the actual situation
    ```
4. scale both the stable and canary deployments: replicas 1 -> 2

5. view images of sidecars injected: Only the newly created canary Pod is injected with sidecar version 8.9.0.

### Ⅳ. Special notes for reviews

