### PR TITLE
fix sidecarset hash without image is calculated differently when changing image tag to `latest`

### DIFF
--- a/pkg/control/sidecarcontrol/hash.go
+++ b/pkg/control/sidecarcontrol/hash.go
@@ -37,14 +37,17 @@ func SidecarSetHash(sidecarSet *appsv1alpha1.SidecarSet) (string, error) {
 }
 
 // SidecarSetHashWithoutImage calculates sidecars's container hash without its image
+// also ignore ImagePullPolicy, because if change image tag to `latest`, the ImagePullPolicy will be set to `Always` as default.
 // we use this to determine if the sidecar reconcile needs to update a pod image
 func SidecarSetHashWithoutImage(sidecarSet *appsv1alpha1.SidecarSet) (string, error) {
 	ss := sidecarSet.DeepCopy()
 	for i := range ss.Spec.Containers {
 		ss.Spec.Containers[i].Image = ""
+		ss.Spec.Containers[i].ImagePullPolicy = ""
 	}
 	for i := range ss.Spec.InitContainers {
 		ss.Spec.InitContainers[i].Image = ""
+		ss.Spec.InitContainers[i].ImagePullPolicy = ""
 	}
 	encoded, err := encodeSidecarSet(ss)
 	if err != nil {

--- a/pkg/webhook/sidecarset/mutating/sidecarset_mutating_test.go
+++ b/pkg/webhook/sidecarset/mutating/sidecarset_mutating_test.go
@@ -77,7 +77,7 @@ func TestMutatingSidecarSetFn(t *testing.T) {
 	if sidecarSet.Annotations[sidecarcontrol.SidecarSetHashAnnotation] != "6wbd76bd7984x24fb4f44fv9222cw9v9bcf85x766744wddd4zwx927zzz2zb684" {
 		t.Fatalf("sidecarset %v hash initialized incorrectly, got %v", sidecarSet.Name, sidecarSet.Annotations[sidecarcontrol.SidecarSetHashAnnotation])
 	}
-	if sidecarSet.Annotations[sidecarcontrol.SidecarSetHashWithoutImageAnnotation] != "82684vwf9d4cb4wz4vffx4ddfbb47ww4z4wwxdbwb8w2zbb7zvf4524cdd49bv94" {
+	if sidecarSet.Annotations[sidecarcontrol.SidecarSetHashWithoutImageAnnotation] != "wv7f5xvv7vbwcz9b62f884z4bf62822zd5ff66429475b4527bb7d2z5df5x8479" {
 		t.Fatalf("sidecarset %v hash-without-image initialized incorrectly, got %v", sidecarSet.Name, sidecarSet.Annotations[sidecarcontrol.SidecarSetHashWithoutImageAnnotation])
 	}
 	if sidecarSet.Spec.PatchPodMetadata[0].PatchPolicy != appsv1alpha1.SidecarSetRetainPatchPolicy {


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
https://github.com/openkruise/kruise/blob/5a862a3313c4edbb8e1831fbf1e16c56d3645bdb/apis/apps/defaults/v1alpha1.go#L105-L108

https://github.com/kubernetes/kubernetes/blob/60c4c2b2521fb454ce69dee737e3eb91a25e0535/pkg/apis/core/v1/defaults.go#L73-L78

when change image tag to `latest`, the sidecarset without image hash will be changed
I think `ImagePullPolicy` should not be involved in the hash, because it will cause the hash to change, causing the pod not to to be upgraded


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it
```
apiVersion: apps.kruise.io/v1alpha1
kind: SidecarSet
metadata:
  name: sidecarset
spec:
  selector:
    matchLabels:
      app: sample
  containers:
  - name: nginx
    image: nginx:1.19.6
  updateStrategy:
    type: RollingUpdate
```
change 1.19.6 to latest
This is the change I printed that participates in the hash calculation
IfNotPresent -> Always
```
{
    "containers": [
        {
            "name": "nginx",
            "resources": {},
            "terminationMessagePath": "/dev/termination-log",
            "terminationMessagePolicy": "File",
            "imagePullPolicy": "IfNotPresent",
            "podInjectPolicy": "BeforeAppContainer",
            "upgradeStrategy": {
                "upgradeType": "ColdUpgrade"
            },
            "shareVolumePolicy": {
                "type": "disabled"
            }
        }
    ]
}

{
    "containers": [
        {
            "name": "nginx",
            "resources": {},
            "terminationMessagePath": "/dev/termination-log",
            "terminationMessagePolicy": "File",
            "imagePullPolicy": "Always",
            "podInjectPolicy": "BeforeAppContainer",
            "upgradeStrategy": {
                "upgradeType": "ColdUpgrade"
            },
            "shareVolumePolicy": {
                "type": "disabled"
            }
        }
    ]
}
```


### Ⅳ. Special notes for reviews

