### PR TITLE
Fix: prevent index out of range in NestedField function (#2008)

### DIFF
--- a/pkg/util/workloadspread/utils.go
+++ b/pkg/util/workloadspread/utils.go
@@ -60,13 +60,23 @@ func NestedField[T any](obj any, paths ...string) (T, bool, error) {
 }
 
 func nestedSlice[T any](obj []any, paths ...string) (T, bool, error) {
+	if len(paths) == 0 {
+		val, ok := any(obj).(T)
+		if !ok {
+			return *new(T), false, errors.New("type conversion error")
+		}
+		return val, true, nil
+	}
+
 	idx, err := strconv.Atoi(paths[0])
 	if err != nil {
-		return *new(T), false, err
+		return *new(T), false, fmt.Errorf("invalid index: %v", err)
 	}
-	if idx < 0 || len(obj) <= idx {
-		return *new(T), false, fmt.Errorf("index %d out of range", idx)
+
+	if idx < 0 || idx >= len(obj) {
+		return *new(T), false, fmt.Errorf("index %d out of range with length %d", idx, len(obj))
 	}
+
 	return NestedField[T](obj[idx], paths[1:]...)
 }
 


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines; https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

Ⅰ. Describe what this PR does
This PR improves the robustness of the NestedField function by introducing bounds checking before accessing elements. This prevents possible "index out of range" panics when the function is called with malformed or unexpected input.

Ⅱ. Does this pull request fix one issue?
Fixes #2008

Ⅲ. Describe how to verify it
Run the existing unit tests to confirm that the function no longer panics with invalid input.

Optionally, manually test the NestedField function using inputs that previously caused a panic to ensure it now handles them gracefully.

Ⅳ. Special notes for reviews
The change is limited to input validation within the NestedField function.

No breaking changes or modifications to existing tests are included.