### PR TITLE
Documentation: Replace placeholder $LINK with actual Embargo Policy l…

### DIFF
--- a/SECURITY_CONTACTS.md
+++ b/SECURITY_CONTACTS.md
@@ -1,6 +1,6 @@
 Defined below are the security persons of contact for this project. If you have questions regarding the triaging and handling of incoming problems, they may be contacted.
 
-The following security contacts have agreed to abide by the Embargo Policy $LINK and will be removed and replaced if found to be in violation of that agreement.
+The following security contacts have agreed to abide by the [Embargo Policy](embargo-policy.md) and will be removed and replaced if found to be in violation of that agreement.
 
 DO NOT REPORT SECURITY VULNERABILITIES DIRECTLY TO THESE NAMES, USE THE INSTRUCTIONS AT [SECURITY.md](SECURITY.md)
 


### PR DESCRIPTION
### 📘 Fix Placeholder Link in SECURITY_CONTACTS.md

This pull request fixes a documentation issue in the `SECURITY_CONTACTS.md` file where a placeholder `$LINK` was used instead of an actual reference.

#### 📝 What Changed

Replaced:
...abide by the Embargo Policy $LINK...
With:
...abide by the [Embargo Policy](embargo-policy.md)...


#### 📌 Why This Matters
The placeholder `$LINK` may confuse readers or contributors looking for the Embargo Policy. Replacing it with a proper markdown link improves documentation clarity and navigability.

#### ✅ Verification
Confirmed that the link `[Embargo Policy](embargo-policy.md)` correctly points to the local embargo policy document.

#### 🧾 Notes
This is a documentation-only update and does not affect project code or functionality.

