### PR TITLE
fix: support more fieldpath

### DIFF
--- a/pkg/control/sidecarcontrol/util_test.go
+++ b/pkg/control/sidecarcontrol/util_test.go
@@ -470,36 +470,60 @@ func TestConvertDownwardAPIFieldLabel(t *testing.T) {
 			expectedErr: true,
 		},
 		{
-			version:     "v1",
-			label:       "metadata.name",
-			value:       "test-pod",
-			expectedErr: true,
-		},
-		{
-			version:     "v1",
-			label:       "metadata.annotations",
-			value:       "myAnnoValue",
-			expectedErr: true,
-		},
-		{
-			version:     "v1",
-			label:       "metadata.labels",
-			value:       "myLabelValue",
-			expectedErr: true,
+			version:       "v1",
+			label:         "metadata.name",
+			value:         "test-pod",
+			expectedLabel: "metadata.name",
+			expectedValue: "test-pod",
 		},
 		{
 			version:       "v1",
-			label:         "metadata.annotations['myAnnoKey']",
-			value:         "myAnnoValue",
-			expectedLabel: "metadata.annotations['myAnnoKey']",
-			expectedValue: "myAnnoValue",
+			label:         "metadata.annotations",
+			value:         "myValue",
+			expectedLabel: "metadata.annotations",
+			expectedValue: "myValue",
 		},
 		{
 			version:       "v1",
-			label:         "metadata.labels['myLabelKey']",
-			value:         "myLabelValue",
-			expectedLabel: "metadata.labels['myLabelKey']",
-			expectedValue: "myLabelValue",
+			label:         "metadata.annotations['myKey']",
+			value:         "myValue",
+			expectedLabel: "metadata.annotations['myKey']",
+			expectedValue: "myValue",
+		},
+		{
+			version:       "v1",
+			label:         "spec.host",
+			value:         "127.0.0.1",
+			expectedLabel: "spec.nodeName",
+			expectedValue: "127.0.0.1",
+		},
+		{
+			version:       "v1",
+			label:         "status.podIPs",
+			value:         "10.244.0.6,fd00::6",
+			expectedLabel: "status.podIPs",
+			expectedValue: "10.244.0.6,fd00::6",
+		},
+		{
+			version:       "v1",
+			label:         "status.podIPs",
+			value:         "10.244.0.6",
+			expectedLabel: "status.podIPs",
+			expectedValue: "10.244.0.6",
+		},
+		{
+			version:       "v1",
+			label:         "status.hostIPs",
+			value:         "10.244.0.6,fd00::6",
+			expectedLabel: "status.hostIPs",
+			expectedValue: "10.244.0.6,fd00::6",
+		},
+		{
+			version:       "v1",
+			label:         "status.hostIPs",
+			value:         "10.244.0.6",
+			expectedLabel: "status.hostIPs",
+			expectedValue: "10.244.0.6",
 		},
 	}
 	for _, tc := range testCases {
@@ -560,6 +584,33 @@ func TestExtractContainerNameFromFieldPath(t *testing.T) {
 				},
 			}},
 			expectedName: "test-pod-anno",
+		},
+		{
+			fieldSelector: &corev1.ObjectFieldSelector{
+				APIVersion: "v1",
+				FieldPath:  "metadata.name",
+			},
+			pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+				Name: "test-pod-anno",
+				Annotations: map[string]string{
+					"test-anno": "test-pod-anno",
+				},
+			}},
+			expectedName: "test-pod-anno",
+		},
+		{
+			fieldSelector: &corev1.ObjectFieldSelector{
+				APIVersion: "v1",
+				FieldPath:  "metadata.namespace",
+			},
+			pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-pod-anno",
+				Namespace: "test-namespace",
+				Annotations: map[string]string{
+					"test-anno": "test-pod-anno",
+				},
+			}},
+			expectedName: "test-namespace",
 		},
 	}
 	for _, tc := range testCases {

--- a/pkg/webhook/sidecarset/validating/sidecarset_create_update_handler.go
+++ b/pkg/webhook/sidecarset/validating/sidecarset_create_update_handler.go
@@ -52,6 +52,7 @@ const (
 
 var validDownwardAPIFieldPathExpressions = sets.NewString(
 	"metadata.name",
+	"metadata.namespace",
 	"metadata.labels",
 	"metadata.annotations")
 


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
simply use kube code instead of copying it to support more field path in "transferEnv" of sidecarset

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes: #1735
### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

