### PR TITLE
Feature/CloneSet supports hot-standy pods management

### DIFF
--- a/apis/apps/v1alpha1/cloneset_types.go
+++ b/apis/apps/v1alpha1/cloneset_types.go
@@ -44,6 +44,12 @@ type CloneSetSpec struct {
 	// If unspecified, defaults to 1.
 	Replicas *int32 `json:"replicas,omitempty"`
 
+	// HotStandbyReplicas is the desired number of hot-standby replicas of the given Template.
+	// These are replicas in the sense that they are instantiations of the
+	// same Template.
+	// If unspecified, defaults to 0.
+	HotStandbyReplicas *int32 `json:"hotStandbyReplicas,omitempty"`
+
 	// Selector is a label query over pods that should match the replica count.
 	// It must match the pod template's labels.
 	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
@@ -184,6 +190,27 @@ type CloneSetStatus struct {
 	// This field is calculated via Replicas - Partition.
 	ExpectedUpdatedReplicas int32 `json:"expectedUpdatedReplicas,omitempty"`
 
+	// HotStandbyReplicas is the number of hot-standby Pods created by the CloneSet controller.
+	HotStandbyReplicas int32 `json:"hotStandbyReplicas,omitempty"`
+
+	// HotStandbyReadyReplicas is the number of hot-standby Pods created by the CloneSet controller that have a Ready Condition.
+	HotStandbyReadyReplicas int32 `json:"hotStandbyReadyReplicas,omitempty"`
+
+	// HotStandbyAvailableReplicas is the number of hot-standby Pods created by the CloneSet controller that have a Ready Condition for at least minReadySeconds.
+	HotStandbyAvailableReplicas int32 `json:"hotStandbyAvailableReplicas,omitempty"`
+
+	// HotStandbyUpdatedReplicas is the number of hot-standby Pods created by the CloneSet controller from the CloneSet version
+	// indicated by updateRevision.
+	HotStandbyUpdatedReplicas int32 `json:"hotStandbyUpdatedReplicas,omitempty"`
+
+	// HotStandbyUpdatedReadyReplicas is the number of hot-standby Pods created by the CloneSet controller from the CloneSet version
+	// indicated by updateRevision and have a Ready Condition.
+	HotStandbyUpdatedReadyReplicas int32 `json:"hotStandbyUpdatedReadyReplicas,omitempty"`
+
+	// HotStandbyExpectedUpdatedReplicas is the number of hot-standby Pods that should be updated by CloneSet controller.
+	// This field is calculated via Replicas - Partition.
+	HotStandbyExpectedUpdatedReplicas int32 `json:"hotStandbyExpectedUpdatedReplicas,omitempty"`
+
 	// UpdateRevision, if not empty, indicates the latest revision of the CloneSet.
 	UpdateRevision string `json:"updateRevision,omitempty"`
 
@@ -210,6 +237,10 @@ const (
 	CloneSetConditionFailedScale CloneSetConditionType = "FailedScale"
 	// CloneSetConditionFailedUpdate indicates cloneset controller failed to update pods.
 	CloneSetConditionFailedUpdate CloneSetConditionType = "FailedUpdate"
+	// CloneSetConditionHotStandbyFailedScale indicates cloneset controller failed to create or delete hot-standby pods/pvc.
+	CloneSetConditionHotStandbyFailedScale CloneSetConditionType = "HotStandbyFailedScale"
+	// CloneSetConditionHotStandbyFailedUpdate indicates cloneset controller failed to update hot-standby pods.
+	CloneSetConditionHotStandbyFailedUpdate CloneSetConditionType = "HotStandbyFailedUpdate"
 )
 
 // CloneSetCondition describes the state of a CloneSet at a certain point.

--- a/apis/apps/v1alpha1/cloneset_types.go
+++ b/apis/apps/v1alpha1/cloneset_types.go
@@ -207,6 +207,10 @@ type CloneSetStatus struct {
 	// indicated by updateRevision and have a Ready Condition.
 	HotStandbyUpdatedReadyReplicas int32 `json:"hotStandbyUpdatedReadyReplicas,omitempty"`
 
+	// HotStandbyUpdatedAvailableReplicas is the number of hot-standby Pods created by the CloneSet controller from the CloneSet version
+	// indicated by updateRevision and have a Ready Condition for at least minReadySeconds.
+	HotStandbyUpdatedAvailableReplicas int32 `json:"hotStandbyUpdatedAvailableReplicas,omitempty"`
+
 	// HotStandbyExpectedUpdatedReplicas is the number of hot-standby Pods that should be updated by CloneSet controller.
 	// This field is calculated via Replicas - Partition.
 	HotStandbyExpectedUpdatedReplicas int32 `json:"hotStandbyExpectedUpdatedReplicas,omitempty"`

--- a/apis/apps/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/apps/v1alpha1/zz_generated.deepcopy.go
@@ -428,6 +428,11 @@ func (in *CloneSetSpec) DeepCopyInto(out *CloneSetSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.HotStandbyReplicas != nil {
+		in, out := &in.HotStandbyReplicas, &out.HotStandbyReplicas
+		*out = new(int32)
+		**out = **in
+	}
 	if in.Selector != nil {
 		in, out := &in.Selector, &out.Selector
 		*out = new(metav1.LabelSelector)

--- a/config/crd/bases/apps.kruise.io_clonesets.yaml
+++ b/config/crd/bases/apps.kruise.io_clonesets.yaml
@@ -560,6 +560,12 @@ spec:
                   indicated by updateRevision and have a Ready Condition.
                 format: int32
                 type: integer
+              HotStandbyUpdatedAvailableReplicas:
+                description: |-
+                  HotStandbyUpdatedAvailableReplicas is the number of hot-standby Pods created by the CloneSet controller from the CloneSet version
+                  indicated by updateRevision and have a Ready Condition for at least minReadySeconds.
+                format: int32
+                type: integer
               hotStandbyExpectedUpdatedReplicas:
                 description: |-
                   HotStandbyUpdatedReplicas is the number of hot-standby Pods created by the CloneSet controller from the CloneSet version 

--- a/config/crd/bases/apps.kruise.io_clonesets.yaml
+++ b/config/crd/bases/apps.kruise.io_clonesets.yaml
@@ -166,6 +166,14 @@ spec:
                   If unspecified, defaults to 1.
                 format: int32
                 type: integer
+              hotStandbyReplicas:
+                description: |-
+                  Replicas is the desired number of hot-standby replicas of the given Template.
+                  These are replicas in the sense that they are instantiations of the
+                  same Template.
+                  If unspecified, defaults to 0.
+                format: int32
+                type: integer
               revisionHistoryLimit:
                 description: |-
                   RevisionHistoryLimit is the maximum number of revisions that will
@@ -523,6 +531,38 @@ spec:
               updatedReplicas:
                 description: |-
                   UpdatedReplicas is the number of Pods created by the CloneSet controller from the CloneSet version
+                  indicated by updateRevision.
+                format: int32
+                type: integer
+              hotStandbyReplicas:
+                description: HotStandbyReplicas is the number of hot-standby Pods created by the CloneSet controller.
+                format: int32
+                type: integer
+              hotStandbyReadyReplicas:
+                description: HotStandbyReadyReplicas is the number of hot-standby Pods created by the
+                  CloneSet controller that have a Ready Condition.
+                format: int32
+                type: integer
+              hotStandbyAvailableReplicas:
+                description: HotStandbyAvailableReplicas is the number of hot-standby Pods created by the
+                  CloneSet controller that have a Ready Condition for at least minReadySeconds.
+                format: int32
+                type: integer
+              hotStandbyUpdatedReplicas:
+                description: |-
+                  HotStandbyUpdatedReplicas is the number of hot-standby Pods created by the CloneSet controller from the CloneSet version
+                  indicated by updateRevision.
+                format: int32
+                type: integer
+              hotStandbyUpdatedReadyReplicas:
+                description: |-
+                  HotStandbyUpdatedReadyReplicas is the number of hot-standby Pods created by the CloneSet controller from the CloneSet version
+                  indicated by updateRevision and have a Ready Condition.
+                format: int32
+                type: integer
+              hotStandbyExpectedUpdatedReplicas:
+                description: |-
+                  HotStandbyUpdatedReplicas is the number of hot-standby Pods created by the CloneSet controller from the CloneSet version 
                   indicated by updateRevision.
                 format: int32
                 type: integer

--- a/pkg/util/hotstandby/hot_standby_utils.go
+++ b/pkg/util/hotstandby/hot_standby_utils.go
@@ -1,0 +1,68 @@
+package hotstandby
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"strconv"
+)
+
+const (
+	// PodHotStandbyEnableKey Pod label key that shows whether hot-standby is enabled
+	PodHotStandbyEnableKey = "hotstandby.apps.kruise.io/hot-standby"
+
+	// PodHotStandbyRecoveryKey Pod label key that shows hot-standby pod is recovered to normal
+	PodHotStandbyRecoveryKey = "hotstandby.apps.kruise.io/plan-to-recover"
+
+	True = "true"
+
+	False = "false"
+)
+
+// IsHotStandbyPod returns if Pod has hot-standby label
+func IsHotStandbyPod(pod *v1.Pod) bool {
+	if len(pod.Labels) <= 0 {
+		return false
+	}
+
+	if value, _ := strconv.ParseBool(pod.Labels[PodHotStandbyEnableKey]); value {
+		return true
+	}
+
+	return false
+}
+
+func PutHotStandbyPodLabel(pod *v1.Pod) {
+	pod.Labels[PodHotStandbyEnableKey] = True
+}
+
+func PutNormalPodLabel(pod *v1.Pod) {
+	pod.Labels[PodHotStandbyEnableKey] = False
+}
+
+// FilterOutNormalPods returns Pods matched and unmatched the hot-standby label
+func FilterOutNormalPods(pods []*v1.Pod) (normal []*v1.Pod) {
+	for _, p := range pods {
+		if !IsHotStandbyPod(p) {
+			normal = append(normal, p)
+		}
+	}
+	return
+}
+
+// FilterOutHotStandbyPods returns Pods matched and unmatched the hot-standby label
+func FilterOutHotStandbyPods(pods []*v1.Pod) (hotStandby []*v1.Pod) {
+	for _, p := range pods {
+		if IsHotStandbyPod(p) {
+			hotStandby = append(hotStandby, p)
+		}
+	}
+	return
+}
+
+// GetHotStandbyPodIndexes returns hot-standby Pod indexes by update num
+func GetHotStandbyPodIndexes(updateNum int, waitUpdateIndexes []int) []int {
+	if updateNum < len(waitUpdateIndexes) {
+		waitUpdateIndexes = waitUpdateIndexes[:updateNum]
+	}
+
+	return waitUpdateIndexes
+}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
add feature that CloneSet supports hot-standby pods management

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

fixes #1762 

### Ⅲ. Describe how to verify it
1. ClonetSet CRD supports defining the desired hot-standby replicas in Spec and related replicas statistic in Status
2. CloneSet supports hot-standby management, such as:
    a.  creating hot-standby pods while creating workload with the desired hot-standby replicas greater than 0.
    b.  creating hot-standby pods while the desired hot-standby replicas increasing.
    c.  inplace updating or recreating hot-standby pods while pod template changing.
    d.  deleting hot-standby pods while hot-standby replicas decreasing
    e.  deleting hot-standby pods while workload deleting.
     f.  recovering hot-standby pods to normal firstly while scaling out and then creating hot-standby pods until its num equal to the desired hot-standby replicas.

### Ⅳ. Special notes for reviews

