### PR TITLE
fix: namespaced kruise-controller panic due to `multiNamespaceCache`

### DIFF
--- a/main.go
+++ b/main.go
@@ -247,17 +247,23 @@ func main() {
 			setupLog.Error(err, "unable to wait webhook ready")
 			os.Exit(1)
 		}
-
-		setupLog.Info("setup controllers")
-		if err = controller.SetupWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to setup controllers")
-			os.Exit(1)
-		}
 	}()
+
+	setupLog.Info("setup controllers")
+	if err = controller.SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to setup controllers")
+		os.Exit(1)
+	}
 
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctx); err != nil {
 		setupLog.Error(err, "problem running manager")
+		os.Exit(1)
+	}
+
+	setupLog.Info("setup controllers that need manager started")
+	if err = controller.SetupAfterStart(mgr); err != nil {
+		setupLog.Error(err, "unable to setup controllers after manager start")
 		os.Exit(1)
 	}
 }

--- a/pkg/controller/daemonset/daemonset_controller.go
+++ b/pkg/controller/daemonset/daemonset_controller.go
@@ -40,7 +40,6 @@ import (
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
 	appslisters "k8s.io/client-go/listers/apps/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/client-go/util/retry"
@@ -66,6 +65,7 @@ import (
 	kruiseclientset "github.com/openkruise/kruise/pkg/client/clientset/versioned"
 	"github.com/openkruise/kruise/pkg/client/clientset/versioned/scheme"
 	kruiseappslisters "github.com/openkruise/kruise/pkg/client/listers/apps/v1alpha1"
+	controllerutil "github.com/openkruise/kruise/pkg/controller/util"
 	"github.com/openkruise/kruise/pkg/features"
 	kruiseutil "github.com/openkruise/kruise/pkg/util"
 	utilclient "github.com/openkruise/kruise/pkg/util/client"
@@ -172,10 +172,10 @@ func newReconciler(mgr manager.Manager) (reconcile.Reconciler, error) {
 		return nil, err
 	}
 
-	dsLister := kruiseappslisters.NewDaemonSetLister(dsInformer.(cache.SharedIndexInformer).GetIndexer())
-	historyLister := appslisters.NewControllerRevisionLister(revInformer.(cache.SharedIndexInformer).GetIndexer())
-	podLister := corelisters.NewPodLister(podInformer.(cache.SharedIndexInformer).GetIndexer())
-	nodeLister := corelisters.NewNodeLister(nodeInformer.(cache.SharedIndexInformer).GetIndexer())
+	dsLister := kruiseappslisters.NewDaemonSetLister(controllerutil.GetCacheIndexer(dsInformer))
+	historyLister := appslisters.NewControllerRevisionLister(controllerutil.GetCacheIndexer(revInformer))
+	podLister := corelisters.NewPodLister(controllerutil.GetCacheIndexer(podInformer))
+	nodeLister := corelisters.NewNodeLister(controllerutil.GetCacheIndexer(nodeInformer))
 	failedPodsBackoff := flowcontrol.NewBackOff(1*time.Second, 15*time.Minute)
 	revisionAdapter := revisionadapter.NewDefaultImpl()
 

--- a/pkg/controller/util/cache.go
+++ b/pkg/controller/util/cache.go
@@ -1,0 +1,20 @@
+package util
+
+import (
+	"k8s.io/client-go/tools/cache"
+	toolscache "sigs.k8s.io/controller-runtime/pkg/cache"
+)
+
+// GetCacheIndexer helps to get the cache indexer from the informer
+func GetCacheIndexer(informer toolscache.Informer) cache.Indexer {
+	shardIndexInformer, ok := informer.(cache.SharedIndexInformer)
+	if ok {
+		return shardIndexInformer.GetIndexer()
+	}
+	indexers := cache.Indexers{}
+	err := informer.(toolscache.Informer).AddIndexers(indexers)
+	if err != nil {
+		panic(err)
+	}
+	return cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, indexers)
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
if set namespace, mgr will use `multiNamespaceCache`, it use `informer` not `shardIndexInformer`


### Ⅱ. Does this pull request fix one issue?
fix #1764

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

