### PR TITLE
Feature: Add context logging to WorkloadSpread

### DIFF
--- a/pkg/controller/workloadspread/reschedule_test.go
+++ b/pkg/controller/workloadspread/reschedule_test.go
@@ -284,7 +284,7 @@ func TestRescheduleSubset(t *testing.T) {
 				},
 			}
 
-			err := reconciler.syncWorkloadSpread(workloadSpread)
+			err := reconciler.syncWorkloadSpread(context.Background(), workloadSpread)
 			if err != nil {
 				t.Fatalf("sync WorkloadSpread failed: %s", err.Error())
 			}

--- a/pkg/controller/workloadspread/workloadspread_controller_test.go
+++ b/pkg/controller/workloadspread/workloadspread_controller_test.go
@@ -725,7 +725,7 @@ func TestSubsetPodDeletionCost(t *testing.T) {
 				recorder: record.NewFakeRecorder(10),
 			}
 
-			err := r.syncSubsetPodDeletionCost(workloadSpread, &workloadSpread.Spec.Subsets[0], cs.subsetIndex, cs.getPods(), 5)
+			err := r.syncSubsetPodDeletionCost(context.Background(), workloadSpread, &workloadSpread.Spec.Subsets[0], cs.subsetIndex, cs.getPods(), 5)
 			if err != nil {
 				t.Fatalf("set pod deletion-cost annotation failed: %s", err.Error())
 			}
@@ -1772,7 +1772,7 @@ func TestWorkloadSpreadReconcile(t *testing.T) {
 				controllerFinder: &controllerfinder.ControllerFinder{Client: fakeClient},
 			}
 
-			err := reconciler.syncWorkloadSpread(workloadSpread)
+			err := reconciler.syncWorkloadSpread(context.Background(), workloadSpread)
 			if err != nil {
 				t.Fatalf("sync WorkloadSpread failed: %s", err.Error())
 			}
@@ -1857,11 +1857,11 @@ func TestUpdateSubsetSequence(t *testing.T) {
 	}
 
 	r := ReconcileWorkloadSpread{}
-	versionedPodMap, subsetsPods, err := r.groupVersionedPods(workloadSpread, pods, 5)
+	versionedPodMap, subsetsPods, err := r.groupVersionedPods(context.Background(), workloadSpread, pods, 5)
 	if err != nil {
 		t.Fatalf("error group pods")
 	}
-	status, _ := r.calculateWorkloadSpreadStatus(workloadSpread, versionedPodMap, subsetsPods, 5)
+	status, _ := r.calculateWorkloadSpreadStatus(context.Background(), workloadSpread, versionedPodMap, subsetsPods, 5)
 	if status == nil {
 		t.Fatalf("error get WorkloadSpread status")
 	} else {

--- a/pkg/controller/workloadspread/workloadspread_controller_utils_test.go
+++ b/pkg/controller/workloadspread/workloadspread_controller_utils_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package workloadspread
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -227,7 +228,7 @@ func TestMatchSubset(t *testing.T) {
 			subset := cs.getSubset()
 			node := cs.getNode()
 			pod := cs.getPod()
-			isMatch, score, err := matchesSubset(pod, node, subset, 0)
+			isMatch, score, err := matchesSubset(context.Background(), pod, node, subset, 0)
 			if err != nil {
 				t.Fatal("unexpected err occurred")
 			}

--- a/pkg/controller/workloadspread/workloadspread_event_handler_test.go
+++ b/pkg/controller/workloadspread/workloadspread_event_handler_test.go
@@ -380,7 +380,7 @@ func TestGetWorkloadSpreadForCloneSet(t *testing.T) {
 				Name:      cs.getCloneSet().Name,
 			}
 			handler := workloadEventHandler{Reader: fakeClient}
-			workloadSpread, _ := handler.getWorkloadSpreadForWorkload(nsn, controllerKruiseKindCS, nil)
+			workloadSpread, _ := handler.getWorkloadSpreadForWorkload(context.Background(), nsn, controllerKruiseKindCS, nil)
 			expectTopology := cs.expectWorkloadSpread()
 
 			if expectTopology == nil {
@@ -505,7 +505,7 @@ func TestGetWorkloadSpreadForDeployment(t *testing.T) {
 				Name:      cs.getDeployment().Name,
 			}
 			handler := workloadEventHandler{Reader: fakeClient}
-			workloadSpread, _ := handler.getWorkloadSpreadForWorkload(nsn, controllerKindDep, nil)
+			workloadSpread, _ := handler.getWorkloadSpreadForWorkload(context.Background(), nsn, controllerKindDep, nil)
 			expectTopology := cs.expectWorkloadSpread()
 
 			if expectTopology == nil {
@@ -607,7 +607,7 @@ func TestGetWorkloadSpreadForJob(t *testing.T) {
 				Name:      cs.getJob().Name,
 			}
 			handler := workloadEventHandler{Reader: fakeClient}
-			workloadSpread, _ := handler.getWorkloadSpreadForWorkload(nsn, controllerKindJob, nil)
+			workloadSpread, _ := handler.getWorkloadSpreadForWorkload(context.Background(), nsn, controllerKindJob, nil)
 			expectTopology := cs.expectWorkloadSpread()
 
 			if expectTopology == nil {
@@ -732,7 +732,7 @@ func TestGetWorkloadSpreadForReplicaSet(t *testing.T) {
 				Name:      cs.getReplicaset().Name,
 			}
 			handler := workloadEventHandler{Reader: fakeClient}
-			workloadSpread, _ := handler.getWorkloadSpreadForWorkload(nsn, controllerKindRS, nil)
+			workloadSpread, _ := handler.getWorkloadSpreadForWorkload(context.Background(), nsn, controllerKindRS, nil)
 			expectTopology := cs.expectWorkloadSpread()
 
 			if expectTopology == nil {
@@ -857,7 +857,7 @@ func TestGetWorkloadSpreadForStatefulSet(t *testing.T) {
 				Name:      cs.getStatefulSet().Name,
 			}
 			handler := workloadEventHandler{Reader: fakeClient}
-			workloadSpread, _ := handler.getWorkloadSpreadForWorkload(nsn, controllerKindSts, nil)
+			workloadSpread, _ := handler.getWorkloadSpreadForWorkload(context.Background(), nsn, controllerKindSts, nil)
 			expectTopology := cs.expectWorkloadSpread()
 
 			if expectTopology == nil {
@@ -982,7 +982,7 @@ func TestGetWorkloadSpreadForAdvancedStatefulSet(t *testing.T) {
 				Name:      cs.getStatefulSet().Name,
 			}
 			handler := workloadEventHandler{Reader: fakeClient}
-			workloadSpread, _ := handler.getWorkloadSpreadForWorkload(nsn, controllerKruiseKindSts, nil)
+			workloadSpread, _ := handler.getWorkloadSpreadForWorkload(context.Background(), nsn, controllerKruiseKindSts, nil)
 			expectTopology := cs.expectWorkloadSpread()
 
 			if expectTopology == nil {

--- a/pkg/util/log.go
+++ b/pkg/util/log.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2025 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"k8s.io/klog/v2"
+)
+
+type loggerContextKey struct{}
+
+func NewLogContext(ctx context.Context) context.Context {
+	return context.WithValue(ctx, loggerContextKey{}, uuid.New().String())
+}
+
+func NewLogContextWithId(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, loggerContextKey{}, id)
+}
+
+func FromLogContext(ctx context.Context) klog.Logger {
+	value := ctx.Value(loggerContextKey{})
+	if value == nil {
+		return klog.Background()
+	}
+	return klog.Background().WithValues("context", value)
+}

--- a/pkg/webhook/pod/mutating/pod_create_update_handler.go
+++ b/pkg/webhook/pod/mutating/pod_create_update_handler.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"github.com/openkruise/kruise/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -46,7 +47,7 @@ var _ admission.Handler = &PodCreateHandler{}
 // Handle handles admission requests.
 func (h *PodCreateHandler) Handle(ctx context.Context, req admission.Request) admission.Response {
 	obj := &corev1.Pod{}
-
+	ctx = util.NewLogContextWithId(ctx, string(req.UID))
 	err := h.Decoder.Decode(req, obj)
 	if err != nil {
 		return admission.Errored(http.StatusBadRequest, err)

--- a/pkg/webhook/workloadspread/validating/workloadspread_validation_test.go
+++ b/pkg/webhook/workloadspread/validating/workloadspread_validation_test.go
@@ -16,6 +16,7 @@ limitations under the License.
 package validating
 
 import (
+	"context"
 	"strconv"
 	"testing"
 
@@ -463,7 +464,7 @@ func TestValidateWorkloadSpreadCreate(t *testing.T) {
 		t.Run("success case "+strconv.Itoa(i), func(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(workloadSpreadDemo).Build()
 			handler.Client = fakeClient
-			if errs := handler.validatingWorkloadSpreadFn(&successCase); len(errs) != 0 {
+			if errs := handler.validatingWorkloadSpreadFn(context.Background(), &successCase); len(errs) != 0 {
 				t.Errorf("expected success: %v", errs)
 			}
 		})
@@ -811,7 +812,7 @@ func TestValidateWorkloadSpreadCreate(t *testing.T) {
 		t.Run(errorCase.name, func(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(workloadSpreadDemo).Build()
 			handler.Client = fakeClient
-			errs := handler.validatingWorkloadSpreadFn(errorCase.getWorkloadSpread())
+			errs := handler.validatingWorkloadSpreadFn(context.Background(), errorCase.getWorkloadSpread())
 			if len(errs) == 0 {
 				t.Errorf("expected failure for %s", errorCase.name)
 			}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
all logs generated by WorkloadSpread (oth the controller and the webhook) are tagged with a context. This tag allows all logs from a single reconcile or mutating operation to be correlated, which looks like:
```text
I0109 03:54:32.927508       1 workloadspread.go:314] "Operation Pod matched WorkloadSpread" context="0fb847f6-2894-4849-b3e3-7d9c20f12c93" operation="Create" podNs="e2e-tests-workloadspread-vknnd" podName="busybox-9tfc8" wsNs="e2e-tests-workloadspread-vknnd" wsName="test-workload-spread"
I0109 03:54:32.928258       1 workloadspread.go:329] "inject Pod subset data for WorkloadSpread" context="0fb847f6-2894-4849-b3e3-7d9c20f12c93" podNs="e2e-tests-workloadspread-vknnd" podName="busybox-9tfc8" suitableSubsetName="zone-a" wsNs="e2e-tests-workloadspread-vknnd" wsName="test-workload-spread"
I0109 03:54:32.928276       1 workloadspread.go:333] "handler operation Pod generatedUID for WorkloadSpread done" context="0fb847f6-2894-4849-b3e3-7d9c20f12c93" operation="Create" podNs="e2e-tests-workloadspread-vknnd" podName="busybox-9tfc8" generatedUID="" wsNs="e2e-tests-workloadspread-vknnd" wsName="test-workload-spread"
I0109 03:54:32.928308       1 workloadspread.go:255] "Cost of handling pod creation by WorkloadSpread" context="0fb847f6-2894-4849-b3e3-7d9c20f12c93" namespace="e2e-tests-workloadspread-vknnd" name="test-workload-spread" cost="853.708µs"
```


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #1878 

### Ⅲ. Describe how to verify it
Just see the logs

### Ⅳ. Special notes for reviews

