### PR TITLE
fix: prevent index out of range in NestedField function (#2008)

### DIFF
--- a/pkg/util/workloadspread/utils.go
+++ b/pkg/util/workloadspread/utils.go
@@ -60,17 +60,39 @@ func NestedField[T any](obj any, paths ...string) (T, bool, error) {
 }
 
 func nestedSlice[T any](obj []any, paths ...string) (T, bool, error) {
+	if len(paths) == 0 {
+		val, ok := any(obj).(T)
+		if !ok {
+			return *new(T), false, fmt.Errorf("type assertion to %T failed", *new(T))
+		}
+		return val, true, nil
+	}
 	idx, err := strconv.Atoi(paths[0])
 	if err != nil {
-		return *new(T), false, err
+		return *new(T), false, fmt.Errorf("invalid index '%s': %w", paths[0], err)
 	}
-	if idx < 0 || len(obj) <= idx {
+	if idx < 0 || idx >= len(obj) {
 		return *new(T), false, fmt.Errorf("index %d out of range", idx)
 	}
-	return NestedField[T](obj[idx], paths[1:]...)
+	val := obj[idx]
+	if len(paths) > 1 {
+		return NestedField[T](val, paths[1:]...)
+	}
+	typedVal, ok := val.(T)
+	if !ok {
+		return *new(T), false, fmt.Errorf("type assertion to %T failed", typedVal)
+	}
+	return typedVal, true, nil
 }
 
 func nestedMap[T any](obj map[string]any, paths ...string) (T, bool, error) {
+	if len(paths) == 0 {
+		val, ok := any(obj).(T)
+		if !ok {
+			return *new(T), false, fmt.Errorf("type assertion to %T failed", *new(T))
+		}
+		return val, true, nil
+	}
 	if val, ok := obj[paths[0]]; ok {
 		return NestedField[T](val, paths[1:]...)
 	} else {

--- a/pkg/util/workloadspread/utils_test.go
+++ b/pkg/util/workloadspread/utils_test.go
@@ -241,3 +241,18 @@ func TestIsPodSelected(t *testing.T) {
 		})
 	}
 }
+
+func TestNestedSlice_EmptyPaths_ExpectFullSlice(t *testing.T) {
+	input := []any{"hello", "world"}
+	val, ok, err := nestedSlice[[]any](input) // Expecting full slice as T
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected ok to be true, got false")
+	}
+	if len(val) != 2 || val[0] != "hello" || val[1] != "world" {
+		t.Errorf("unexpected value: %v", val)
+	}
+}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
This PR fixes a bug in the NestedField utility functions that caused a panic with "index out of range" error when empty paths were provided to the nestedSlice and nestedMap functions. It adds proper handling for empty paths to both functions, making them return the entire object cast to the requested type in this case.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #2008

### Ⅲ. Describe how to verify it
- Added a new test case `TestNestedSlice_EmptyPaths_ExpectFullSlice` that verifies the behavior when empty paths are provided
- All existing tests pass with the fix
- The index out of range panic no longer occurs when empty paths are provided

### Ⅳ. Special notes for reviews
The changes are minimal and focused on handling edge cases properly:
- In both `nestedSlice` and `nestedMap` functions, empty paths now return the entire object cast to the requested type instead of returning an error
- This maintains consistency with how `NestedField` handles empty paths