### PR TITLE
sync all fields in ud spec to subset workload spec

### DIFF
--- a/pkg/controller/uniteddeployment/adapter/adapter.go
+++ b/pkg/controller/uniteddeployment/adapter/adapter.go
@@ -46,9 +46,6 @@ type Adapter interface {
 	GetSubsetFailure() *string
 	// ApplySubsetTemplate updates the subset to the latest revision.
 	ApplySubsetTemplate(ud *alpha1.UnitedDeployment, subsetName, revision string, replicas, partition int32, subset runtime.Object) error
-	// IsExpected checks the subset is the expected revision or not.
-	// If not, UnitedDeployment will call ApplySubsetTemplate to update it.
-	IsExpected(subset metav1.Object, revision string) bool
 	// PostUpdate does some works after subset updated
 	PostUpdate(ud *alpha1.UnitedDeployment, subset runtime.Object, revision string, partition int32) error
 }

--- a/pkg/controller/uniteddeployment/adapter/adapter_test.go
+++ b/pkg/controller/uniteddeployment/adapter/adapter_test.go
@@ -1,0 +1,239 @@
+/*
+Copyright 2024 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package adapter
+
+import (
+	"testing"
+
+	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
+	"github.com/openkruise/kruise/apis/apps/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/scale/scheme/appsv1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestPostUpdate(t *testing.T) {
+	fakeClient, scheme := getClientAndScheme()
+	testCases := []struct {
+		name         string
+		adapter      Adapter
+		subsetGetter func() client.Object
+	}{
+		{
+			name: "AdvancedStatefulSet",
+			adapter: &AdvancedStatefulSetAdapter{
+				Client: fakeClient,
+				Scheme: scheme,
+			},
+			subsetGetter: func() client.Object {
+				return nil
+			},
+		},
+		{
+			name: "CloneSet",
+			adapter: &CloneSetAdapter{
+				Client: fakeClient,
+				Scheme: scheme,
+			},
+			subsetGetter: func() client.Object {
+				return nil
+			},
+		},
+		{
+			name: "Deployment",
+			adapter: &DeploymentAdapter{
+				Client: fakeClient,
+				Scheme: scheme,
+			},
+			subsetGetter: func() client.Object {
+				return nil
+			},
+		},
+		{
+			name: "StatefulSet",
+			adapter: &StatefulSetAdapter{
+				Client: fakeClient,
+				Scheme: scheme,
+			},
+			subsetGetter: func() client.Object {
+				return &appsv1.StatefulSet{
+					Spec: appsv1.StatefulSetSpec{
+						UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
+							Type: appsv1.OnDeleteStatefulSetStrategyType,
+						},
+					},
+				}
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if err := testCase.adapter.PostUpdate(nil, testCase.subsetGetter(), "", 0); err != nil {
+				t.Errorf("PostUpdate() error = %v", err)
+			}
+		})
+	}
+}
+
+func TestApplySubsetTemplate(t *testing.T) {
+	var scheme = runtime.NewScheme()
+	var fakeClient = fake.NewClientBuilder().WithScheme(scheme).Build()
+	_ = appsv1alpha1.AddToScheme(scheme)
+	_ = appsv1beta1.AddToScheme(scheme)
+	_ = appsv1.AddToScheme(scheme)
+
+	testCases := []struct {
+		name    string
+		adapter Adapter
+	}{
+		{
+			name: "AdvancedStatefulSet",
+			adapter: &AdvancedStatefulSetAdapter{
+				Client: fakeClient,
+				Scheme: scheme,
+			},
+		},
+		{
+			name: "CloneSet",
+			adapter: &CloneSetAdapter{
+				Client: fakeClient,
+				Scheme: scheme,
+			},
+		},
+		{
+			name: "Deployment",
+			adapter: &DeploymentAdapter{
+				Client: fakeClient,
+				Scheme: scheme,
+			},
+		},
+		{
+			name: "StatefulSet",
+			adapter: &StatefulSetAdapter{
+				Client: fakeClient,
+				Scheme: scheme,
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			subset := testCase.adapter.NewResourceObject()
+			ud := newUnitedDeploymentWithAdapter(testCase.adapter)
+			revision := "abcd"
+			subsetName := "subset-a"
+			if err := testCase.adapter.ApplySubsetTemplate(ud, subsetName, revision, 2, 4, subset); err != nil {
+				t.Fatalf("ApplySubsetTemplate() error = %v", err)
+			}
+			if subset.GetNamespace() != ud.Namespace {
+				t.Errorf("compare namespace failed: ud %+v, subset %+v", subset.GetNamespace(), ud.Namespace)
+			}
+			compareMap(subset.GetLabels(), map[string]string{
+				"custom-label-1":                            "custom-value-1",
+				"selector-key":                              "selector-value",
+				appsv1alpha1.SubSetNameLabelKey:             subsetName,
+				appsv1alpha1.ControllerRevisionHashLabelKey: revision,
+			}, t)
+			compareMap(subset.GetAnnotations(), map[string]string{
+				"annotation-key":                      "annotation-value",
+				appsv1alpha1.AnnotationSubsetPatchKey: `{"metadata":{"annotations":{"patched-key":"patched-value"}}}`,
+			}, t)
+			compareMap(getPodAnnotationsFromSubset(subset), map[string]string{"patched-key": "patched-value"}, t)
+		})
+	}
+}
+
+func compareMap(actual, expect map[string]string, t *testing.T) {
+	for k := range expect {
+		ev := expect[k]
+		av, ok := actual[k]
+		if !ok {
+			t.Errorf("missing key %s", k)
+		}
+		if ev != av {
+			t.Errorf("diff in map key %s: expect %s, actual %s", k, ev, av)
+		}
+	}
+}
+
+func getClientAndScheme() (fakeClient client.Client, scheme *runtime.Scheme) {
+	scheme = runtime.NewScheme()
+	fakeClient = fake.NewClientBuilder().WithScheme(scheme).Build()
+	_ = appsv1alpha1.AddToScheme(scheme)
+	_ = appsv1beta1.AddToScheme(scheme)
+	_ = appsv1.AddToScheme(scheme)
+	return
+}
+
+func getPodAnnotationsFromSubset(object client.Object) map[string]string {
+	switch object.(type) {
+	case *v1beta1.StatefulSet:
+		return object.(*v1beta1.StatefulSet).Spec.Template.Annotations
+	case *appsv1alpha1.CloneSet:
+		return object.(*appsv1alpha1.CloneSet).Spec.Template.Annotations
+	case *appsv1.Deployment:
+		return object.(*appsv1.Deployment).Spec.Template.Annotations
+	case *appsv1.StatefulSet:
+		return object.(*appsv1.StatefulSet).Spec.Template.Annotations
+	}
+	return nil
+}
+
+func newUnitedDeploymentWithAdapter(adapter Adapter) *appsv1alpha1.UnitedDeployment {
+	ud := &appsv1alpha1.UnitedDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
+		Spec: appsv1alpha1.UnitedDeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{
+				"selector-key": "selector-value",
+			}},
+			Topology: appsv1alpha1.Topology{
+				Subsets: []appsv1alpha1.Subset{
+					{
+						Name: "subset-a",
+						Patch: runtime.RawExtension{
+							Raw: []byte(`{"metadata":{"annotations":{"patched-key":"patched-value"}}}`),
+						},
+					},
+				},
+			},
+		},
+	}
+	object := adapter.NewResourceObject()
+	switch object.(type) {
+	case *v1beta1.StatefulSet:
+		ud.Spec.Template.AdvancedStatefulSetTemplate = &appsv1alpha1.AdvancedStatefulSetTemplateSpec{}
+		ud.Spec.Template.AdvancedStatefulSetTemplate.Labels = map[string]string{"custom-label-1": "custom-value-1"}
+		ud.Spec.Template.AdvancedStatefulSetTemplate.Annotations = map[string]string{"annotation-key": "annotation-value"}
+	case *appsv1alpha1.CloneSet:
+		ud.Spec.Template.CloneSetTemplate = &appsv1alpha1.CloneSetTemplateSpec{}
+		ud.Spec.Template.CloneSetTemplate.Labels = map[string]string{"custom-label-1": "custom-value-1"}
+		ud.Spec.Template.CloneSetTemplate.Annotations = map[string]string{"annotation-key": "annotation-value"}
+	case *appsv1.Deployment:
+		ud.Spec.Template.DeploymentTemplate = &appsv1alpha1.DeploymentTemplateSpec{}
+		ud.Spec.Template.DeploymentTemplate.Labels = map[string]string{"custom-label-1": "custom-value-1"}
+		ud.Spec.Template.DeploymentTemplate.Annotations = map[string]string{"annotation-key": "annotation-value"}
+	case *appsv1.StatefulSet:
+		ud.Spec.Template.StatefulSetTemplate = &appsv1alpha1.StatefulSetTemplateSpec{}
+		ud.Spec.Template.StatefulSetTemplate.Labels = map[string]string{"custom-label-1": "custom-value-1"}
+		ud.Spec.Template.StatefulSetTemplate.Annotations = map[string]string{"annotation-key": "annotation-value"}
+	}
+	return ud
+}

--- a/pkg/controller/uniteddeployment/adapter/advanced_statefulset_adapter.go
+++ b/pkg/controller/uniteddeployment/adapter/advanced_statefulset_adapter.go
@@ -133,7 +133,7 @@ func (a *AdvancedStatefulSetAdapter) ApplySubsetTemplate(ud *alpha1.UnitedDeploy
 	for k, v := range ud.Spec.Selector.MatchLabels {
 		set.Labels[k] = v
 	}
-	set.Labels[appsv1.ControllerRevisionHashLabelKey] = revision
+	set.Labels[alpha1.ControllerRevisionHashLabelKey] = revision
 	// record the subset name as a label
 	set.Labels[alpha1.SubSetNameLabelKey] = subsetName
 
@@ -153,30 +153,22 @@ func (a *AdvancedStatefulSetAdapter) ApplySubsetTemplate(ud *alpha1.UnitedDeploy
 		return err
 	}
 
+	set.Spec = *ud.Spec.Template.AdvancedStatefulSetTemplate.Spec.DeepCopy()
 	set.Spec.Selector = selectors
 	set.Spec.Replicas = &replicas
-	if ud.Spec.Template.AdvancedStatefulSetTemplate.Spec.UpdateStrategy.Type == appsv1.OnDeleteStatefulSetStrategyType {
-		set.Spec.UpdateStrategy.Type = appsv1.OnDeleteStatefulSetStrategyType
-	} else {
-		set.Spec.UpdateStrategy.RollingUpdate = ud.Spec.Template.AdvancedStatefulSetTemplate.Spec.UpdateStrategy.RollingUpdate
+	if ud.Spec.Template.AdvancedStatefulSetTemplate.Spec.UpdateStrategy.Type == "" || // Default value is RollingUpdate, which is not set in webhook
+		ud.Spec.Template.AdvancedStatefulSetTemplate.Spec.UpdateStrategy.Type == appsv1.RollingUpdateStatefulSetStrategyType {
 		if set.Spec.UpdateStrategy.RollingUpdate == nil {
 			set.Spec.UpdateStrategy.RollingUpdate = &v1beta1.RollingUpdateStatefulSetStrategy{}
 		}
 		set.Spec.UpdateStrategy.RollingUpdate.Partition = &partition
 	}
 
-	set.Spec.Template = *ud.Spec.Template.AdvancedStatefulSetTemplate.Spec.Template.DeepCopy()
 	if set.Spec.Template.Labels == nil {
 		set.Spec.Template.Labels = map[string]string{}
 	}
 	set.Spec.Template.Labels[alpha1.SubSetNameLabelKey] = subsetName
 	set.Spec.Template.Labels[alpha1.ControllerRevisionHashLabelKey] = revision
-
-	set.Spec.RevisionHistoryLimit = ud.Spec.Template.AdvancedStatefulSetTemplate.Spec.RevisionHistoryLimit
-	set.Spec.PodManagementPolicy = ud.Spec.Template.AdvancedStatefulSetTemplate.Spec.PodManagementPolicy
-	set.Spec.ServiceName = ud.Spec.Template.AdvancedStatefulSetTemplate.Spec.ServiceName
-	set.Spec.VolumeClaimTemplates = ud.Spec.Template.AdvancedStatefulSetTemplate.Spec.VolumeClaimTemplates
-	set.Spec.PersistentVolumeClaimRetentionPolicy = ud.Spec.Template.AdvancedStatefulSetTemplate.Spec.PersistentVolumeClaimRetentionPolicy
 
 	attachNodeAffinity(&set.Spec.Template.Spec, subSetConfig)
 	attachTolerations(&set.Spec.Template.Spec, subSetConfig)
@@ -205,14 +197,8 @@ func (a *AdvancedStatefulSetAdapter) ApplySubsetTemplate(ud *alpha1.UnitedDeploy
 }
 
 // PostUpdate does some works after subset updated.
-func (a *AdvancedStatefulSetAdapter) PostUpdate(ud *alpha1.UnitedDeployment, obj runtime.Object, revision string, partition int32) error {
+func (a *AdvancedStatefulSetAdapter) PostUpdate(_ *alpha1.UnitedDeployment, _ runtime.Object, _ string, _ int32) error {
 	return nil
-}
-
-// IsExpected checks the subset is the expected revision or not.
-// The revision label can tell the current subset revision.
-func (a *AdvancedStatefulSetAdapter) IsExpected(obj metav1.Object, revision string) bool {
-	return obj.GetLabels()[appsv1.ControllerRevisionHashLabelKey] != revision
 }
 
 func (a *AdvancedStatefulSetAdapter) getStatefulSetPods(set *v1beta1.StatefulSet) ([]*corev1.Pod, error) {

--- a/pkg/controller/uniteddeployment/adapter/deployment_adapter.go
+++ b/pkg/controller/uniteddeployment/adapter/deployment_adapter.go
@@ -67,7 +67,7 @@ func (a *DeploymentAdapter) GetSpecReplicas(obj metav1.Object) *int32 {
 	return set.Spec.Replicas
 }
 
-func (a *DeploymentAdapter) GetSpecPartition(obj metav1.Object, pods []*corev1.Pod) *int32 {
+func (a *DeploymentAdapter) GetSpecPartition(_ metav1.Object, _ []*corev1.Pod) *int32 {
 	return nil
 }
 
@@ -88,7 +88,7 @@ func (a *DeploymentAdapter) GetSubsetFailure() *string {
 }
 
 // ApplySubsetTemplate updates the subset to the latest revision, depending on the DeploymentTemplate.
-func (a *DeploymentAdapter) ApplySubsetTemplate(ud *alpha1.UnitedDeployment, subsetName, revision string, replicas, partition int32, obj runtime.Object) error {
+func (a *DeploymentAdapter) ApplySubsetTemplate(ud *alpha1.UnitedDeployment, subsetName, revision string, replicas, _ int32, obj runtime.Object) error {
 	// Convert to Deployment Object
 	set := obj.(*appsv1.Deployment)
 
@@ -140,15 +140,14 @@ func (a *DeploymentAdapter) ApplySubsetTemplate(ud *alpha1.UnitedDeployment, sub
 		return err
 	}
 
+	set.Spec = *ud.Spec.Template.DeploymentTemplate.Spec.DeepCopy()
 	set.Spec.Selector = selectors
 	set.Spec.Replicas = &replicas
-	set.Spec.Template = *ud.Spec.Template.DeploymentTemplate.Spec.Template.DeepCopy()
 	if set.Spec.Template.Labels == nil {
 		set.Spec.Template.Labels = map[string]string{}
 	}
 	set.Spec.Template.Labels[alpha1.SubSetNameLabelKey] = subsetName
 	set.Spec.Template.Labels[alpha1.ControllerRevisionHashLabelKey] = revision
-	set.Spec.RevisionHistoryLimit = ud.Spec.Template.DeploymentTemplate.Spec.RevisionHistoryLimit
 
 	attachNodeAffinity(&set.Spec.Template.Spec, subSetConfig)
 	attachTolerations(&set.Spec.Template.Spec, subSetConfig)
@@ -178,14 +177,8 @@ func (a *DeploymentAdapter) ApplySubsetTemplate(ud *alpha1.UnitedDeployment, sub
 }
 
 // PostUpdate does some works after subset updated. Deployments typically don't have post update operations.
-func (a *DeploymentAdapter) PostUpdate(ud *alpha1.UnitedDeployment, obj runtime.Object, revision string, partition int32) error {
+func (a *DeploymentAdapter) PostUpdate(_ *alpha1.UnitedDeployment, _ runtime.Object, _ string, _ int32) error {
 	return nil
-}
-
-// IsExpected checks the subset is the expected revision or not.
-// The revision label can tell the current subset revision.
-func (a *DeploymentAdapter) IsExpected(obj metav1.Object, revision string) bool {
-	return obj.GetLabels()[appsv1.ControllerRevisionHashLabelKey] != revision
 }
 
 // getDeploymentPods gets all Pods under a Deployment object

--- a/pkg/controller/uniteddeployment/subset.go
+++ b/pkg/controller/uniteddeployment/subset.go
@@ -83,6 +83,4 @@ type ControlInterface interface {
 	DeleteSubset(*Subset) error
 	// GetSubsetFailure extracts the subset failure message to expose on UnitedDeployment status.
 	GetSubsetFailure(*Subset) *string
-	// IsExpected check the subset is the expected revision
-	IsExpected(subSet *Subset, revision string) bool
 }

--- a/pkg/controller/uniteddeployment/subset_control.go
+++ b/pkg/controller/uniteddeployment/subset_control.go
@@ -122,13 +122,8 @@ func (m *SubsetControl) DeleteSubset(subSet *Subset) error {
 }
 
 // GetSubsetFailure return the error message extracted form Subset workload status conditions.
-func (m *SubsetControl) GetSubsetFailure(subset *Subset) *string {
+func (m *SubsetControl) GetSubsetFailure(*Subset) *string {
 	return m.adapter.GetSubsetFailure()
-}
-
-// IsExpected checks the subset is expected revision or not.
-func (m *SubsetControl) IsExpected(subSet *Subset, revision string) bool {
-	return m.adapter.IsExpected(subSet.Spec.SubsetRef.Resources[0], revision)
 }
 
 func (m *SubsetControl) convertToSubset(set metav1.Object, updatedRevision string) (*Subset, error) {


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

UnitedDeployment will sync all fields in spec.template to the subset workload spec.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

fixes #1791

### Ⅲ. Describe how to verify it

1. set a not very popular field of workload template and check whether the field is synced to all subset workloads
2. run the TestDeploymentRollingUpdate unit test

### Ⅳ. Special notes for reviews

