### PR TITLE
fix: Update Go Version in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,7 @@ We encourage contributors to follow the [PR template](./.github/PULL_REQUEST_TEM
 As a contributor, if you want to make any contribution to the Kruise project, we should reach an agreement on the version of tools used in the development environment.
 Here are some dependencies with specific versions:
 
-- Golang : v1.18+
+- Golang : v1.22+
 - Kubernetes: v1.16+
 
 ### Developing guide

--- a/SECURITY_CONTACTS.md
+++ b/SECURITY_CONTACTS.md
@@ -1,6 +1,6 @@
 Defined below are the security persons of contact for this project. If you have questions regarding the triaging and handling of incoming problems, they may be contacted.
 
-The following security contacts have agreed to abide by the Embargo Policy $LINK and will be removed and replaced if found to be in violation of that agreement.
+The following security contacts have agreed to abide by the Embargo Policy [Embargo Policy](embargo-policy.md) and will be removed and replaced if found to be in violation of that agreement.
 
 DO NOT REPORT SECURITY VULNERABILITIES DIRECTLY TO THESE NAMES, USE THE INSTRUCTIONS AT [SECURITY.md](SECURITY.md)
 


### PR DESCRIPTION
### 🛠️ Update Go Version in CONTRIBUTING.md

This pull request updates the Go version requirement mentioned in the `CONTRIBUTING.md` file under the "Developing Environment" section.

#### 🔍 What Changed
Previously:
Golang : v1.18+

Updated to:
Golang : v1.22+


#### 📌 Reason for Change
According to the `CHANGELOG.md` for version `v1.8.0`, the project has upgraded its dependencies:
Update Kubernetes dependency to v1.30.10 and Golang to v1.22


Keeping the documentation up to date ensures that contributors use the correct Go version to avoid compatibility issues during development.

#### ✅ Verification
This is a documentation-only update. You can verify the change by reviewing the modified `CONTRIBUTING.md` file.

#### 📝 Notes
No code changes are included in this PR. This update strictly improves documentation clarity and consistency.

