### PR TITLE
Feature: SidecarSet injection supports Partial strategy

### DIFF
--- a/apis/apps/v1alpha1/sidecarset_types.go
+++ b/apis/apps/v1alpha1/sidecarset_types.go
@@ -226,9 +226,14 @@ const (
 	// AlwaysSidecarSetInjectRevisionPolicy means the SidecarSet will always inject
 	// the specific revision to Pods when pod creating, except matching UpdateStrategy.Selector.
 	AlwaysSidecarSetInjectRevisionPolicy SidecarSetInjectRevisionPolicy = "Always"
-	// PartitionBasedSidecarSetInjectRevisionPolicy means the SidecarSet will inject the
-	// specific or the latest revision according to Partition.
-	//PartitionBasedSidecarSetInjectRevisionPolicy SidecarSetInjectRevisionPolicy = "PartitionBased"
+
+	// TODOSidecarSetInjectRevisionPolicy means the SidecarSet will inject the specific or the latest revision according to UpdateStrategy.
+	//
+	// Only when a newly created Pod is **not** selected by the Selector explicitly configured in `UpdateStrategy` will it be injected with the specified version of the Sidecar.
+	// Under all other conditions, newly created Pods have a probability of being injected with the latest Sidecar, where the probability is `1 - UpdateStrategy.Partition`.
+	// If `Partition` is not a percentage or is not configured, its value is considered to be 0%.
+	// TODO: rename me
+	TODOSidecarSetInjectRevisionPolicy SidecarSetInjectRevisionPolicy = "TODO"
 )
 
 // SidecarSetUpdateStrategy indicates the strategy that the SidecarSet
@@ -251,7 +256,8 @@ type SidecarSetUpdateStrategy struct {
 	// injected into newly created Pods by a SidecarSet configured with an injectionStrategy.
 	// In most cases, all newly created Pods are injected with the specified Sidecar version as configured in injectionStrategy.revision,
 	// which is consistent with previous versions.
-	// Now, if updateStrategy.Selector is  also configured and the updateStrategy.paused field is set to false,
+	//
+	// Now, if updateStrategy.Selector is also configured and the updateStrategy.paused field is set to false,
 	// then Pods matching the selector will be injected with the latest version of the Sidecar container.
 	Selector *metav1.LabelSelector `json:"selector,omitempty"`
 

--- a/apis/apps/v1alpha1/sidecarset_types.go
+++ b/apis/apps/v1alpha1/sidecarset_types.go
@@ -216,7 +216,8 @@ type SidecarSetInjectRevision struct {
 	// + optional
 	RevisionName *string `json:"revisionName,omitempty"`
 	// Policy describes the behavior of revision injection.
-	// Defaults to Always.
+	// +kubebuilder:validation:Enum=Always;TODO
+	// +kubebuilder:default=Always
 	Policy SidecarSetInjectRevisionPolicy `json:"policy,omitempty"`
 }
 
@@ -229,8 +230,10 @@ const (
 
 	// TODOSidecarSetInjectRevisionPolicy means the SidecarSet will inject the specific or the latest revision according to UpdateStrategy.
 	//
-	// Only when a newly created Pod is **not** selected by the Selector explicitly configured in `UpdateStrategy` will it be injected with the specified version of the Sidecar.
-	// Under all other conditions, newly created Pods have a probability of being injected with the latest Sidecar, where the probability is `1 - UpdateStrategy.Partition`.
+	// If UpdateStrategy.Pause is not true, only when a newly created Pod is **not** selected by the Selector explicitly
+	// configured in `UpdateStrategy` will it be injected with the specified version of the Sidecar.
+	// Under all other conditions, newly created Pods have a probability of being injected with the latest Sidecar,
+	// where the probability is `1 - UpdateStrategy.Partition`.
 	// If `Partition` is not a percentage or is not configured, its value is considered to be 0%.
 	// TODO: rename me
 	TODOSidecarSetInjectRevisionPolicy SidecarSetInjectRevisionPolicy = "TODO"
@@ -256,9 +259,6 @@ type SidecarSetUpdateStrategy struct {
 	// injected into newly created Pods by a SidecarSet configured with an injectionStrategy.
 	// In most cases, all newly created Pods are injected with the specified Sidecar version as configured in injectionStrategy.revision,
 	// which is consistent with previous versions.
-	//
-	// Now, if updateStrategy.Selector is also configured and the updateStrategy.paused field is set to false,
-	// then Pods matching the selector will be injected with the latest version of the Sidecar container.
 	Selector *metav1.LabelSelector `json:"selector,omitempty"`
 
 	// Partition is the desired number of pods in old revisions. It means when partition

--- a/apis/apps/v1alpha1/sidecarset_types.go
+++ b/apis/apps/v1alpha1/sidecarset_types.go
@@ -216,7 +216,7 @@ type SidecarSetInjectRevision struct {
 	// + optional
 	RevisionName *string `json:"revisionName,omitempty"`
 	// Policy describes the behavior of revision injection.
-	// +kubebuilder:validation:Enum=Always;TODO
+	// +kubebuilder:validation:Enum=Always;Partial;
 	// +kubebuilder:default=Always
 	Policy SidecarSetInjectRevisionPolicy `json:"policy,omitempty"`
 }
@@ -228,15 +228,14 @@ const (
 	// the specific revision to Pods when pod creating, except matching UpdateStrategy.Selector.
 	AlwaysSidecarSetInjectRevisionPolicy SidecarSetInjectRevisionPolicy = "Always"
 
-	// TODOSidecarSetInjectRevisionPolicy means the SidecarSet will inject the specific or the latest revision according to UpdateStrategy.
+	// PartialSidecarSetInjectRevisionPolicy means the SidecarSet will inject the specific or the latest revision according to UpdateStrategy.
 	//
 	// If UpdateStrategy.Pause is not true, only when a newly created Pod is **not** selected by the Selector explicitly
 	// configured in `UpdateStrategy` will it be injected with the specified version of the Sidecar.
 	// Under all other conditions, newly created Pods have a probability of being injected with the latest Sidecar,
 	// where the probability is `1 - UpdateStrategy.Partition`.
 	// If `Partition` is not a percentage or is not configured, its value is considered to be 0%.
-	// TODO: rename me
-	TODOSidecarSetInjectRevisionPolicy SidecarSetInjectRevisionPolicy = "TODO"
+	PartialSidecarSetInjectRevisionPolicy SidecarSetInjectRevisionPolicy = "Partial"
 )
 
 // SidecarSetUpdateStrategy indicates the strategy that the SidecarSet

--- a/config/crd/bases/apps.kruise.io_sidecarsets.yaml
+++ b/config/crd/bases/apps.kruise.io_sidecarsets.yaml
@@ -262,7 +262,7 @@ spec:
                         description: Policy describes the behavior of revision injection.
                         enum:
                         - Always
-                        - TODO
+                        - Partial
                         type: string
                       revisionName:
                         description: RevisionName corresponds to a specific ControllerRevision

--- a/config/crd/bases/apps.kruise.io_sidecarsets.yaml
+++ b/config/crd/bases/apps.kruise.io_sidecarsets.yaml
@@ -258,9 +258,11 @@ spec:
                           history SidecarSet to inject specific version of the sidecar to pods.
                         type: string
                       policy:
-                        description: |-
-                          Policy describes the behavior of revision injection.
-                          Defaults to Always.
+                        default: Always
+                        description: Policy describes the behavior of revision injection.
+                        enum:
+                        - Always
+                        - TODO
                         type: string
                       revisionName:
                         description: RevisionName corresponds to a specific ControllerRevision
@@ -534,8 +536,6 @@ spec:
                       injected into newly created Pods by a SidecarSet configured with an injectionStrategy.
                       In most cases, all newly created Pods are injected with the specified Sidecar version as configured in injectionStrategy.revision,
                       which is consistent with previous versions.
-                      Now, if updateStrategy.Selector is  also configured and the updateStrategy.paused field is set to false,
-                      then Pods matching the selector will be injected with the latest version of the Sidecar container.
                     properties:
                       matchExpressions:
                         description: matchExpressions is a list of label selector

--- a/pkg/controller/sidecarset/sidecarset_pod_event_handler.go
+++ b/pkg/controller/sidecarset/sidecarset_pod_event_handler.go
@@ -140,22 +140,6 @@ func (p *enqueueRequestForPod) getPodMatchedSidecarSets(pod *corev1.Pod) ([]*app
 		return matchedSidecarSets, nil
 	}
 
-	// This code will trigger an invalid reconcile, where the Pod matches the sidecarSet selector but does not inject the sidecar container.
-	// Comment out this code to reduce some invalid reconcile.
-	/*sidecarSets := appsv1alpha1.SidecarSetList{}
-	if err := p.reader.List(context.TODO(), &sidecarSets); err != nil {
-		return nil, err
-	}
-
-	for _, sidecarSet := range sidecarSets.Items {
-		matched, err := sidecarcontrol.PodMatchedSidecarSet(pod, sidecarSet)
-		if err != nil {
-			return nil, err
-		}
-		if matched {
-			matchedSidecarSets = append(matchedSidecarSets, &sidecarSet)
-		}
-	}*/
 	return matchedSidecarSets, nil
 }
 

--- a/pkg/util/tools.go
+++ b/pkg/util/tools.go
@@ -227,6 +227,20 @@ func GetScaledValueFromIntOrPercent(intOrPercent *intstrutil.IntOrString, total 
 	return 0, fmt.Errorf("invalid type: neither int nor percentage")
 }
 
+// ParsePercentageAsFloat64 parses a string as a percentage and returns the value as a float64.
+func ParsePercentageAsFloat64(s string) (float64, error) {
+	if strings.HasSuffix(s, "%") {
+		s = strings.TrimSuffix(s, "%")
+	} else {
+		return 0, fmt.Errorf("invalid type: string is not a percentage")
+	}
+	v, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0, err
+	}
+	return v / 100, nil
+}
+
 func EqualIgnoreHash(template1, template2 *corev1.PodTemplateSpec) bool {
 	t1Copy := template1.DeepCopy()
 	t2Copy := template2.DeepCopy()

--- a/pkg/util/tools_test.go
+++ b/pkg/util/tools_test.go
@@ -19,6 +19,7 @@ package util
 
 import (
 	"fmt"
+	"math"
 	"sync"
 	"testing"
 
@@ -323,7 +324,7 @@ func TestGetScaledValueFromIntOrPercent(t *testing.T) {
 		expectVal int
 	}{
 		{
-			input:     intstr.FromInt(123),
+			input:     intstr.FromInt32(123),
 			expectErr: false,
 			expectVal: 123,
 		},
@@ -408,5 +409,38 @@ func TestGetScaledValueFromIntOrPercent(t *testing.T) {
 		if test.expectVal != value {
 			t.Errorf("expected %v, but got %v", test.expectVal, value)
 		}
+	}
+}
+
+func TestParsePercentageAsFloat64(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected float64
+		err      error
+	}{
+		{"100%", 1.0, nil},
+		{"50%", 0.5, nil},
+		{"25%", 0.25, nil},
+		{"10%", 0.10, nil},
+		{"1%", 0.01, nil},
+		{"0%", 0.00, nil},
+		{"invalid", 0, fmt.Errorf("invalid type: string is not a percentage")},
+		{"100", 0, fmt.Errorf("invalid type: string is not a percentage")},
+		{"", 0, fmt.Errorf("invalid type: string is not a percentage")},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.input, func(t *testing.T) {
+			got, err := ParsePercentageAsFloat64(tc.input)
+			if err != nil && tc.err == nil {
+				t.Errorf("expected no error, but got: %v", err)
+			}
+			if err == nil && tc.err != nil {
+				t.Errorf("expected error: %v, but got none", tc.err)
+			}
+			if math.Abs(got-tc.expected) > 1e-9 {
+				t.Errorf("expected %v, but got %v", tc.expected, got)
+			}
+		})
 	}
 }

--- a/pkg/webhook/pod/mutating/sidecarset.go
+++ b/pkg/webhook/pod/mutating/sidecarset.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"sort"
 	"strings"
 
@@ -30,6 +31,7 @@ import (
 	"github.com/openkruise/kruise/pkg/util/fieldindex"
 	"github.com/openkruise/kruise/pkg/util/history"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	admissionv1 "k8s.io/api/admission/v1"
 	apps "k8s.io/api/apps/v1"
@@ -206,28 +208,48 @@ func (h *PodCreateHandler) getSuitableRevisionSidecarSet(sidecarSet *appsv1alpha
 			return sidecarSet.DeepCopy(), nil
 		}
 
-		// On pod creation, if a new pod matches the SidecarSet update strategy selector,
-		// the latest revision rather than that specified in the sidecarset.spec.injectionStrategy will be injected.
-		if updateStrategy := sidecarSet.Spec.UpdateStrategy; !updateStrategy.Paused && updateStrategy.Selector != nil {
-			selector, err := util.ValidatedLabelSelectorAsSelector(updateStrategy.Selector)
-			if err != nil {
-				klog.ErrorS(err, "Failed to parse SidecarSet update strategy selector", "name", sidecarSet.Name)
-				return nil, err
-			}
-			if selector.Matches(labels.Set(newPod.Labels)) {
-				klog.InfoS("New pod matches SidecarSet update strategy selector, latest revision will be injected",
-					"namespace", newPod.Namespace, "podName", newPod.Name, "sidecarSet", sidecarSet.Name)
-				return sidecarSet.DeepCopy(), nil
-			}
+		specificHistory, err := h.getSpecificHistorySidecarSet(sidecarSet, revisionInfo)
+		if err != nil {
+			return nil, err
 		}
 
-		// TODO: support 'PartitionBased' policy to inject old/new revision according to Partition
 		switch sidecarSet.Spec.InjectionStrategy.Revision.Policy {
-		case "", appsv1alpha1.AlwaysSidecarSetInjectRevisionPolicy:
-			return h.getSpecificHistorySidecarSet(sidecarSet, revisionInfo)
+		case appsv1alpha1.TODOSidecarSetInjectRevisionPolicy:
+			if updateStrategy := sidecarSet.Spec.UpdateStrategy; !updateStrategy.Paused && updateStrategy.Selector != nil {
+				selector, err := util.ValidatedLabelSelectorAsSelector(updateStrategy.Selector)
+				if err != nil {
+					klog.ErrorS(err, "Failed to parse SidecarSet update strategy selector", "name", sidecarSet.Name)
+					return nil, err
+				}
+				if !selector.Matches(labels.Set(newPod.Labels)) {
+					// Only the Pods that are not selected by the selector will definitely be injected with the specified version of the Sidecar.
+					klog.V(3).InfoS("New pod is not updated, specified revision will be injected",
+						"pod", klog.KObj(newPod), "sidecarSet", klog.KObj(sidecarSet), "revisionInfo", revisionInfo)
+					return specificHistory, nil
+				}
+			}
+			klog.V(3).InfoS("New pod is updated, which has a probility to be injected with the latest sidecar",
+				"pod", klog.KObj(newPod), "sidecarSet", klog.KObj(sidecarSet), "partition", sidecarSet.Spec.UpdateStrategy.Partition)
+			return h.selectRevisionRandomly(specificHistory, sidecarSet.DeepCopy(), sidecarSet.Spec.UpdateStrategy.Partition)
+		default: // Always strategy
+			return specificHistory, nil
 		}
+	}
+}
 
-		return h.getSpecificHistorySidecarSet(sidecarSet, revisionInfo)
+// selectRevisionRandomly selects 'old' according to the probabilities specified by the partition.
+func (h *PodCreateHandler) selectRevisionRandomly(old, new *appsv1alpha1.SidecarSet, partition *intstr.IntOrString) (*appsv1alpha1.SidecarSet, error) {
+	if partition == nil || partition.Type == intstr.Int {
+		return new, nil
+	}
+	probability, err := util.ParsePercentageAsFloat64(partition.StrVal)
+	if err != nil {
+		return nil, err
+	}
+	if rand.Float64() <= probability {
+		return old, nil
+	} else {
+		return new, nil
 	}
 }
 

--- a/pkg/webhook/pod/mutating/sidecarset.go
+++ b/pkg/webhook/pod/mutating/sidecarset.go
@@ -219,8 +219,8 @@ func (h *PodCreateHandler) getSuitableRevisionSidecarSet(sidecarSet *appsv1alpha
 		}
 
 		switch sidecarSet.Spec.InjectionStrategy.Revision.Policy {
-		case appsv1alpha1.TODOSidecarSetInjectRevisionPolicy:
-			if updateStrategy := sidecarSet.Spec.UpdateStrategy; !updateStrategy.Paused && updateStrategy.Selector != nil {
+		case appsv1alpha1.PartialSidecarSetInjectRevisionPolicy:
+			if updateStrategy := sidecarSet.Spec.UpdateStrategy; updateStrategy.Selector != nil {
 				selector, err := util.ValidatedLabelSelectorAsSelector(updateStrategy.Selector)
 				if err != nil {
 					klog.ErrorS(err, "Failed to parse SidecarSet update strategy selector", "sidecarSet", klog.KObj(sidecarSet))

--- a/pkg/webhook/pod/mutating/sidecarset_test.go
+++ b/pkg/webhook/pod/mutating/sidecarset_test.go
@@ -702,7 +702,7 @@ func TestCanarySidecarSetInjection(t *testing.T) {
 			InjectionStrategy: appsv1alpha1.SidecarSetInjectionStrategy{
 				Revision: &appsv1alpha1.SidecarSetInjectRevision{
 					CustomVersion: &revisionID,
-					Policy:        appsv1alpha1.TODOSidecarSetInjectRevisionPolicy,
+					Policy:        appsv1alpha1.PartialSidecarSetInjectRevisionPolicy,
 				},
 			},
 		},

--- a/pkg/webhook/pod/mutating/sidecarset_test.go
+++ b/pkg/webhook/pod/mutating/sidecarset_test.go
@@ -32,12 +32,12 @@ import (
 	"github.com/openkruise/kruise/pkg/util"
 	"github.com/openkruise/kruise/pkg/util/fieldindex"
 	webhookutil "github.com/openkruise/kruise/pkg/webhook/util"
-
 	admissionv1 "k8s.io/api/admission/v1"
 	apps "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	intstrutil "k8s.io/apimachinery/pkg/util/intstr"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -57,7 +57,7 @@ func TestMain(m *testing.M) {
 	utilruntime.Must(apis.AddToScheme(scheme.Scheme))
 
 	code := m.Run()
-	t.Stop()
+	_ = t.Stop()
 	os.Exit(code)
 }
 
@@ -465,10 +465,10 @@ func testPodHasNoMatchedSidecarSet(t *testing.T, sidecarSetIn *appsv1alpha1.Side
 	podIn.Labels["app"] = "doesnt-match"
 	podOut := podIn.DeepCopy()
 	decoder := admission.NewDecoder(scheme.Scheme)
-	client := fake.NewClientBuilder().WithObjects(sidecarSetIn).WithIndex(
+	c := fake.NewClientBuilder().WithObjects(sidecarSetIn).WithIndex(
 		&appsv1alpha1.SidecarSet{}, fieldindex.IndexNameForSidecarSetNamespace, fieldindex.IndexSidecarSet,
 	).Build()
-	podHandler := &PodCreateHandler{Decoder: decoder, Client: client}
+	podHandler := &PodCreateHandler{Decoder: decoder, Client: c}
 	req := newAdmission(admissionv1.Create, runtime.RawExtension{}, runtime.RawExtension{}, "")
 	_, _ = podHandler.sidecarsetMutatingPod(context.Background(), req, podOut)
 
@@ -509,10 +509,10 @@ func doMergeSidecarSecretsTest(t *testing.T, sidecarSetIn *appsv1alpha1.SidecarS
 	podIn.Spec.ImagePullSecrets = podImagePullSecrets
 	podOut := podIn.DeepCopy()
 	decoder := admission.NewDecoder(scheme.Scheme)
-	client := fake.NewClientBuilder().WithObjects(sidecarSetIn).WithIndex(
+	c := fake.NewClientBuilder().WithObjects(sidecarSetIn).WithIndex(
 		&appsv1alpha1.SidecarSet{}, fieldindex.IndexNameForSidecarSetNamespace, fieldindex.IndexSidecarSet,
 	).Build()
-	podHandler := &PodCreateHandler{Decoder: decoder, Client: client}
+	podHandler := &PodCreateHandler{Decoder: decoder, Client: c}
 	req := newAdmission(admissionv1.Create, runtime.RawExtension{}, runtime.RawExtension{}, "")
 	_, _ = podHandler.sidecarsetMutatingPod(context.Background(), req, podOut)
 
@@ -532,10 +532,10 @@ func testInjectionStrategyPaused(t *testing.T, sidecarIn *appsv1alpha1.SidecarSe
 	sidecarPaused := sidecarIn
 	sidecarPaused.Spec.InjectionStrategy.Paused = true
 	decoder := admission.NewDecoder(scheme.Scheme)
-	client := fake.NewClientBuilder().WithObjects(sidecarPaused).WithIndex(
+	c := fake.NewClientBuilder().WithObjects(sidecarPaused).WithIndex(
 		&appsv1alpha1.SidecarSet{}, fieldindex.IndexNameForSidecarSetNamespace, fieldindex.IndexSidecarSet,
 	).Build()
-	podHandler := &PodCreateHandler{Decoder: decoder, Client: client}
+	podHandler := &PodCreateHandler{Decoder: decoder, Client: c}
 	req := newAdmission(admissionv1.Create, runtime.RawExtension{}, runtime.RawExtension{}, "")
 	_, _ = podHandler.sidecarsetMutatingPod(context.Background(), req, podOut)
 
@@ -572,13 +572,13 @@ func TestInjectMetadata(t *testing.T) {
 		},
 	}
 	decoder := admission.NewDecoder(scheme.Scheme)
-	client := fake.NewClientBuilder().WithObjects(demo1, demo2).WithIndex(
+	c := fake.NewClientBuilder().WithObjects(demo1, demo2).WithIndex(
 		&appsv1alpha1.SidecarSet{}, fieldindex.IndexNameForSidecarSetNamespace, fieldindex.IndexSidecarSet,
 	).Build()
 
-	podHandler := &PodCreateHandler{Decoder: decoder, Client: client}
+	podHandler := &PodCreateHandler{Decoder: decoder, Client: c}
 	req := newAdmission(admissionv1.Create, runtime.RawExtension{}, runtime.RawExtension{}, "")
-	podHandler.sidecarsetMutatingPod(context.Background(), req, podIn)
+	_, _ = podHandler.sidecarsetMutatingPod(context.Background(), req, podIn)
 	expect := map[string]string{
 		"key1": `{"envoy":2,"log-agent":1}`,
 		"key":  "envoy=1,log=2",
@@ -645,10 +645,10 @@ func testInjectionStrategyRevision(t *testing.T, env []client.Object) {
 	podIn := pod1.DeepCopy()
 	podOut := podIn.DeepCopy()
 	decoder := admission.NewDecoder(scheme.Scheme)
-	client := fake.NewClientBuilder().WithObjects(env...).WithIndex(
+	c := fake.NewClientBuilder().WithObjects(env...).WithIndex(
 		&appsv1alpha1.SidecarSet{}, fieldindex.IndexNameForSidecarSetNamespace, fieldindex.IndexSidecarSet,
 	).Build()
-	podHandler := &PodCreateHandler{Decoder: decoder, Client: client}
+	podHandler := &PodCreateHandler{Decoder: decoder, Client: c}
 	req := newAdmission(admissionv1.Create, runtime.RawExtension{}, runtime.RawExtension{}, "")
 	_, err := podHandler.sidecarsetMutatingPod(context.Background(), req, podOut)
 	if err != nil {
@@ -676,7 +676,7 @@ func TestCanarySidecarSetInjection(t *testing.T) {
 
 	// a canary sidecarset contains both updatestrategy.selector and injectionstrategy.revision
 	revisionID := fmt.Sprintf("%s-12345", sidecarSetName)
-	sidecarSetCanary := &appsv1alpha1.SidecarSet{
+	sidecarSet := &appsv1alpha1.SidecarSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: sidecarSetName,
 		},
@@ -702,7 +702,7 @@ func TestCanarySidecarSetInjection(t *testing.T) {
 			InjectionStrategy: appsv1alpha1.SidecarSetInjectionStrategy{
 				Revision: &appsv1alpha1.SidecarSetInjectRevision{
 					CustomVersion: &revisionID,
-					Policy:        appsv1alpha1.AlwaysSidecarSetInjectRevisionPolicy,
+					Policy:        appsv1alpha1.TODOSidecarSetInjectRevisionPolicy,
 				},
 			},
 		},
@@ -771,36 +771,119 @@ func TestCanarySidecarSetInjection(t *testing.T) {
 		},
 	}
 
-	decoder := admission.NewDecoder(scheme.Scheme)
-	testClient := fake.NewClientBuilder().WithObjects(revision, sidecarSetCanary).WithIndex(
-		&appsv1alpha1.SidecarSet{}, fieldindex.IndexNameForSidecarSetNamespace, fieldindex.IndexSidecarSet,
-	).Build()
-	podHandler := &PodCreateHandler{Decoder: decoder, Client: testClient}
-	req := newAdmission(admissionv1.Create, runtime.RawExtension{}, runtime.RawExtension{}, "")
-	if _, err := podHandler.sidecarsetMutatingPod(context.Background(), req, stablePod); err != nil {
-		t.Fatalf("failed to mutating pod, err: %v", err)
+	tests := []struct {
+		name          string
+		getPod        func() *corev1.Pod
+		getSidecarSet func() *appsv1alpha1.SidecarSet
+		noHistory     bool
+		expectImage   string
+		expectErr     bool
+	}{
+		{
+			name:          "stable pod",
+			getPod:        stablePod.DeepCopy,
+			getSidecarSet: sidecarSet.DeepCopy,
+			expectImage:   stableImage,
+		},
+		{
+			name:          "canary without partition",
+			getPod:        canaryPod.DeepCopy,
+			getSidecarSet: sidecarSet.DeepCopy,
+			expectImage:   canaryImage,
+		},
+		{
+			name:   "canary with partition 100%",
+			getPod: canaryPod.DeepCopy,
+			getSidecarSet: func() *appsv1alpha1.SidecarSet {
+				ss := sidecarSet.DeepCopy()
+				percent := intstrutil.FromString("100%")
+				ss.Spec.UpdateStrategy.Partition = &percent
+				return ss
+			},
+			expectImage: stableImage,
+		},
+		{
+			name:   "canary with partition 0%",
+			getPod: canaryPod.DeepCopy,
+			getSidecarSet: func() *appsv1alpha1.SidecarSet {
+				ss := sidecarSet.DeepCopy()
+				percent := intstrutil.FromString("0%")
+				ss.Spec.UpdateStrategy.Partition = &percent
+				return ss
+			},
+			expectImage: canaryImage,
+		},
+		{
+			name:   "canary with bad partition",
+			getPod: canaryPod.DeepCopy,
+			getSidecarSet: func() *appsv1alpha1.SidecarSet {
+				ss := sidecarSet.DeepCopy()
+				percent := intstrutil.FromString("abc%")
+				ss.Spec.UpdateStrategy.Partition = &percent
+				return ss
+			},
+			expectErr: true,
+		},
+		{
+			name:          "canary no history",
+			getPod:        canaryPod.DeepCopy,
+			getSidecarSet: sidecarSet.DeepCopy,
+			noHistory:     true,
+			expectErr:     true,
+		},
+		{
+			name:   "canary with bad selector",
+			getPod: canaryPod.DeepCopy,
+			getSidecarSet: func() *appsv1alpha1.SidecarSet {
+				ss := sidecarSet.DeepCopy()
+				ss.Spec.UpdateStrategy.Selector = &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      "somekey",
+							Operator: "badOp",
+						},
+					},
+				}
+				return ss
+			},
+			expectErr: true,
+		},
 	}
-	if _, err := podHandler.sidecarsetMutatingPod(context.Background(), req, canaryPod); err != nil {
-		t.Fatalf("failed to mutating pod, err: %v", err)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			decoder := admission.NewDecoder(scheme.Scheme)
+			builder := fake.NewClientBuilder().WithObjects(test.getSidecarSet()).WithIndex(
+				&appsv1alpha1.SidecarSet{}, fieldindex.IndexNameForSidecarSetNamespace, fieldindex.IndexSidecarSet,
+			)
+			if !test.noHistory {
+				builder.WithObjects(revision)
+			}
+			testClient := builder.Build()
+			podHandler := &PodCreateHandler{Decoder: decoder, Client: testClient}
+			req := newAdmission(admissionv1.Create, runtime.RawExtension{}, runtime.RawExtension{}, "")
+			pod := test.getPod()
+			if _, err := podHandler.sidecarsetMutatingPod(context.Background(), req, pod); err != nil {
+				if test.expectErr {
+					return
+				}
+				t.Fatalf("failed to mutating pod, err: %v", err)
+			}
+			if len(pod.Spec.Containers) != 2 || pod.Spec.Containers[1].Image != test.expectImage {
+				t.Fatalf("inject sidecar failed")
+			}
+			t.Logf("sidecar image: %s", pod.Spec.Containers[1].Image)
+		})
 	}
-	if len(stablePod.Spec.Containers) != 2 || stablePod.Spec.Containers[1].Image != stableImage {
-		t.Fatalf("inject stable sidecar failed")
-	}
-	fmt.Printf("stable sidecar image: %s\n", stablePod.Spec.Containers[1].Image)
-	if len(canaryPod.Spec.Containers) != 2 || canaryPod.Spec.Containers[1].Image != canaryImage {
-		t.Fatalf("inject canary sidecar failed")
-	}
-	fmt.Printf("canary sidecar image: %s\n", canaryPod.Spec.Containers[1].Image)
 }
 
 func testSidecarSetPodInjectPolicy(t *testing.T, sidecarSetIn *appsv1alpha1.SidecarSet) {
 	podIn := pod1.DeepCopy()
 	decoder := admission.NewDecoder(scheme.Scheme)
-	client := fake.NewClientBuilder().WithObjects(sidecarSetIn).WithIndex(
+	c := fake.NewClientBuilder().WithObjects(sidecarSetIn).WithIndex(
 		&appsv1alpha1.SidecarSet{}, fieldindex.IndexNameForSidecarSetNamespace, fieldindex.IndexSidecarSet,
 	).Build()
 	podOut := podIn.DeepCopy()
-	podHandler := &PodCreateHandler{Decoder: decoder, Client: client}
+	podHandler := &PodCreateHandler{Decoder: decoder, Client: c}
 	req := newAdmission(admissionv1.Create, runtime.RawExtension{}, runtime.RawExtension{}, "")
 	_, err := podHandler.sidecarsetMutatingPod(context.Background(), req, podOut)
 	if err != nil {
@@ -875,11 +958,11 @@ func testSidecarVolumesAppend(t *testing.T, sidecarSetIn *appsv1alpha1.SidecarSe
 	podIn := pod1.DeepCopy()
 
 	decoder := admission.NewDecoder(scheme.Scheme)
-	client := fake.NewClientBuilder().WithObjects(sidecarSetIn).WithIndex(
+	c := fake.NewClientBuilder().WithObjects(sidecarSetIn).WithIndex(
 		&appsv1alpha1.SidecarSet{}, fieldindex.IndexNameForSidecarSetNamespace, fieldindex.IndexSidecarSet,
 	).Build()
 	podOut := podIn.DeepCopy()
-	podHandler := &PodCreateHandler{Decoder: decoder, Client: client}
+	podHandler := &PodCreateHandler{Decoder: decoder, Client: c}
 	req := newAdmission(admissionv1.Create, runtime.RawExtension{}, runtime.RawExtension{}, "")
 	_, err := podHandler.sidecarsetMutatingPod(context.Background(), req, podOut)
 	if err != nil {
@@ -1030,11 +1113,11 @@ func testPodVolumeMountsAppend(t *testing.T, sidecarSetIn *appsv1alpha1.SidecarS
 		t.Run(cs.name, func(t *testing.T) {
 			podIn := cs.getPod()
 			decoder := admission.NewDecoder(scheme.Scheme)
-			client := fake.NewClientBuilder().WithObjects(cs.getSidecarSets()).WithIndex(
+			c := fake.NewClientBuilder().WithObjects(cs.getSidecarSets()).WithIndex(
 				&appsv1alpha1.SidecarSet{}, fieldindex.IndexNameForSidecarSetNamespace, fieldindex.IndexSidecarSet,
 			).Build()
 			podOut := podIn.DeepCopy()
-			podHandler := &PodCreateHandler{Decoder: decoder, Client: client}
+			podHandler := &PodCreateHandler{Decoder: decoder, Client: c}
 			req := newAdmission(admissionv1.Create, runtime.RawExtension{}, runtime.RawExtension{}, "")
 			_, err := podHandler.sidecarsetMutatingPod(context.Background(), req, podOut)
 			if err != nil {
@@ -1077,11 +1160,11 @@ func testSidecarSetTransferEnv(t *testing.T, sidecarSetIn *appsv1alpha1.SidecarS
 	podIn := pod1.DeepCopy()
 	sidecarSetIn.Spec.InitContainers[0].PodInjectPolicy = ""
 	decoder := admission.NewDecoder(scheme.Scheme)
-	client := fake.NewClientBuilder().WithObjects(sidecarSetIn).WithIndex(
+	c := fake.NewClientBuilder().WithObjects(sidecarSetIn).WithIndex(
 		&appsv1alpha1.SidecarSet{}, fieldindex.IndexNameForSidecarSetNamespace, fieldindex.IndexSidecarSet,
 	).Build()
 	podOut := podIn.DeepCopy()
-	podHandler := &PodCreateHandler{Decoder: decoder, Client: client}
+	podHandler := &PodCreateHandler{Decoder: decoder, Client: c}
 	req := newAdmission(admissionv1.Create, runtime.RawExtension{}, runtime.RawExtension{}, "")
 	_, err := podHandler.sidecarsetMutatingPod(context.Background(), req, podOut)
 	if err != nil {
@@ -1113,11 +1196,11 @@ func testSidecarSetHashInject(t *testing.T, sidecarSetIn1 *appsv1alpha1.SidecarS
 	sidecarSetIn3 := sidecarSet3.DeepCopy()
 
 	decoder := admission.NewDecoder(scheme.Scheme)
-	client := fake.NewClientBuilder().WithObjects(sidecarSetIn1, sidecarSetIn2, sidecarSetIn3).WithIndex(
+	c := fake.NewClientBuilder().WithObjects(sidecarSetIn1, sidecarSetIn2, sidecarSetIn3).WithIndex(
 		&appsv1alpha1.SidecarSet{}, fieldindex.IndexNameForSidecarSetNamespace, fieldindex.IndexSidecarSet,
 	).Build()
 	podOut := podIn.DeepCopy()
-	podHandler := &PodCreateHandler{Decoder: decoder, Client: client}
+	podHandler := &PodCreateHandler{Decoder: decoder, Client: c}
 	req := newAdmission(admissionv1.Create, runtime.RawExtension{}, runtime.RawExtension{}, "")
 	_, err := podHandler.sidecarsetMutatingPod(context.Background(), req, podOut)
 	if err != nil {
@@ -1146,11 +1229,11 @@ func TestSidecarSetNameInject(t *testing.T) {
 func testSidecarSetNameInject(t *testing.T, sidecarSetIn1, sidecarSetIn3 *appsv1alpha1.SidecarSet) {
 	podIn := pod1.DeepCopy()
 	decoder := admission.NewDecoder(scheme.Scheme)
-	client := fake.NewClientBuilder().WithObjects(sidecarSetIn1, sidecarSetIn3).WithIndex(
+	c := fake.NewClientBuilder().WithObjects(sidecarSetIn1, sidecarSetIn3).WithIndex(
 		&appsv1alpha1.SidecarSet{}, fieldindex.IndexNameForSidecarSetNamespace, fieldindex.IndexSidecarSet,
 	).Build()
 	podOut := podIn.DeepCopy()
-	podHandler := &PodCreateHandler{Decoder: decoder, Client: client}
+	podHandler := &PodCreateHandler{Decoder: decoder, Client: c}
 	req := newAdmission(admissionv1.Create, runtime.RawExtension{}, runtime.RawExtension{}, "")
 	_, err := podHandler.sidecarsetMutatingPod(context.Background(), req, podOut)
 	if err != nil {
@@ -1376,11 +1459,11 @@ func TestInjectInitContainer(t *testing.T) {
 		t.Run(cs.name, func(t *testing.T) {
 			decoder := admission.NewDecoder(scheme.Scheme)
 			ss := cs.getSidecarSets()
-			client := fake.NewClientBuilder().WithObjects(ss[0], ss[1]).WithIndex(
+			c := fake.NewClientBuilder().WithObjects(ss[0], ss[1]).WithIndex(
 				&appsv1alpha1.SidecarSet{}, fieldindex.IndexNameForSidecarSetNamespace, fieldindex.IndexSidecarSet,
 			).Build()
 			pod := cs.getPod()
-			podHandler := &PodCreateHandler{Decoder: decoder, Client: client}
+			podHandler := &PodCreateHandler{Decoder: decoder, Client: c}
 			req := newAdmission(admissionv1.Create, runtime.RawExtension{}, runtime.RawExtension{}, "")
 			_, err := podHandler.sidecarsetMutatingPod(context.Background(), req, pod)
 			if err != nil {

--- a/pkg/webhook/pod/mutating/sidecarset_test.go
+++ b/pkg/webhook/pod/mutating/sidecarset_test.go
@@ -848,6 +848,18 @@ func TestCanarySidecarSetInjection(t *testing.T) {
 			},
 			expectErr: true,
 		},
+		{
+			name:   "canary paused",
+			getPod: canaryPod.DeepCopy,
+			getSidecarSet: func() *appsv1alpha1.SidecarSet {
+				ss := sidecarSet.DeepCopy()
+				percent := intstrutil.FromString("0%")
+				ss.Spec.UpdateStrategy.Partition = &percent
+				ss.Spec.UpdateStrategy.Paused = true
+				return ss
+			},
+			expectImage: stableImage,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/pkg/webhook/sidecarset/validating/sidecarset_create_update_handler.go
+++ b/pkg/webhook/sidecarset/validating/sidecarset_create_update_handler.go
@@ -209,7 +209,9 @@ func (h *SidecarSetCreateUpdateHandler) validateSidecarSetInjectionStrategy(obj 
 			errList = append(errList, field.Invalid(field.NewPath("revision").Child("policy"), revisionInfo, fmt.Sprintf("Invalid policy %v, supported: [%s, %s]",
 				revisionInfo.Policy, appsv1alpha1.AlwaysSidecarSetInjectRevisionPolicy, appsv1alpha1.PartialSidecarSetInjectRevisionPolicy)))
 		}
-
+		if obj.Spec.UpdateStrategy.Partition != nil && obj.Spec.UpdateStrategy.Selector != nil {
+			errList = append(errList, field.Invalid(field.NewPath("updateStrategy"), obj.Spec.UpdateStrategy, "Partition and Selector cannot be used together"))
+		}
 	}
 	return errList
 }

--- a/pkg/webhook/sidecarset/validating/sidecarset_create_update_handler.go
+++ b/pkg/webhook/sidecarset/validating/sidecarset_create_update_handler.go
@@ -73,7 +73,7 @@ type SidecarSetCreateUpdateHandler struct {
 	Decoder *admission.Decoder
 }
 
-func (h *SidecarSetCreateUpdateHandler) validatingSidecarSetFn(ctx context.Context, obj *appsv1alpha1.SidecarSet, older *appsv1alpha1.SidecarSet) (bool, string, error) {
+func (h *SidecarSetCreateUpdateHandler) validatingSidecarSetFn(_ context.Context, obj *appsv1alpha1.SidecarSet, older *appsv1alpha1.SidecarSet) (bool, string, error) {
 	allErrs := h.validateSidecarSet(obj, older)
 	if len(allErrs) != 0 {
 		return false, "", allErrs.ToAggregate()
@@ -102,7 +102,7 @@ func (h *SidecarSetCreateUpdateHandler) validateSidecarSet(obj *appsv1alpha1.Sid
 	return allErrs
 }
 
-func validateSidecarSetName(name string, prefix bool) (allErrs []string) {
+func validateSidecarSetName(name string, _ bool) (allErrs []string) {
 	if !validateSidecarSetNameRegex.MatchString(name) {
 		allErrs = append(allErrs, validationutil.RegexError(validateSidecarSetNameMsg, validSidecarSetNameFmt, "example-com"))
 	}
@@ -188,7 +188,7 @@ func validateSelector(selector *metav1.LabelSelector, fldPath *field.Path) field
 	return allErrs
 }
 
-func (h *SidecarSetCreateUpdateHandler) validateSidecarSetInjectionStrategy(obj *appsv1alpha1.SidecarSet, fldPath *field.Path) field.ErrorList {
+func (h *SidecarSetCreateUpdateHandler) validateSidecarSetInjectionStrategy(obj *appsv1alpha1.SidecarSet, _ *field.Path) field.ErrorList {
 	errList := field.ErrorList{}
 	revisionInfo := obj.Spec.InjectionStrategy.Revision
 
@@ -204,9 +204,10 @@ func (h *SidecarSetCreateUpdateHandler) validateSidecarSetInjectionStrategy(obj 
 		}
 
 		switch revisionInfo.Policy {
-		case "", appsv1alpha1.AlwaysSidecarSetInjectRevisionPolicy:
+		case "", appsv1alpha1.AlwaysSidecarSetInjectRevisionPolicy, appsv1alpha1.TODOSidecarSetInjectRevisionPolicy:
 		default:
-			errList = append(errList, field.Invalid(field.NewPath("revision").Child("policy"), revisionInfo, fmt.Sprintf("Invalid policy %v, only support 'Always' currently", revisionInfo.Policy)))
+			errList = append(errList, field.Invalid(field.NewPath("revision").Child("policy"), revisionInfo, fmt.Sprintf("Invalid policy %v, supported: [%s, %s]",
+				revisionInfo.Policy, appsv1alpha1.AlwaysSidecarSetInjectRevisionPolicy, appsv1alpha1.TODOSidecarSetInjectRevisionPolicy)))
 		}
 
 	}

--- a/pkg/webhook/sidecarset/validating/sidecarset_create_update_handler.go
+++ b/pkg/webhook/sidecarset/validating/sidecarset_create_update_handler.go
@@ -28,6 +28,7 @@ import (
 	"github.com/openkruise/kruise/pkg/control/sidecarcontrol"
 	"github.com/openkruise/kruise/pkg/util"
 	webhookutil "github.com/openkruise/kruise/pkg/webhook/util"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	admissionv1 "k8s.io/api/admission/v1"
 	v1 "k8s.io/api/core/v1"
@@ -209,17 +210,28 @@ func (h *SidecarSetCreateUpdateHandler) validateSidecarSetInjectionStrategy(obj 
 			errList = append(errList, field.Invalid(field.NewPath("revision").Child("policy"), revisionInfo, fmt.Sprintf("Invalid policy %v, supported: [%s, %s]",
 				revisionInfo.Policy, appsv1alpha1.AlwaysSidecarSetInjectRevisionPolicy, appsv1alpha1.PartialSidecarSetInjectRevisionPolicy)))
 		}
-		if obj.Spec.UpdateStrategy.Partition != nil && obj.Spec.UpdateStrategy.Selector != nil {
-			errList = append(errList, field.Invalid(field.NewPath("updateStrategy"), obj.Spec.UpdateStrategy, "Partition and Selector cannot be used together"))
-		}
 	}
 	return errList
+}
+
+// intStrIsSet returns true when the intstr is not nil and not the default 0 value.
+func intStrIsSet(i *intstr.IntOrString) bool {
+	if i == nil {
+		return false
+	}
+	if i.Type == intstr.String {
+		return true
+	}
+	return i.IntVal != 0
 }
 
 func validateSidecarSetUpdateStrategy(strategy *appsv1alpha1.SidecarSetUpdateStrategy, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	// if SidecarSet update strategy is RollingUpdate
 	if strategy.Type == appsv1alpha1.RollingUpdateSidecarSetStrategyType {
+		if intStrIsSet(strategy.Partition) && strategy.Selector != nil {
+			allErrs = append(allErrs, field.Invalid(field.NewPath("updateStrategy"), fmt.Sprintf("%++v", strategy), "Partition and Selector cannot be used together"))
+		}
 		if strategy.Selector != nil {
 			allErrs = append(allErrs, validateSelector(strategy.Selector, fldPath.Child("selector"))...)
 		}

--- a/pkg/webhook/sidecarset/validating/sidecarset_create_update_handler.go
+++ b/pkg/webhook/sidecarset/validating/sidecarset_create_update_handler.go
@@ -204,10 +204,10 @@ func (h *SidecarSetCreateUpdateHandler) validateSidecarSetInjectionStrategy(obj 
 		}
 
 		switch revisionInfo.Policy {
-		case "", appsv1alpha1.AlwaysSidecarSetInjectRevisionPolicy, appsv1alpha1.TODOSidecarSetInjectRevisionPolicy:
+		case "", appsv1alpha1.AlwaysSidecarSetInjectRevisionPolicy, appsv1alpha1.PartialSidecarSetInjectRevisionPolicy:
 		default:
 			errList = append(errList, field.Invalid(field.NewPath("revision").Child("policy"), revisionInfo, fmt.Sprintf("Invalid policy %v, supported: [%s, %s]",
-				revisionInfo.Policy, appsv1alpha1.AlwaysSidecarSetInjectRevisionPolicy, appsv1alpha1.TODOSidecarSetInjectRevisionPolicy)))
+				revisionInfo.Policy, appsv1alpha1.AlwaysSidecarSetInjectRevisionPolicy, appsv1alpha1.PartialSidecarSetInjectRevisionPolicy)))
 		}
 
 	}

--- a/test/e2e/apps/sidecarset.go
+++ b/test/e2e/apps/sidecarset.go
@@ -1663,7 +1663,7 @@ var _ = SIGDescribe("SidecarSet", func() {
 			}
 			sidecarSetIn.Spec.InjectionStrategy.Revision = &appsv1alpha1.SidecarSetInjectRevision{
 				CustomVersion: ptr.To("0"),
-				Policy:        appsv1alpha1.TODOSidecarSetInjectRevisionPolicy,
+				Policy:        appsv1alpha1.PartialSidecarSetInjectRevisionPolicy,
 			}
 			sidecarSetIn.Labels = map[string]string{
 				appsv1alpha1.SidecarSetCustomVersionLabel: "1",

--- a/test/e2e/apps/sidecarset.go
+++ b/test/e2e/apps/sidecarset.go
@@ -30,6 +30,7 @@ import (
 	"github.com/openkruise/kruise/pkg/util"
 	"github.com/openkruise/kruise/pkg/util/configuration"
 	"github.com/openkruise/kruise/test/e2e/framework"
+	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
 
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
@@ -74,7 +75,7 @@ var _ = SIGDescribe("SidecarSet", func() {
 			// sidecarSet no matched pods
 			sidecarSet.Spec.Selector.MatchLabels["app"] = "nomatched"
 			ginkgo.By(fmt.Sprintf("Creating SidecarSet %s", sidecarSet.Name))
-			tester.CreateSidecarSet(sidecarSet)
+			_, _ = tester.CreateSidecarSet(sidecarSet)
 			time.Sleep(time.Second)
 
 			// create deployment
@@ -124,14 +125,14 @@ var _ = SIGDescribe("SidecarSet", func() {
 				},
 			}
 			ginkgo.By(fmt.Sprintf("Creating SidecarSet %s with volumes.downwardAPI", sidecarSet.Name))
-			tester.CreateSidecarSet(sidecarSet)
+			_, _ = tester.CreateSidecarSet(sidecarSet)
 		})
 
 		framework.ConformanceIt("sidecarSet inject pod sidecar container", func() {
 			// create sidecarSet
 			sidecarSet := tester.NewBaseSidecarSet(ns)
 			ginkgo.By(fmt.Sprintf("Creating SidecarSet %s", sidecarSet.Name))
-			tester.CreateSidecarSet(sidecarSet)
+			_, _ = tester.CreateSidecarSet(sidecarSet)
 			time.Sleep(time.Second)
 
 			// create deployment
@@ -214,7 +215,7 @@ var _ = SIGDescribe("SidecarSet", func() {
 				ginkgo.By(cs.name)
 				sidecarSetIn := cs.getSidecarSets()
 				ginkgo.By(fmt.Sprintf("Creating SidecarSet %s", sidecarSetIn.Name))
-				tester.CreateSidecarSet(sidecarSetIn)
+				_, _ = tester.CreateSidecarSet(sidecarSetIn)
 				time.Sleep(time.Second)
 
 				deploymentIn := cs.getDeployment()
@@ -317,7 +318,7 @@ var _ = SIGDescribe("SidecarSet", func() {
 				ginkgo.By(cs.name)
 				sidecarSetIn := cs.getSidecarSets()
 				ginkgo.By(fmt.Sprintf("Creating SidecarSet %s", sidecarSetIn.Name))
-				tester.CreateSidecarSet(sidecarSetIn)
+				_, _ = tester.CreateSidecarSet(sidecarSetIn)
 				time.Sleep(time.Second)
 
 				deploymentIn := cs.getDeployment()
@@ -375,7 +376,7 @@ var _ = SIGDescribe("SidecarSet", func() {
 				},
 			}
 			ginkgo.By(fmt.Sprintf("Creating SidecarSet %s", sidecarSetIn.Name))
-			tester.CreateSidecarSet(sidecarSetIn)
+			_, _ = tester.CreateSidecarSet(sidecarSetIn)
 			time.Sleep(time.Second)
 
 			// create deployment
@@ -447,7 +448,7 @@ var _ = SIGDescribe("SidecarSet", func() {
 				},
 			}
 			ginkgo.By(fmt.Sprintf("Creating SidecarSet %s", sidecarSetIn.Name))
-			tester.CreateSidecarSet(sidecarSetIn)
+			_, _ = tester.CreateSidecarSet(sidecarSetIn)
 			time.Sleep(time.Second)
 
 			// create deployment
@@ -522,7 +523,7 @@ var _ = SIGDescribe("SidecarSet", func() {
 				},
 			}
 			ginkgo.By(fmt.Sprintf("Creating SidecarSet %s", sidecarSetIn.Name))
-			tester.CreateSidecarSet(sidecarSetIn)
+			_, _ = tester.CreateSidecarSet(sidecarSetIn)
 			time.Sleep(time.Second)
 
 			// create deployment
@@ -688,7 +689,9 @@ var _ = SIGDescribe("SidecarSet", func() {
 			_, err := c.CoreV1().ConfigMaps(cm.Namespace).Create(context.TODO(), cm, metav1.CreateOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			time.Sleep(time.Second)
-			defer c.CoreV1().ConfigMaps(cm.Namespace).Delete(context.TODO(), cm.Name, metav1.DeleteOptions{})
+			defer func(maps v1core.ConfigMapInterface, ctx context.Context, name string, opts metav1.DeleteOptions) {
+				_ = maps.Delete(ctx, name, opts)
+			}(c.CoreV1().ConfigMaps(cm.Namespace), context.TODO(), cm.Name, metav1.DeleteOptions{})
 
 			// create sidecarSet again
 			sidecarSetIn, err = tester.CreateSidecarSet(sidecarSetIn)
@@ -697,7 +700,7 @@ var _ = SIGDescribe("SidecarSet", func() {
 
 			// create deployment
 			deploymentIn := tester.NewBaseDeployment(ns)
-			deploymentIn.Spec.Replicas = utilpointer.Int32Ptr(2)
+			deploymentIn.Spec.Replicas = ptr.To(int32(2))
 			ginkgo.By(fmt.Sprintf("Creating Deployment(%s/%s)", deploymentIn.Namespace, deploymentIn.Name))
 			tester.CreateDeployment(deploymentIn)
 			// check pods
@@ -776,7 +779,7 @@ var _ = SIGDescribe("SidecarSet", func() {
 
 			// create deployment
 			deploymentIn := tester.NewBaseDeployment(ns)
-			deploymentIn.Spec.Replicas = utilpointer.Int32Ptr(2)
+			deploymentIn.Spec.Replicas = ptr.To(int32(2))
 			ginkgo.By(fmt.Sprintf("Creating Deployment(%s/%s)", deploymentIn.Namespace, deploymentIn.Name))
 			tester.CreateDeployment(deploymentIn)
 
@@ -843,7 +846,7 @@ var _ = SIGDescribe("SidecarSet", func() {
 
 			// create deployment
 			deploymentIn := tester.NewBaseDeployment(ns)
-			deploymentIn.Spec.Replicas = utilpointer.Int32Ptr(2)
+			deploymentIn.Spec.Replicas = ptr.To(int32(2))
 			ginkgo.By(fmt.Sprintf("Creating Deployment(%s/%s)", deploymentIn.Namespace, deploymentIn.Name))
 			tester.CreateDeployment(deploymentIn)
 
@@ -944,7 +947,7 @@ var _ = SIGDescribe("SidecarSet", func() {
 
 			// create deployment
 			deploymentIn := tester.NewBaseDeployment(ns)
-			deploymentIn.Spec.Replicas = utilpointer.Int32Ptr(1)
+			deploymentIn.Spec.Replicas = ptr.To(int32(1))
 			ginkgo.By(fmt.Sprintf("Creating Deployment(%s/%s)", deploymentIn.Namespace, deploymentIn.Name))
 			tester.CreateDeployment(deploymentIn)
 
@@ -1002,7 +1005,7 @@ var _ = SIGDescribe("SidecarSet", func() {
 			}
 
 			// scale deployment replicas=2
-			deploymentIn.Spec.Replicas = utilpointer.Int32Ptr(2)
+			deploymentIn.Spec.Replicas = ptr.To(int32(2))
 			tester.UpdateDeployment(deploymentIn)
 			time.Sleep(time.Second)
 
@@ -1046,7 +1049,7 @@ var _ = SIGDescribe("SidecarSet", func() {
 
 			// create deployment
 			deploymentIn := tester.NewBaseDeployment(ns)
-			deploymentIn.Spec.Replicas = utilpointer.Int32Ptr(2)
+			deploymentIn.Spec.Replicas = ptr.To(int32(2))
 			ginkgo.By(fmt.Sprintf("Creating Deployment(%s/%s)", deploymentIn.Namespace, deploymentIn.Name))
 			tester.CreateDeployment(deploymentIn)
 
@@ -1122,7 +1125,7 @@ var _ = SIGDescribe("SidecarSet", func() {
 
 			// create deployment
 			deploymentIn := tester.NewBaseDeployment(ns)
-			deploymentIn.Spec.Replicas = utilpointer.Int32Ptr(2)
+			deploymentIn.Spec.Replicas = ptr.To(int32(2))
 			ginkgo.By(fmt.Sprintf("Creating Deployment(%s/%s)", deploymentIn.Namespace, deploymentIn.Name))
 			tester.CreateDeployment(deploymentIn)
 			// update sidecarSet sidecar container
@@ -1166,7 +1169,7 @@ var _ = SIGDescribe("SidecarSet", func() {
 
 			// create deployment
 			deploymentIn := tester.NewBaseDeployment(ns)
-			deploymentIn.Spec.Replicas = utilpointer.Int32Ptr(2)
+			deploymentIn.Spec.Replicas = ptr.To(int32(2))
 			ginkgo.By(fmt.Sprintf("Creating Deployment(%s/%s)", deploymentIn.Namespace, deploymentIn.Name))
 			tester.CreateDeployment(deploymentIn)
 			// update pod[0] labels[canary.release] = true
@@ -1239,7 +1242,7 @@ var _ = SIGDescribe("SidecarSet", func() {
 
 			// create deployment
 			deploymentIn := tester.NewBaseDeployment(ns)
-			deploymentIn.Spec.Replicas = utilpointer.Int32Ptr(2)
+			deploymentIn.Spec.Replicas = ptr.To(int32(2))
 			ginkgo.By(fmt.Sprintf("Creating Deployment(%s/%s)", deploymentIn.Namespace, deploymentIn.Name))
 			tester.CreateDeployment(deploymentIn)
 
@@ -1294,7 +1297,7 @@ var _ = SIGDescribe("SidecarSet", func() {
 
 			// create deployment
 			deploymentIn := tester.NewBaseDeployment(ns)
-			deploymentIn.Spec.Replicas = utilpointer.Int32Ptr(4)
+			deploymentIn.Spec.Replicas = ptr.To(int32(4))
 			ginkgo.By(fmt.Sprintf("Creating Deployment(%s/%s)", deploymentIn.Namespace, deploymentIn.Name))
 			tester.CreateDeployment(deploymentIn)
 
@@ -1344,7 +1347,7 @@ var _ = SIGDescribe("SidecarSet", func() {
 
 			// create deployment
 			deploymentIn := tester.NewBaseDeployment(ns)
-			deploymentIn.Spec.Replicas = utilpointer.Int32Ptr(1)
+			deploymentIn.Spec.Replicas = ptr.To(int32(1))
 			ginkgo.By(fmt.Sprintf("Creating Deployment(%s/%s)", deploymentIn.Namespace, deploymentIn.Name))
 			tester.CreateDeployment(deploymentIn)
 
@@ -1547,7 +1550,7 @@ var _ = SIGDescribe("SidecarSet", func() {
 
 			// create deployment
 			deploymentIn := tester.NewBaseDeployment(ns)
-			deploymentIn.Spec.Replicas = utilpointer.Int32Ptr(1)
+			deploymentIn.Spec.Replicas = ptr.To(int32(1))
 			ginkgo.By(fmt.Sprintf("Creating Deployment(%s.%s)", deploymentIn.Namespace, deploymentIn.Name))
 			tester.CreateDeployment(deploymentIn)
 
@@ -1602,7 +1605,6 @@ var _ = SIGDescribe("SidecarSet", func() {
 			sidecarSetIn.Spec.UpdateStrategy.Type = appsv1alpha1.RollingUpdateSidecarSetStrategyType
 			ginkgo.By(fmt.Sprintf("Creating SidecarSet %s", sidecarSetIn.Name))
 			sidecarSetIn, _ = tester.CreateSidecarSet(sidecarSetIn)
-			time.Sleep(time.Second)
 
 			// create deployment
 			deploymentStable, deploymentCanary := tester.NewBaseDeployment(ns), tester.NewBaseDeployment(ns)
@@ -1659,7 +1661,10 @@ var _ = SIGDescribe("SidecarSet", func() {
 			sidecarSetIn.Spec.UpdateStrategy.Selector = &metav1.LabelSelector{
 				MatchLabels: map[string]string{"version": "canary"},
 			}
-			sidecarSetIn.Spec.InjectionStrategy.Revision = &appsv1alpha1.SidecarSetInjectRevision{CustomVersion: ptr.To("0")}
+			sidecarSetIn.Spec.InjectionStrategy.Revision = &appsv1alpha1.SidecarSetInjectRevision{
+				CustomVersion: ptr.To("0"),
+				Policy:        appsv1alpha1.TODOSidecarSetInjectRevisionPolicy,
+			}
 			sidecarSetIn.Labels = map[string]string{
 				appsv1alpha1.SidecarSetCustomVersionLabel: "1",
 			}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

Now, SidecarSet supports two policies in `injectionStrategy`:

1. `Always`, which is the default and current policy. Under this policy, all newly created Pods will be injected with the specified revision in `injectionStrategy`.
2. `Partial`, under which only when the Pod is **not** selected by the Selector explicitly configured in `UpdateStrategy` will it be definitely injected with the specified revision. In all other conditions, newly created Pods have a probability of being injected with the latest Sidecar, where the probability is `1 - UpdateStrategy.Partition`. If `Partition` is not a percentage or is not configured, its value is considered to be 0%.


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #1833

### Ⅲ. Describe how to verify it
see the unit tests added

### Ⅳ. Special notes for reviews

