### PR TITLE
A feature-gate to limit CloneSet pod name within 63 chars or less

### DIFF
--- a/pkg/controller/cloneset/core/cloneset_core_test.go
+++ b/pkg/controller/cloneset/core/cloneset_core_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
+	"github.com/openkruise/kruise/pkg/features"
+	utilfeature "github.com/openkruise/kruise/pkg/util/feature"
 	"github.com/openkruise/kruise/pkg/util/inplaceupdate"
 )
 
@@ -68,6 +70,51 @@ func Test_CommonControl_GetUpdateOptions(t *testing.T) {
 			}
 			if got := c.GetUpdateOptions(); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("GetUpdateOptions() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGeneratePodName(t *testing.T) {
+	tests := []struct {
+		name      string
+		prefix    string
+		id        string
+		shortName string
+		longName  string
+	}{
+		{
+			name:      "short prefix case",
+			prefix:    "short-prefix",
+			id:        "abcdefg",
+			shortName: "short-prefix-abcdefg",
+			longName:  "short-prefix-abcdefg",
+		},
+		{
+			name:      "long prefix case",
+			prefix:    "looooooooooooooooooooooooooooooooooooooooooooooooooooooooong-prefix",
+			id:        "abcdefg",
+			shortName: "loooooooooooooooooooooooooooooooooooooooooooooooooooooooabcdefg",
+			longName:  "looooooooooooooooooooooooooooooooooooooooooooooooooooooooong-prefix-abcdefg",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			defer utilfeature.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.CloneSetShortPodName, true)()
+			generatedName := generatePodName(test.prefix, test.id)
+			if generatedName != test.shortName || len(generatedName) > 63 {
+				t.Fatalf("expect %s, but got %s", test.shortName, generatedName)
+			}
+		})
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			defer utilfeature.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.CloneSetShortPodName, false)()
+			generatedName := generatePodName(test.prefix, test.id)
+			if generatedName != test.longName {
+				t.Fatalf("expect %s, but got %s", test.longName, generatedName)
 			}
 		})
 	}

--- a/pkg/features/kruise_features.go
+++ b/pkg/features/kruise_features.go
@@ -131,6 +131,9 @@ const (
 
 	// Enables policies auto resizing PVCs created by a StatefulSet when user expands volumeClaimTemplates.
 	StatefulSetAutoResizePVCGate featuregate.Feature = "StatefulSetAutoResizePVCGate"
+
+	// CloneSetShortPodName enable CloneSet create Pods with 63 name length or less.
+	CloneSetShortPodName featuregate.Feature = "CloneSetShortPodName"
 )
 
 var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
@@ -166,6 +169,7 @@ var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	PodIndexLabel:                          {Default: true, PreRelease: featuregate.Beta},
 	EnableExternalCerts:                    {Default: false, PreRelease: featuregate.Alpha},
 	StatefulSetAutoResizePVCGate:           {Default: false, PreRelease: featuregate.Alpha},
+	CloneSetShortPodName:                   {Default: false, PreRelease: featuregate.Alpha},
 }
 
 func init() {


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
follow the name generation of `Deployment` https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/storage/names/generate.go#L53.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
#1736 

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

