### PR TITLE
add helm pre delete hook

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -26,3 +26,4 @@ jobs:
           docker buildx create --use --platform=linux/amd64,linux/arm64,linux/ppc64le --name multi-platform-builder
           docker buildx ls
           IMG=openkruise/kruise-manager:${{ github.ref_name }} make docker-multiarch
+          HOOK_IMG=openkruise/kruise-helm-hook:${{ github.ref_name }} make docker-build-hook

--- a/Dockerfile_helm_hook
+++ b/Dockerfile_helm_hook
@@ -1,0 +1,40 @@
+ARG BASE_IMAGE=alpine
+ARG BASE_IMAGE_VERSION=3.19
+FROM golang:1.20.14-alpine3.19 AS builder
+
+WORKDIR /workspace
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+
+# Copy the go source
+COPY apis/ apis/
+COPY cmd/ cmd/
+COPY pkg/ pkg/
+# Build
+RUN --mount=type=cache,target=/go CGO_ENABLED=0 GO111MODULE=on go build -a -o helm_hook ./cmd/helm_hook/main.go
+
+FROM ${BASE_IMAGE}:${BASE_IMAGE_VERSION}
+WORKDIR /
+RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories
+RUN set -eux; \
+    mkdir -p /log /tmp && \
+    chown -R nobody:nobody /log && \
+    chown -R nobody:nobody /tmp && \
+    apk --no-cache --update upgrade && \
+    apk --no-cache add ca-certificates && \
+    apk --no-cache add tzdata && \
+    rm -rf /var/cache/apk/* && \
+    update-ca-certificates && \
+    echo "only include root and nobody user" && \
+    echo -e "root:x:0:0:root:/root:/bin/ash\nnobody:x:65534:65534:nobody:/:/sbin/nologin" | tee /etc/passwd && \
+    echo -e "root:x:0:root\nnobody:x:65534:" | tee /etc/group
+COPY --from=builder /workspace/helm_hook .
+RUN chown -R nobody:nobody /helm_hook && \
+    rm -rf /usr/local/sbin/* && \
+    rm -rf /usr/local/bin/* && \
+    rm -rf /usr/sbin/* && \
+    rm -rf /usr/bin/* && \
+    rm -rf /sbin/* && \
+    rm -rf /bin/*
+ENTRYPOINT ["/helm_hook"]

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 # Image URL to use all building/pushing image targets
 IMG ?= openkruise/kruise-manager:test
+HOOK_IMG ?= openkruise/kruise-helm-hook:test
 # Platforms to build the image for
 PLATFORMS ?= linux/amd64,linux/arm64,linux/ppc64le
 CRD_OPTIONS ?= "crd:crdVersions=v1"
@@ -182,3 +183,7 @@ generate_helm_crds:
 # kruise-e2e-test runs kruise e2e tests.
 .PHONY: kruise-e2e-test
 kruise-e2e-test: $(tools/kind) delete-cluster create-cluster install-csi docker-build kube-load-image install-kruise run-kruise-e2e-test delete-cluster
+
+.PHONY: docker-build-hook
+docker-build-hook:
+	docker build -f ./Dockerfile_helm_hook . -t ${HOOK_IMG}

--- a/cmd/helm_hook/main.go
+++ b/cmd/helm_hook/main.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2024 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"log"
+
+	kruiseclientset "github.com/openkruise/kruise/pkg/client/clientset/versioned"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+)
+
+func main() {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		panic(err)
+	}
+	kc, err := kruiseclientset.NewForConfig(config)
+	if err != nil {
+		panic(err)
+	}
+	cloneSets, err := kc.AppsV1alpha1().CloneSets("").List(context.Background(), metav1.ListOptions{Limit: 1})
+	if err != nil {
+		panic(err)
+	}
+	if len(cloneSets.Items) > 0 || cloneSets.Continue != "" {
+		log.Fatalln("there still exists some clonesets in the cluster")
+	}
+	statefulSets, err := kc.AppsV1alpha1().StatefulSets("").List(context.Background(), metav1.ListOptions{Limit: 1})
+	if err != nil {
+		panic(err)
+	}
+	if len(statefulSets.Items) > 0 || statefulSets.Continue != "" {
+		log.Fatalln("there still exists some advanced statefulsets in the cluster")
+	}
+	statefulSetsBeta1, err := kc.AppsV1beta1().StatefulSets("").List(context.Background(), metav1.ListOptions{Limit: 1})
+	if err != nil {
+		panic(err)
+	}
+	if len(statefulSetsBeta1.Items) > 0 || statefulSetsBeta1.Continue != "" {
+		log.Fatalln("there still exists some advanced statefulsets in the cluster")
+	}
+	daemonSets, err := kc.AppsV1alpha1().DaemonSets("").List(context.Background(), metav1.ListOptions{Limit: 1})
+	if err != nil {
+		panic(err)
+	}
+	if len(daemonSets.Items) > 0 || daemonSets.Continue != "" {
+		log.Fatalln("there still exists some advanced daemonsets in the cluster")
+	}
+	log.Println("cluster is clean, ready to delete kruise")
+}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

By adding a Helm Hook to prevent all Pods from being deleted when Kruise is accidentally removed in a cluster containing resources like CloneSet.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #1840 

### Ⅲ. Describe how to verify it

1. install kruise with latest helm chart
2. apply some cloneset
3. helm uninstall the release
4. a hook will failed causing uninstallation failing
5. delete the cloneset
6. helm uninstall the release successfully

### Ⅳ. Special notes for reviews
latest chart PR: https://github.com/openkruise/charts/pull/125
