### PR TITLE
set upstream after changing to <project> dir

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,7 @@ Then you could finish the preparation in the following steps:
 3. **Set remote** upstream to be `https://github.com/openkruise/<project>.git` using the following two commands:
 
 ```bash
+cd <project>
 git remote add upstream https://github.com/openkruise/<project>.git
 git remote set-url --push upstream no-pushing
 ```


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
After cloning the project, one needs to change directory to <project> and then set upstream URL.


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

### Ⅲ. Describe how to verify it
clone the project, change the dir and then run command mentioned in docs

### Ⅳ. Special notes for reviews

