### PR TITLE
support pub pub.kruise.io/disable-fetch-replicas-from-workload=true

### DIFF
--- a/apis/policy/v1alpha1/podunavailablebudget_types.go
+++ b/apis/policy/v1alpha1/podunavailablebudget_types.go
@@ -35,9 +35,11 @@ const (
 	PubUpdateOperation PubOperation = "UPDATE"
 	PubDeleteOperation PubOperation = "DELETE"
 	PubEvictOperation  PubOperation = "EVICT"
-	// PubProtectTotalReplicas indicates the pub protected total replicas, rather than workload.spec.replicas.
-	// and must be used with pub.spec.selector.
-	PubProtectTotalReplicas = "pub.kruise.io/protect-total-replicas"
+	// PubProtectTotalReplicasAnnotation is the target replicas.
+	// By default, PUB will get the target replicas through workload.spec.replicas. but there are some scenarios that may workload doesn't
+	// implement scale subresources or Pod doesn't have workload management. In this scenario, you can set pub.kruise.io/protect-total-replicas
+	// in pub annotations to get the target replicas to realize the same effect of protection ability.
+	PubProtectTotalReplicasAnnotation = "pub.kruise.io/protect-total-replicas"
 	// Marked the pod will not be pub-protected, solving the scenario of force pod deletion
 	PodPubNoProtectionAnnotation = "pub.kruise.io/no-protect"
 )

--- a/pkg/webhook/podunavailablebudget/validating/pub_create_update_handler.go
+++ b/pkg/webhook/podunavailablebudget/validating/pub_create_update_handler.go
@@ -94,9 +94,9 @@ func (h *PodUnavailableBudgetCreateUpdateHandler) validatingPodUnavailableBudget
 			}
 		}
 	}
-	if replicasValue, ok := obj.Annotations[policyv1alpha1.PubProtectTotalReplicas]; ok {
+	if replicasValue, ok := obj.Annotations[policyv1alpha1.PubProtectTotalReplicasAnnotation]; ok {
 		if _, err := strconv.ParseInt(replicasValue, 10, 32); err != nil {
-			allErrs = append(allErrs, field.InternalError(field.NewPath("metadata"), fmt.Errorf("annotation[%s] is invalid", policyv1alpha1.PubProtectTotalReplicas)))
+			allErrs = append(allErrs, field.InternalError(field.NewPath("metadata"), fmt.Errorf("annotation[%s] is invalid", policyv1alpha1.PubProtectTotalReplicasAnnotation)))
 		}
 	}
 

--- a/pkg/webhook/podunavailablebudget/validating/pub_validating_test.go
+++ b/pkg/webhook/podunavailablebudget/validating/pub_validating_test.go
@@ -20,13 +20,11 @@ import (
 	"context"
 	"testing"
 
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-
 	policyv1alpha1 "github.com/openkruise/kruise/apis/policy/v1alpha1"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
@@ -166,7 +164,7 @@ func TestValidatingPub(t *testing.T) {
 				pub := pubDemo.DeepCopy()
 				pub.Spec.Selector = nil
 				pub.Spec.MinAvailable = nil
-				pub.Annotations[policyv1alpha1.PubProtectTotalReplicas] = "%%"
+				pub.Annotations[policyv1alpha1.PubProtectTotalReplicasAnnotation] = "%%"
 				return pub
 			},
 			expectErrList: 1,
@@ -177,7 +175,7 @@ func TestValidatingPub(t *testing.T) {
 				pub := pubDemo.DeepCopy()
 				pub.Spec.Selector = nil
 				pub.Spec.MinAvailable = nil
-				pub.Annotations[policyv1alpha1.PubProtectTotalReplicas] = "1000"
+				pub.Annotations[policyv1alpha1.PubProtectTotalReplicasAnnotation] = "1000"
 				return pub
 			},
 			expectErrList: 0,


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
The custom workload implements the scale subresource, but the replicas value in the scale subresource is inaccurate, so they want to use the _pub.kruise.io/protect-total-replicas_.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

