### PR TITLE
feat: SidecarSet support in-place initContainer when k8s greater than 1.28

### DIFF
--- a/pkg/control/pubcontrol/pub_control.go
+++ b/pkg/control/pubcontrol/pub_control.go
@@ -181,6 +181,12 @@ func getSidecarSetsInPod(pod *corev1.Pod) (sidecarSets, containers sets.String) 
 			sidecarSets.Insert(sidecarSetName)
 		}
 	}
+	for _, container := range pod.Spec.InitContainers {
+		val := util.GetContainerEnvValue(&container, sidecarcontrol.SidecarEnvKey)
+		if val == "true" {
+			containers.Insert(container.Name)
+		}
+	}
 	for _, container := range pod.Spec.Containers {
 		val := util.GetContainerEnvValue(&container, sidecarcontrol.SidecarEnvKey)
 		if val == "true" {

--- a/pkg/control/sidecarcontrol/api.go
+++ b/pkg/control/sidecarcontrol/api.go
@@ -66,8 +66,14 @@ type SidecarControl interface {
 	// consistent indicates pod.spec and pod.status is consistent,
 	// when pod.spec.image is v2 and pod.status.image is v1, then it is inconsistent.
 	IsSidecarSetUpgradable(pod *v1.Pod) (canUpgrade, consistent bool)
+	// IsSupportInitContainerInPlace indicates whether the sidecarSet supports in-place upgrade of initContainer
+	IsSupportInitContainerInPlace() bool
 }
 
-func New(cs *appsv1alpha1.SidecarSet) SidecarControl {
-	return &commonControl{SidecarSet: cs}
+func New(cs *appsv1alpha1.SidecarSet, opts ...Option) SidecarControl {
+	control := &commonControl{SidecarSet: cs}
+	for _, opt := range opts {
+		opt(control)
+	}
+	return control
 }

--- a/pkg/controller/sidecarset/sidecarset_pod_event_handler.go
+++ b/pkg/controller/sidecarset/sidecarset_pod_event_handler.go
@@ -8,6 +8,8 @@ import (
 
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
 	"github.com/openkruise/kruise/pkg/control/sidecarcontrol"
+	"github.com/openkruise/kruise/pkg/util"
+	"github.com/openkruise/kruise/pkg/util/discovery"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -184,7 +186,8 @@ func isPodStatusChanged(oldPod, newPod *corev1.Pod) bool {
 }
 
 func isPodConsistentChanged(oldPod, newPod *corev1.Pod, sidecarSet *appsv1alpha1.SidecarSet) (bool, time.Duration) {
-	control := sidecarcontrol.New(sidecarSet)
+	control := sidecarcontrol.New(sidecarSet,
+		sidecarcontrol.WithSupportInitContainerInPlace(util.IsSupportInitContainerInPlace(discovery.DiscoverServerVersion())))
 	var enqueueDelayTime time.Duration
 	// contain sidecar empty container
 	oldConsistent := control.IsPodStateConsistent(oldPod, nil)

--- a/pkg/util/discovery/discovery.go
+++ b/pkg/util/discovery/discovery.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/version"
 
 	"github.com/openkruise/kruise/apis"
 	"github.com/openkruise/kruise/pkg/client"
@@ -89,4 +90,17 @@ func DiscoverObject(obj runtime.Object) bool {
 		return false
 	}
 	return DiscoverGVK(gvk)
+}
+
+func DiscoverServerVersion() (version version.Info) {
+	genericClient := client.GetGenericClient()
+	if genericClient == nil {
+		return
+	}
+	serverVersion, err := genericClient.DiscoveryClient.ServerVersion()
+	if err != nil {
+		klog.ErrorS(err, "Failed to get server version")
+		return
+	}
+	return *serverVersion
 }

--- a/pkg/util/tools.go
+++ b/pkg/util/tools.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/coreos/go-semver/semver"
 	"github.com/docker/distribution/reference"
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -31,6 +32,7 @@ import (
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	intstrutil "k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/integer"
 )
@@ -234,4 +236,14 @@ func EqualIgnoreHash(template1, template2 *corev1.PodTemplateSpec) bool {
 	delete(t1Copy.Labels, appsv1.DefaultDeploymentUniqueLabelKey)
 	delete(t2Copy.Labels, appsv1.DefaultDeploymentUniqueLabelKey)
 	return apiequality.Semantic.DeepEqual(t1Copy, t2Copy)
+}
+
+// IsSupportInitContainerInPlace checks if the version supports init container in place, only available from 1.28
+func IsSupportInitContainerInPlace(ver version.Info) bool {
+	major := ver.Major
+	minor := ver.Minor
+	if major == "" || minor == "" {
+		return false
+	}
+	return semver.New(fmt.Sprintf("%s.%s.0", ver.Major, ver.Minor)).Compare(*semver.New("1.28.0")) >= 0
 }

--- a/pkg/util/tools_test.go
+++ b/pkg/util/tools_test.go
@@ -19,6 +19,7 @@ package util
 
 import (
 	"fmt"
+	"k8s.io/apimachinery/pkg/version"
 	"sync"
 	"testing"
 
@@ -408,5 +409,47 @@ func TestGetScaledValueFromIntOrPercent(t *testing.T) {
 		if test.expectVal != value {
 			t.Errorf("expected %v, but got %v", test.expectVal, value)
 		}
+	}
+}
+
+func TestIsSupportInitContainerInPlace(t *testing.T) {
+	tests := []struct {
+		name     string
+		version  version.Info
+		expected bool
+	}{
+		{
+			name:     "v1.18.0",
+			version:  version.Info{Major: "1", Minor: "18"},
+			expected: false,
+		},
+		{
+			name:     "v1.26",
+			version:  version.Info{Major: "1", Minor: "26"},
+			expected: false,
+		},
+		{
+			name:     "v1.27.4",
+			version:  version.Info{Major: "1", Minor: "27"},
+			expected: false,
+		},
+		{
+			name:     "v1.28",
+			version:  version.Info{Major: "1", Minor: "28"},
+			expected: true,
+		},
+		{
+			name:     "v1.29",
+			version:  version.Info{Major: "1", Minor: "29"},
+			expected: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if IsSupportInitContainerInPlace(test.version) != test.expected {
+				t.Errorf("expected %v, but got %v", test.expected, !test.expected)
+			}
+		})
 	}
 }

--- a/pkg/webhook/sidecarset/validating/webhooks.go
+++ b/pkg/webhook/sidecarset/validating/webhooks.go
@@ -20,6 +20,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
+	"github.com/openkruise/kruise/pkg/util"
+	utildiscovery "github.com/openkruise/kruise/pkg/util/discovery"
 	"github.com/openkruise/kruise/pkg/webhook/types"
 )
 
@@ -29,9 +31,12 @@ var (
 	// HandlerGetterMap contains admission webhook handlers
 	HandlerGetterMap = map[string]types.HandlerGetter{
 		"validate-apps-kruise-io-v1alpha1-sidecarset": func(mgr manager.Manager) admission.Handler {
+			curVersion := utildiscovery.DiscoverServerVersion()
 			return &SidecarSetCreateUpdateHandler{
-				Client:  mgr.GetClient(),
-				Decoder: admission.NewDecoder(mgr.GetScheme()),
+				curVersion:                  curVersion.String(),
+				supportInitContainerInPlace: util.IsSupportInitContainerInPlace(curVersion),
+				Client:                      mgr.GetClient(),
+				Decoder:                     admission.NewDecoder(mgr.GetScheme()),
 			}
 		},
 	}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
#1671

SidecarSet support in-place initContainer when k8s greater than 1.28

automatically determines whether the current k8s cluster version is greater than 1.28. If so, it adds initContainer to the in-place


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

