### PR TITLE
feat: add fuzz-testing

### DIFF
--- a/apis/apps/v1alpha1/fuzz_test.go
+++ b/apis/apps/v1alpha1/fuzz_test.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2020 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"testing"
+
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
+)
+
+func FuzzResourceDistributionValidation(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		ff := fuzz.NewConsumer(data)
+		rd := &ResourceDistribution{}
+		ff.GenerateStruct(rd)
+
+		_ = rd.Validate()
+	})
+}

--- a/apis/apps/v1alpha1/resourcedistribution_types.go
+++ b/apis/apps/v1alpha1/resourcedistribution_types.go
@@ -16,6 +16,7 @@ package v1alpha1
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
@@ -119,6 +120,21 @@ type ResourceDistributionCondition struct {
 
 	// FailedNamespaces describe all failed namespaces when Status is False
 	FailedNamespaces []string `json:"failedNamespace,omitempty"`
+}
+
+func (rd *ResourceDistribution) Validate() (error field.ErrorList) {
+	var allErrs field.ErrorList
+	// Ensure resource is not empty
+	if len(rd.Spec.Resource.Raw) == 0 {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("spec.resource"), rd.Spec.Resource, "resource must not be empty"))
+	}
+
+	// Ensure at least one target is specified
+	if !rd.Spec.Targets.AllNamespaces && len(rd.Spec.Targets.IncludedNamespaces.List) == 0 && len(rd.Spec.Targets.NamespaceLabelSelector.MatchLabels) == 0 {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("spec.targets"), rd.Spec.Targets, "at least one target namespace must be specified"))
+	}
+
+	return allErrs
 }
 
 type ResourceDistributionConditionType string

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 )
 
 require (
+	github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 // indirect
 	github.com/NYTimes/gziphandler v1.1.1 // indirect
 	github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df // indirect
 	github.com/coreos/go-semver v0.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 cloud.google.com/go v0.112.0 h1:tpFCD7hpHFlQ8yPwT3x+QeXqc2T6+n6T+hmABHfDUSM=
 cloud.google.com/go/compute v1.24.0 h1:phWcR2eWzRJaL/kOiJwfFsPs4BaKq1j6vnpZrc1YlVg=
 cloud.google.com/go/compute/metadata v0.2.3 h1:mg4jlk7mCAj6xXp9UJ4fjI9VUI5rubuGBW5aJ7UnBMY=
+github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 h1:He8afgbRMd7mFxO99hRNu+6tazq8nFF9lIwo9JFroBk=
+github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6/go.mod h1:8o94RPi1/7XTJvwPpRSzSUedZrtlirdB3r9Z20bi2f8=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/NYTimes/gziphandler v1.1.1 h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cqUQ3I=


### PR DESCRIPTION
### PR Description
This PR introduces a fuzz test for Kruise, specifically targeting the validation of ResourceDistribution resources. The current test focuses on validating the resource field as described in the [ResourceDistribution documentation](https://openkruise.io/docs/user-manuals/resourcedistribution#resource-field). Over time, this test will be expanded to cover additional aspects and edge cases.

### Why do we need this?
Fuzz testing is essential for improving the reliability and security of the Kruise project. By adding this fuzz test, we aim to identify potential bugs, vulnerabilities, or unexpected behavior that may not be caught during standard testing.

### Todos

- [x]  Create a proof of concept (POC) for fuzz testing.
- [ ]  Add documentation explaining how fuzz testing works within Kruise.
- [ ]  Integrate OSS-Fuzz with Kruise for continuous fuzz testing.
- [ ]  Explore and add additional fuzz tests to cover more scenarios.
- [ ]  Continuously improve and expand fuzz tests as new edge cases emerge.

### Additional Notes
This is an ongoing process, and more tests will be added over time to ensure Kruise's robustness.

// @furykerry @hantmac 