### PR TITLE
Feature: enhanced maxSurge performance

### DIFF
--- a/pkg/controller/cloneset/sync/cloneset_scale.go
+++ b/pkg/controller/cloneset/sync/cloneset_scale.go
@@ -112,7 +112,7 @@ func (r *realControl) Scale(
 
 		podsCanDelete := make([]*v1.Pod, 0, len(podsToDelete))
 		for _, pod := range podsToDelete {
-			if !isPodReady(coreControl, pod, updateCS.Spec.MinReadySeconds) {
+			if !IsPodAvailable(coreControl, pod, updateCS.Spec.MinReadySeconds) {
 				podsCanDelete = append(podsCanDelete, pod)
 			} else if diffRes.DeleteReadyLimit > 0 {
 				podsCanDelete = append(podsCanDelete, pod)
@@ -139,7 +139,7 @@ func (r *realControl) Scale(
 		podsPreparingToDelete := r.choosePodsToDelete(updateCS, diffRes.ScaleDownNum, diffRes.ScaleDownNumOldRevision, notUpdatedPods, updatedPods)
 		podsToDelete := make([]*v1.Pod, 0, len(podsPreparingToDelete))
 		for _, pod := range podsPreparingToDelete {
-			if !isPodReady(coreControl, pod, updateCS.Spec.MinReadySeconds) {
+			if !IsPodAvailable(coreControl, pod, updateCS.Spec.MinReadySeconds) {
 				podsToDelete = append(podsToDelete, pod)
 			} else if diffRes.DeleteReadyLimit > 0 {
 				podsToDelete = append(podsToDelete, pod)

--- a/pkg/controller/cloneset/sync/cloneset_sync_utils_test.go
+++ b/pkg/controller/cloneset/sync/cloneset_sync_utils_test.go
@@ -345,7 +345,7 @@ func TestCalculateDiffsWithExpectation(t *testing.T) {
 			expectResult: expectationDiffs{ScaleUpNum: 1, UseSurge: 1, UpdateNum: 2, UpdateMaxUnavailable: 1, ScaleUpLimit: 1},
 		},
 		{
-			name: "update in-place partition=3 with maxSurge (step 2/4)",
+			name: "update in-place partition=3 with maxSurge step 2/4",
 			set:  createTestCloneSet(5, intstr.FromInt(3), intstr.FromInt(1), intstr.FromInt(1)),
 			pods: []*v1.Pod{
 				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),

--- a/pkg/controller/cloneset/sync/cloneset_update.go
+++ b/pkg/controller/cloneset/sync/cloneset_update.go
@@ -79,13 +79,13 @@ func (c *realControl) Update(cs *appsv1alpha1.CloneSet,
 
 	// 2. calculate update diff and the revision to update
 	diffRes := calculateDiffsWithExpectation(cs, pods, currentRevision.Name, updateRevision.Name, nil)
-	if diffRes.updateNum == 0 {
+	if diffRes.UpdateNum == 0 {
 		return nil
 	}
 
 	// 3. find all matched pods can update
 	targetRevision := updateRevision
-	if diffRes.updateNum < 0 {
+	if diffRes.UpdateNum < 0 {
 		targetRevision = currentRevision
 	}
 	var waitUpdateIndexes []int
@@ -95,7 +95,7 @@ func (c *realControl) Update(cs *appsv1alpha1.CloneSet,
 		}
 
 		var waitUpdate, canUpdate bool
-		if diffRes.updateNum > 0 {
+		if diffRes.UpdateNum > 0 {
 			waitUpdate = !clonesetutils.EqualToRevisionHash("", pod, updateRevision.Name)
 		} else {
 			waitUpdate = clonesetutils.EqualToRevisionHash("", pod, updateRevision.Name)
@@ -347,7 +347,7 @@ func SortUpdateIndexes(coreControl clonesetcore.Control, strategy appsv1alpha1.C
 
 // limitUpdateIndexes limits all pods waiting update by the maxUnavailable policy, and returns the indexes of pods that can finally update
 func limitUpdateIndexes(coreControl clonesetcore.Control, minReadySeconds int32, diffRes expectationDiffs, waitUpdateIndexes []int, pods []*v1.Pod, targetRevisionHash string) []int {
-	updateDiff := util.IntAbs(diffRes.updateNum)
+	updateDiff := util.IntAbs(diffRes.UpdateNum)
 	if updateDiff < len(waitUpdateIndexes) {
 		waitUpdateIndexes = waitUpdateIndexes[:updateDiff]
 	}
@@ -363,14 +363,14 @@ func limitUpdateIndexes(coreControl clonesetcore.Control, minReadySeconds int32,
 	}
 	for _, i := range waitUpdateIndexes {
 		// Make sure unavailable pods in target revision should not be more than maxUnavailable.
-		if targetRevisionUnavailableCount+canUpdateCount >= diffRes.updateMaxUnavailable {
+		if targetRevisionUnavailableCount+canUpdateCount >= diffRes.UpdateMaxUnavailable {
 			break
 		}
 
 		// Make sure unavailable pods in all revisions should not be more than maxUnavailable.
 		// Note that update an old pod that already be unavailable will not increase the unavailable number.
 		if IsPodAvailable(coreControl, pods[i], minReadySeconds) {
-			if unavailableCount >= diffRes.updateMaxUnavailable {
+			if unavailableCount >= diffRes.UpdateMaxUnavailable {
 				break
 			}
 			unavailableCount++

--- a/pkg/controller/cloneset/sync/cloneset_update_test.go
+++ b/pkg/controller/cloneset/sync/cloneset_update_test.go
@@ -1228,10 +1228,10 @@ func TestCalculateUpdateCount(t *testing.T) {
 
 		var waitUpdateIndexes []int
 		var targetRevision string
-		if diffRes.updateNum > 0 {
+		if diffRes.UpdateNum > 0 {
 			waitUpdateIndexes = tc.oldRevisionIndexes
 			targetRevision = updateRevision
-		} else if diffRes.updateNum < 0 {
+		} else if diffRes.UpdateNum < 0 {
 			waitUpdateIndexes = newRevisionIndexes
 			targetRevision = currentRevision
 		}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

CloneSet can retain both old and new version Pods simultaneously in some upgrade scenarios (such as blue-green release) by setting `minReadySeconds` to a sufficiently large value along with a suitable `maxSurge`. However, during the above upgrade process, it's not possible to dynamically adjust the number of new Pods by changing `maxSurge` in real-time. This update adds such capability to CloneSet.


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #1666

### Ⅲ. Describe how to verify it
change maxSurge while updating

```text
# 50%
+-------------+---------+-----------+
|     name    | version | lifecycle |
+-------------+---------+-----------+
| sleep-857br |    v1   |   Normal  |
| sleep-8w5f2 |    v1   |   Normal  |
| sleep-lhl5l |    v1   |   Normal  |
| sleep-wr29m |    v1   |   Normal  |
| sleep-bv7s7 |    v2   |   Normal  |
| sleep-dfg6c |    v2   |   Normal  |
+-------------+---------+-----------+
# 50% -> 100%
+-------------+---------+-----------+
|     name    | version | lifecycle |
+-------------+---------+-----------+
| sleep-857br |    v1   |   Normal  |
| sleep-8w5f2 |    v1   |   Normal  |
| sleep-lhl5l |    v1   |   Normal  |
| sleep-wr29m |    v1   |   Normal  |
| sleep-bv7s7 |    v2   |   Normal  |
| sleep-dfg6c |    v2   |   Normal  |
| sleep-pht8b |    v2   |   Normal  |
| sleep-wxw8t |    v2   |   Normal  |
+-------------+---------+-----------+
# 100% -> 25%
+-------------+---------+-----------+
|     name    | version | lifecycle |
+-------------+---------+-----------+
| sleep-857br |    v1   |   Normal  |
| sleep-8w5f2 |    v1   |   Normal  |
| sleep-lhl5l |    v1   |   Normal  |
| sleep-wr29m |    v1   |   Normal  |
| sleep-dfg6c |    v2   |   Normal  |
+-------------+---------+-----------+
# minReadySeconds 9999 -> 0
+-------------+---------+-----------+
|     name    | version | lifecycle |
+-------------+---------+-----------+
| sleep-ckhpn |    v2   |   Normal  |
| sleep-dfg6c |    v2   |   Normal  |
| sleep-hjjks |    v2   |   Normal  |
| sleep-qjx5f |    v2   |   Normal  |
+-------------+---------+-----------+
```

### Ⅳ. Special notes for reviews

