### PR TITLE
fix: Update Go Version in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,7 @@ We encourage contributors to follow the [PR template](./.github/PULL_REQUEST_TEM
 As a contributor, if you want to make any contribution to the Kruise project, we should reach an agreement on the version of tools used in the development environment.
 Here are some dependencies with specific versions:
 
-- Golang : v1.18+
+- Golang : v1.22+
 - Kubernetes: v1.16+
 
 ### Developing guide


### PR DESCRIPTION
### 🛠 Update Go Version in CONTRIBUTING.md

This pull request updates the Go version requirement mentioned in the CONTRIBUTING.md file under the "Developing Environment" section.

#### 🔍 What Changed
Previously:
Golang : v1.18+

Updated to:
Golang : v1.22+


#### 📌 Reason for Change
According to the CHANGELOG.md for version v1.8.0, the project has upgraded its dependencies:
Update Kubernetes dependency to v1.30.10 and Golang to v1.22

