### PR TITLE
Fix: issue cri-dockerd runtime not being found

### DIFF
--- a/pkg/daemon/criruntime/factory.go
+++ b/pkg/daemon/criruntime/factory.go
@@ -208,6 +208,8 @@ func detectRuntime(varRunPath string) (cfgs []runtimeConfig) {
 				runtimeRemoteURI: fmt.Sprintf("unix://%s/cri-dockerd.sock", varRunPath),
 			})
 		}
+		// Check if the cri-dockerd runtime socket exists in the expected k3s runtime directory.
+		// If found, append it to the runtime configuration list to ensure k3s can use cri-dockerd.
 		if _, err = os.Stat(fmt.Sprintf("%s/cri-dockerd/cri-dockerd.sock", varRunPath)); err == nil {
 			cfgs = append(cfgs, runtimeConfig{
 				runtimeType:      ContainerRuntimeCommonCRI,

--- a/pkg/daemon/criruntime/factory.go
+++ b/pkg/daemon/criruntime/factory.go
@@ -208,6 +208,12 @@ func detectRuntime(varRunPath string) (cfgs []runtimeConfig) {
 				runtimeRemoteURI: fmt.Sprintf("unix://%s/cri-dockerd.sock", varRunPath),
 			})
 		}
+		if _, err = os.Stat(fmt.Sprintf("%s/cri-dockerd/cri-dockerd.sock", varRunPath)); err == nil {
+			cfgs = append(cfgs, runtimeConfig{
+				runtimeType:      ContainerRuntimeCommonCRI,
+				runtimeRemoteURI: fmt.Sprintf("unix://%s/cri-dockerd/cri-dockerd.sock", varRunPath),
+			})
+		}
 	}
 	return cfgs
 }


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Within this pull request, support for extra case of cri-dockerd.sock location was proposed to add.
```
if _, err = os.Stat(fmt.Sprintf("%s/cri-dockerd/cri-dockerd.sock", varRunPath)); err == nil {
			cfgs = append(cfgs, runtimeConfig{
				runtimeType:      ContainerRuntimeCommonCRI,
				runtimeRemoteURI: fmt.Sprintf("unix://%s/cri-dockerd/cri-dockerd.sock", varRunPath),
			})
		}
```
This change absolutely follows the format how it was done for other runtimes.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE
### Ⅲ. Describe how to verify it
Using k3s with different runtimes at different nodes the issue was that for each runtime a folder made. 
Runtimes location is: /var/run/k3s. Was not able to use cri-dockerd/cri-dockerd.sock before this change.

### Ⅳ. Special notes for reviews
This change absolutely follows the format how it was done for other runtimes.
