### PR TITLE
docs: Add Operations Guide (Prometheus Metrics & Troubleshooting)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -34,3 +34,10 @@ You can view the full documentation from the [official website](https://openkrui
 ## Tutorials
 
 Several [Tutorials](./tutorial/README.md) are provided to demonstrate how to use the controllers
+
+## Operations
+
+[Operations](./operations): Guides for operating and maintaining OpenKruise
+  - [Prometheus Metrics](.operationsprometheus-metricsmd)
+  - [Troubleshooting](./operations/troubleshooting.md)
+

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -1,0 +1,21 @@
+# Operations Guide
+
+This section provides comprehensive guidance for operators and platform engineers on monitoring, maintaining, and troubleshooting OpenKruise in production environments. A well-operated OpenKruise deployment ensures robust and efficient management of advanced workloads on Kubernetes.
+
+## Contents
+
+- **[Prometheus Metrics](./prometheus-metrics.md):**
+  Learn about the metrics exposed by OpenKruise. This guide covers how to enable metrics, key metric categories, setting up Prometheus scraping and alerting, and example Grafana dashboards for effective monitoring of OpenKruise controllers and workloads.
+
+- **[Troubleshooting Guide](./troubleshooting.md):**
+  A practical guide to diagnosing and resolving common issues encountered with OpenKruise. It covers general troubleshooting steps, specific problems related to the controller manager, webhooks, and various Kruise workloads (CloneSet, AdvancedStatefulSet, SidecarSet), along with useful diagnostic commands.
+
+## Introduction to Operating OpenKruise
+
+Operating OpenKruise effectively involves:
+
+1.  **Monitoring:** Continuously observing the health and performance of OpenKruise controllers and the workloads they manage using metrics. Setting up alerts for abnormal conditions is crucial.
+2.  **.[Troubleshooting](./operations/troubleshooting.md)** Systematically diagnosing issues when they arise, using logs, events, metrics, and resource statuses.
+3.  **Maintenance:** Understanding upgrade procedures, managing configurations, and being aware of how OpenKruise interacts with the broader Kubernetes ecosystem (e.g., API server, networking, storage).
+
+While OpenKruise is designed for resilience, this guide aims to equip you with the knowledge to handle operational aspects confidently and maintain a stable and performant OpenKruise installation.

--- a/docs/operations/prometheus-metrics.md
+++ b/docs/operations/prometheus-metrics.md
@@ -1,0 +1,199 @@
+# Prometheus Metrics
+
+OpenKruise exposes metrics in Prometheus format, crucial for monitoring the health and performance of its controllers and managed workloads. This guide outlines how to access, understand, and utilize these metrics.
+
+## Enabling Metrics
+
+By default, the OpenKruise controller manager (`kruise-controller-manager`) exposes metrics on port `8080` at the `/metrics` endpoint. This is typically enabled during installation (e.g., via Helm).
+
+To verify:
+
+1.  **Port-forward to the `kruise-controller-manager` service:**
+    (The service port for metrics is often named `metrics` or is the main service port, e.g., 8080)
+    ```bash
+    # kubectl get svc -n kruise-system kruise-controller-manager -o jsonpath='{.spec.ports[?(@.name=="metrics")].port}' # to find port
+    kubectl port-forward -n kruise-system svc/kruise-controller-manager 8080:8080
+    ```
+
+2.  **Query the metrics endpoint:**
+    ```bash
+    curl localhost:8080/metrics
+    ```
+
+## Key Metrics Categories
+
+### 1. Controller Runtime Metrics
+Standard metrics from `controller-runtime` library, offering insights into individual controller performance:
+
+| Metric Name                                  | Type      | Description                                      | Labels       |
+| -------------------------------------------- | --------- | ------------------------------------------------ | ------------ |
+| `controller_runtime_reconcile_total`         | Counter   | Total reconciliations per controller.            | `controller` |
+| `controller_runtime_reconcile_errors_total`  | Counter   | Total reconciliation errors per controller.      | `controller` |
+| `controller_runtime_reconcile_time_seconds`  | Histogram | Reconciliation duration per controller.          | `controller` |
+| `workqueue_depth`                            | Gauge     | Current workqueue depth per controller.          | `name`       |
+| `workqueue_adds_total`                       | Counter   | Total items added to workqueue.                  | `name`       |
+| `workqueue_retries_total`                    | Counter   | Total retries handled by workqueue.              | `name`       |
+
+**Use to:** Identify overloaded controllers (high `workqueue_depth`, long `reconcile_time_seconds`) or persistent issues (increasing `reconcile_errors_total`).
+
+### 2. OpenKruise Specific Metrics
+Custom metrics for OpenKruise features.
+**IMPORTANT: Verify exact metric names and labels against your OpenKruise `/metrics` endpoint.** The following are illustrative examples:
+
+| Metric Name (Illustrative)                               | Type      | Description (Illustrative)                                  | Labels (Illustrative)         |
+| -------------------------------------------------------- | --------- | ----------------------------------------------------------- | ----------------------------- |
+| `kruise_cloneset_status_replicas`                        | Gauge     | Current number of replicas for a CloneSet.                  | `cloneset`, `namespace`       |
+| `kruise_cloneset_status_updated_replicas`                | Gauge     | Number of updated replicas for a CloneSet.                  | `cloneset`, `namespace`       |
+| `kruise_advancedstatefulset_update_duration_seconds`     | Histogram | Time for AdvancedStatefulSet updates.                       | `statefulset`, `namespace`    |
+| `kruise_sidecarset_status_matched_pods`                  | Gauge     | Pods matched by a SidecarSet.                               | `sidecarset`                  |
+| `kruise_pod_inplace_update_total`                        | Counter   | Total in-place pod updates.                                 | `controller_kind`, `namespace`|
+| `kruise_webhook_admission_requests_total`                | Counter   | Admission requests to Kruise webhooks.                      | `webhook_type`, `allowed`     |
+| `kruise_webhook_admission_duration_seconds`              | Histogram | Latency of Kruise webhook admission requests.               | `webhook_type`, `operation`   |
+
+**Use to:** Monitor rollouts, feature performance (e.g., in-place updates), and webhook health.
+
+### 3. Go Runtime and Process Metrics
+Standard Go and process metrics for advanced debugging of `kruise-controller-manager` resource usage.
+
+## Setting Up Monitoring with Prometheus
+
+### Prometheus ServiceMonitor
+For Prometheus Operator users, a `ServiceMonitor` automates scraping:
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: kruise-controller-manager
+  namespace: monitoring # Your monitoring namespace
+  labels:
+    release: prometheus # Example label for Prometheus to discover this ServiceMonitor
+spec:
+  selector:
+    matchLabels:
+      # Labels of your kruise-controller-manager service
+      # Verify with: kubectl get svc -n kruise-system kruise-controller-manager --show-labels
+      control-plane: controller-manager # Common label, verify
+  namespaceSelector:
+    matchNames:
+      - kruise-system # OpenKruise installation namespace
+  endpoints:
+  - port: metrics # Name of the metrics port in the service (e.g., 'metrics', 'http-metrics')
+    interval: 30s
+    # path: /metrics # Usually default
+
+
+Note: Ensure selector and port match your OpenKruise service definition.
+
+###Example Prometheus Alerting Rules
+
+#Key alerts to consider (adapt thresholds to your environment):
+
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: kruise-alerts
+  namespace: monitoring # Your monitoring namespace
+spec:
+  groups:
+  - name: kruise.rules
+    rules:
+    - alert: KruiseControllerReconciliationErrors
+      # Alerts if any Kruise controller has a significant error rate
+      expr: sum(rate(controller_runtime_reconcile_errors_total{controller=~".*kruise.*"}[5m])) by (controller) > 0.1
+      for: 10m
+      labels:
+        severity: warning
+      annotations:
+        summary: "Kruise controller {{ $labels.controller }} reconciliation errors"
+        description: "{{ $labels.controller }} has >0.1 reconciliation errors/sec for 10m."
+
+    - alert: KruiseControllerHighReconciliationLatency
+      # Alerts if P95 reconciliation latency for any Kruise controller is high
+      expr: histogram_quantile(0.95, sum(rate(controller_runtime_reconcile_time_seconds_bucket{controller=~".*kruise.*"}[5m])) by (le, controller)) > 5
+      for: 10m
+      labels:
+        severity: warning
+      annotations:
+        summary: "Kruise controller {{ $labels.controller }} high latency"
+        description: "P95 reconciliation latency for {{ $labels.controller }} >5s for 10m."
+
+    - alert: KruiseWebhookErrors
+      # Alerts if Kruise webhooks are frequently denying requests (verify metric name)
+      expr: (sum(rate(kruise_webhook_admission_requests_total{allowed="false"}[5m])) by (webhook_type) / sum(rate(kruise_webhook_admission_requests_total[5m])) by (webhook_type)) * 100 > 5
+      for: 5m
+      labels:
+        severity: critical
+      annotations:
+        summary: "High error rate for Kruise webhook {{ $labels.webhook_type }}"
+        description: "More than 5% of requests to Kruise webhook {{ $labels.webhook_type }} are failing."
+
+
+### Grafana allows visualization of these metrics. You can build dashboards or import existing ones. Below is a compact example dashboard JSON focusing on key controller metrics.
+
+# Importing to Grafana:
+
+# Go to Dashboards -> Import.
+
+# Paste the JSON below or upload it as a file.
+
+# Name the dashboard and select your Prometheus datasource.
+
+# Example Grafana Dashboard JSON (Compact):
+
+{
+  "__inputs": [],
+  "__requires": [
+    {"type": "grafana", "id": "grafana", "name": "Grafana", "version": "7.0.0"},
+    {"type": "datasource", "id": "prometheus", "name": "Prometheus", "version": "1.0.0"}
+  ],
+  "annotations": {"list": [{"builtIn": 1, "datasource": {"type": "grafana", "uid": "-- Grafana --"}, "enable": true, "hide": true, "iconColor": "rgba(0, 211, 255, 1)", "name": "Annotations & Alerts", "type": "dashboard"}]},
+  "editable": true, "fiscalYearStartMonth": 0, "graphTooltip": 0, "id": null, "links": [], "liveNow": false,
+  "panels": [
+    {
+      "title": "Controller Reconciliation Rate (Overall)", "type": "timeseries", "datasource": {"type": "prometheus"}, "gridPos": {"h": 7, "w": 12, "x": 0, "y": 0},
+      "targets": [{"expr": "sum(rate(controller_runtime_reconcile_total{controller=~'.*kruise.*'}[5m])) by (controller)", "legendFormat": "{{controller}}"}],
+      "options": {"legend": {"displayMode": "list", "placement": "bottom"}, "tooltip": {"mode": "single"}}
+    },
+    {
+      "title": "Controller Error Rate (Overall)", "type": "timeseries", "datasource": {"type": "prometheus"}, "gridPos": {"h": 7, "w": 12, "x": 12, "y": 0},
+      "targets": [{"expr": "sum(rate(controller_runtime_reconcile_errors_total{controller=~'.*kruise.*'}[5m])) by (controller)", "legendFormat": "{{controller}}"}],
+      "options": {"legend": {"displayMode": "list", "placement": "bottom"}, "tooltip": {"mode": "single"}}
+    },
+    {
+      "title": "Controller Latency P95 (Overall)", "type": "timeseries", "datasource": {"type": "prometheus"}, "gridPos": {"h": 7, "w": 12, "x": 0, "y": 7}, "fieldConfig": {"defaults": {"unit": "s"}},
+      "targets": [{"expr": "histogram_quantile(0.95, sum(rate(controller_runtime_reconcile_time_seconds_bucket{controller=~'.*kruise.*'}[5m])) by (le, controller))", "legendFormat": "{{controller}} P95"}],
+      "options": {"legend": {"displayMode": "list", "placement": "bottom"}, "tooltip": {"mode": "single"}}
+    },
+    {
+      "title": "WorkQueue Depth (Overall)", "type": "timeseries", "datasource": {"type": "prometheus"}, "gridPos": {"h": 7, "w": 12, "x": 12, "y": 7},
+      "targets": [{"expr": "sum(workqueue_depth{name=~'.*kruise.*'}) by (name)", "legendFormat": "{{name}}"}],
+      "options": {"legend": {"displayMode": "list", "placement": "bottom"}, "tooltip": {"mode": "single"}}
+    },
+    {
+      "title": "Webhook Request Rate (Verify Metric)", "type": "timeseries", "datasource": {"type": "prometheus"}, "gridPos": {"h": 7, "w": 12, "x": 0, "y": 14},
+      "targets": [{"expr": "sum(rate(kruise_webhook_admission_requests_total[1m])) by (webhook_type, operation, kind, allowed)", "legendFormat": "{{webhook_type}} {{operation}} {{kind}} (allowed={{allowed}})"}],
+      "options": {"legend": {"displayMode": "list", "placement": "bottom"}, "tooltip": {"mode": "single"}}
+    }
+  ],
+  "refresh": "30s", "schemaVersion": 37, "style": "dark", "tags": ["kruise", "openkruise"],
+  "templating": {"list": []}, "time": {"from": "now-1h", "to": "now"}, "timepicker": {}, "timezone": "browser",
+  "title": "OpenKruise Controller Health", "uid": "openkruise-health-compact", "version": 1
+}
+
+
+# For quick checks or debugging, query the metrics endpoint directly:
+
+# Ensure port-forward is active as shown in "Enabling Metrics"
+
+# Filter for OpenKruise specific metrics (verify 'kruise_' prefix and metric names)
+curl -s localhost:8080/metrics | grep kruise_
+
+# Filter for controller-runtime metrics related to Kruise controllers
+# (Adjust regex if your controller names differ, e.g., "cloneset-controller")
+
+curl -s localhost:8080/metrics | grep -E 'controller_runtime_.*(cloneset|statefulset|sidecarset|kruise)'
+
+This helps view current metric values for targeted diagnostics.
+
+

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -1,0 +1,318 @@
+# Troubleshooting Guide
+
+This document provides guidance on troubleshooting common issues with OpenKruise. For proactive monitoring, please also refer to the [Prometheus Metrics](./prometheus-metrics.md) documentation.
+
+## Table of Contents
+
+- [General Troubleshooting Steps](#general-troubleshooting-steps)
+- [Kruise Controller Manager Issues](#kruise-controller-manager-issues)
+  - [Controller Manager Not Starting or Crashing](#controller-manager-not-starting-or-crashing)
+  - [Webhook Issues](#webhook-issues)
+- [CloneSet Troubleshooting](#cloneset-troubleshooting)
+  - [Pods Not Scaling Up/Down or Not Updating](#pods-not-scaling-updown-or-not-updating)
+  - [In-place Update Issues](#in-place-update-issues)
+- [Advanced StatefulSet Troubleshooting](#advanced-statefulset-troubleshooting)
+  - [In-place Update Not Working](#in-place-update-not-working)
+  - [PVC Issues](#pvc-issues)
+- [SidecarSet Troubleshooting](#sidecarset-troubleshooting)
+  - [Sidecars Not Injected](#sidecars-not-injected)
+  - [Sidecar Update Issues](#sidecar-update-issues)
+- [Other Kruise Workloads](#other-kruise-workloads)
+- [Common Error Messages](#common-error-messages)
+- [Diagnostic Commands](#diagnostic-commands)
+- [Getting Support](#getting-support)
+
+## General Troubleshooting Steps
+
+1.  **Check Kruise Controller Manager Logs:** This is often the first place to look. The container name is typically `manager`.
+    ```bash
+    kubectl logs -n kruise-system -l control-plane=controller-manager -c manager --tail=200 # Add -f to follow
+    ```
+
+2.  **Examine Kubernetes Events:** Events can provide clues about issues with resource creation, scheduling, or webhooks.
+    ```bash
+    # For events in the workload's namespace
+    kubectl get events -n <namespace-of-your-workload> --sort-by='.lastTimestamp'
+    # For events in the kruise-system namespace
+    kubectl get events -n kruise-system --sort-by='.lastTimestamp'
+    ```
+
+3.  **Inspect Metrics:** Review metrics exposed by OpenKruise. High error rates, reconciliation latencies, or work queue depth can indicate problems. See [Prometheus Metrics](./prometheus-metrics.md).
+
+4.  **Verify CRD Installation:** Ensure all OpenKruise CRDs are correctly installed and up-to-date.
+    ```bash
+    kubectl get crd | grep 'kruise.io'
+    ```
+
+5.  **Describe the Problematic Resource:** This shows the resource's spec, status, and recent events.
+    ```bash
+    kubectl describe <kruise-workload-kind> <resource-name> -n <namespace>
+    # e.g., kubectl describe cloneset my-cloneset -n default
+    ```
+
+## Kruise Controller Manager Issues
+
+### Controller Manager Not Starting or Crashing
+
+**Symptoms:**
+- `kruise-controller-manager` pod(s) in `kruise-system` namespace are in `CrashLoopBackOff`, `Error`, or `Pending` state.
+- Controllers are not reconciling workloads (e.g., no new pods created for a CloneSet).
+
+**Troubleshooting Steps:**
+
+1.  Check pod status and logs:
+    ```bash
+    kubectl get pods -n kruise-system -l control-plane=controller-manager
+    # Describe the failing pod
+    kubectl describe pod -n kruise-system <manager-pod-name>
+    # Get logs from the manager container within the pod
+    kubectl logs -n kruise-system <manager-pod-name> -c manager
+    # If there's an init container or sidecar, check its logs too
+    # kubectl logs -n kruise-system <manager-pod-name> -c <other-container-name>
+    ```
+    Look for OOMKilled (Out Of Memory), permission issues, or connection problems to the Kubernetes API server.
+
+2.  Check resource requests/limits defined for the manager deployment and ensure nodes have capacity.
+
+3.  Verify RBAC permissions: The controller manager needs appropriate ClusterRoles and RoleBindings. Issues here usually manifest as "forbidden" errors in logs.
+
+### Webhook Issues
+
+OpenKruise relies on Mutating and Validating Admission Webhooks for many of its features (e.g., sidecar injection, in-place updates, resource validation).
+
+**Symptoms:**
+- Failure to create, update, or delete OpenKruise CRDs or standard resources (Pods, Deployments) that OpenKruise might interact with.
+- Error messages like:
+  - `"Failed calling webhook ... connection refused"`
+  - `"Internal error occurred: failed calling webhook ...: Post ... x509: certificate signed by unknown authority"`
+  - `"admission webhook ... denied the request"`
+  - Timeout errors related to webhooks.
+
+**Troubleshooting Steps:**
+
+1.  **Check Webhook Configurations:**
+    ```bash
+    kubectl get mutatingwebhookconfiguration | grep kruise
+    kubectl get validatingwebhookconfiguration | grep kruise
+    ```
+    Inspect their YAML (`-o yaml`) paying attention to:
+    - `clientConfig.service`: Must correctly point to the webhook service (e.g., `kruise-webhook-service` or `kruise-manager`) in `kruise-system` on the correct port (e.g., 443, 9443).
+    - `clientConfig.caBundle`: Must contain the CA that signed the webhook server's certificate.
+    - `failurePolicy`: `Fail` means issues block requests; `Ignore` allows requests but features might not work as expected.
+    - `rules.operations` and `rules.resources`: Ensure they cover the intended operations and resources.
+    - `timeoutSeconds`: Default is 10s. If webhooks are slow, requests might time out.
+
+2.  **Check Webhook Service and Endpoints:**
+    ```bash
+    # Identify the webhook service name from the WebhookConfiguration
+    kubectl get svc -n kruise-system | grep kruise # Look for services related to webhook or manager
+    kubectl get endpoints -n kruise-system <webhook-service-name>
+    ```
+    Ensure the service exists, has a `ClusterIP`, and the Endpoints object has at least one ready IP address (matching a running `kruise-controller-manager` pod).
+
+3.  **Check Webhook Pod Logs:** Webhook handling logic runs within the `kruise-controller-manager` pod.
+    ```bash
+    kubectl logs -n kruise-system -l control-plane=controller-manager -c manager | grep -iE "webhook|admission"
+    ```
+
+4.  **Certificate Issues (`x509` errors):**
+    - OpenKruise typically uses a self-signed certificate managed by its controller or a tool like `cert-manager`.
+    - Check the secret storing the webhook certificate (often named `kruise-webhook-certs`, `kruise-manager-webhook-cert` or similar in `kruise-system`).
+      ```bash
+      kubectl get secret -n kruise-system | grep webhook
+      kubectl get secret -n kruise-system <webhook-cert-secret-name> -o yaml
+      ```
+    - The `caBundle` in webhook configurations must match the CA from this secret.
+    - If certificates have expired or are mismatched, restarting the `kruise-controller-manager` deployment often triggers regeneration (if certificates are self-managed by Kruise):
+      ```bash
+      kubectl rollout restart deployment -n kruise-system kruise-controller-manager
+      ```
+    - Ensure the Kubernetes API server can reach the webhook pod on its webhook port (check NetworkPolicies or firewalls).
+
+5.  **Check Metrics:** Review webhook metrics like `kruise_webhook_admission_requests_total` and `kruise_webhook_admission_duration_seconds` (see [Prometheus Metrics](./prometheus-metrics.md)). High latencies or error rates are indicators.
+
+## CloneSet Troubleshooting
+
+### Pods Not Scaling Up/Down or Not Updating
+
+**Symptoms:**
+- CloneSet `spec.replicas` count doesn't match `status.replicas` or `status.readyReplicas`.
+- Pods are not created/deleted/updated as expected when the CloneSet spec changes.
+
+**Troubleshooting Steps:**
+
+1.  Describe the CloneSet and check its status and events:
+    ```bash
+    kubectl describe cloneset <cloneset-name> -n <namespace>
+    kubectl get events --field-selector involvedObject.kind=CloneSet,involvedObject.name=<cloneset-name>,involvedObject.namespace=<namespace> --sort-by='.lastTimestamp'
+    ```
+    Look for conditions like `Progressing=False` or error messages in events.
+
+2.  Check controller logs, filtering for the CloneSet name or UID:
+    ```bash
+    # Get UID of the CloneSet
+    # kubectl get cloneset <cloneset-name> -n <namespace> -o jsonpath='{.metadata.uid}'
+    kubectl logs -n kruise-system -l control-plane=controller-manager -c manager | grep "<cloneset-name-or-uid>"
+    ```
+
+3.  Verify Pod template validity: If the pod template is invalid (e.g., image not found, bad configuration, failing readiness/liveness probes), new pods might fail to start or become ready. Check `kubectl describe pod <new-pod-name>` for newly created pods.
+
+4.  Check `spec.updateStrategy.partition` and `spec.updateStrategy.maxUnavailable`/`maxSurge`. A high partition number can prevent updates to pods with lower ordinal numbers.
+
+5.  Review metrics for the `cloneset-controller` (see [Prometheus Metrics](./prometheus-metrics.md)).
+
+### In-place Update Issues
+
+**Symptoms:**
+- Pods are recreated instead of updated in-place when only container images or specific annotations/labels change.
+- In-place update seems stuck.
+
+**Troubleshooting Steps:**
+
+1.  Ensure `spec.updateStrategy.type` is `InPlaceIfPossible` or `InPlaceOnly`.
+    ```bash
+    kubectl get cloneset <cloneset-name> -n <namespace> -o jsonpath="{.spec.updateStrategy.type}"
+    ```
+
+2.  Verify that the change made qualifies for in-place update (typically only `spec.template.spec.containers[*].image` and certain metadata). Other changes will force pod recreation. Consult OpenKruise documentation for exact fields supporting in-place update.
+
+3.  Examine pod annotations related to in-place update:
+    ```bash
+    kubectl get pod <pod-name> -n <namespace> -o jsonpath="{.metadata.annotations.apps\.kruise\.io/in-place-update-state}"
+    kubectl get pod <pod-name> -n <namespace> -o yaml # Look for other kruise annotations like 'apps.kruise.io/inplace-update-grace-period'
+    ```
+
+4.  Check pod events and container statuses. In-place update might be blocked by readiness/liveness probes failing post-update or by preStop/postStart hooks.
+
+## Advanced StatefulSet Troubleshooting
+
+(Troubleshooting steps are often similar to CloneSet, but with StatefulSet-specific considerations like persistent identity and storage.)
+
+### In-place Update Not Working
+
+**Symptoms & Steps:** Similar to CloneSet in-place update issues. Verify `spec.updateStrategy.type`. Check the `podUpdatePolicy` field in `rollingUpdate` strategy.
+
+### PVC Issues
+
+**Symptoms:**
+- Pods are stuck in `Pending` due to PVC binding issues.
+- Events show errors like "Failed to provision volume" or "PVC not found".
+
+**Troubleshooting Steps:**
+
+1.  Check PVC status:
+    ```bash
+    kubectl get pvc -n <namespace> | grep <statefulset-name>
+    kubectl describe pvc <pvc-name> -n <namespace>
+    ```
+
+2.  Verify `volumeClaimTemplates` in the AdvancedStatefulSet spec.
+3.  Check `StorageClass` configuration and persistent volume provisioner logs.
+4.  Ensure that if `spec.reserveOrdinals` is used, it's not conflicting with PVC creation for active ordinals.
+
+## SidecarSet Troubleshooting
+
+### Sidecars Not Injected
+
+**Symptoms:**
+- Expected sidecar containers are missing from target pods after they are created or restarted.
+
+**Troubleshooting Steps:**
+
+1.  Verify SidecarSet `spec.selector` correctly matches labels of target pods.
+    ```bash
+    kubectl get sidecarset <sidecarset-name> -o jsonpath="{.spec.selector}"
+    kubectl get pods -n <target-namespace> --show-labels # Check if pods have matching labels
+    ```
+
+2.  Ensure the SidecarSet is in the correct scope. Namespace-scoped SidecarSets only affect pods in their own namespace unless `spec.namespaceSelector` is used to target other namespaces.
+    ```bash
+    kubectl get sidecarset <sidecarset-name> -o jsonpath="{.spec.namespace}" # if defined
+    kubectl get sidecarset <sidecarset-name> -o jsonpath="{.spec.namespaceSelector}" # if defined
+    ```
+
+3.  Check webhook functionality (see [Webhook Issues](#webhook-issues)). Sidecar injection relies on a mutating admission webhook.
+
+4.  Inspect SidecarSet status and events:
+    ```bash
+    kubectl describe sidecarset <sidecarset-name>
+    kubectl get sidecarset <sidecarset-name> -o jsonpath='{.status}'
+    ```
+    Look at `status.matchedPods`, `status.updatedPods`.
+
+### Sidecar Update Issues
+
+**Symptoms:**
+- Sidecar containers in existing pods are not updated when the SidecarSet spec (e.g., sidecar image) changes.
+
+**Troubleshooting Steps:**
+
+1.  Verify `spec.updateStrategy.type` (e.g., `RollingUpdate`).
+2.  Check if pods have the necessary annotations indicating SidecarSet control and hash, e.g., `apps.kruise.io/sidecarset-hash`.
+3.  The update process might be gradual, depending on the `rollingUpdate` strategy (e.g., `maxUnavailable`). Monitor `status.updatedPods` and `status.updatedReadyPods`.
+4.  For changes to take effect on existing pods, they typically need to be restarted or recreated if the update strategy doesn't automatically trigger it (e.g., for non-image changes, or if `injectionStrategy.policy` is not `Always`).
+
+## Other Kruise Workloads
+
+(UnitedDeployment, BroadcastJob, AdvancedDaemonSet, etc.)
+Follow similar patterns:
+1.  `kubectl describe <kind> <name> -n <namespace>`
+2.  Check controller logs, filtering for the resource name or UID.
+3.  Check events.
+4.  Verify webhook functionality if applicable.
+5.  Consult specific documentation for that workload type.
+
+## Common Error Messages
+
+### "admission webhook ... denied the request because ..."
+
+**Possible Causes:**
+- Invalid resource spec according to OpenKruise validation rules.
+- An external policy controller (like OPA Gatekeeper, Kyverno) is denying the request due to a policy violation.
+
+**Resolution:**
+1.  Carefully read the denial message; it usually explains the reason.
+2.  Correct the resource YAML definition.
+3.  If it's an external policy controller, check its logs and policies.
+
+### "controller-runtime manager error" / "leader election lost" / "context deadline exceeded"
+
+**Possible Causes:**
+- Controller manager pod crashed or was restarted.
+- Network issues between manager pods or with the Kubernetes API server.
+- Resource contention (CPU/memory) on the manager pod or its node.
+- API server is overloaded or unresponsive.
+
+**Resolution:**
+1.  Check controller manager logs (see [General Troubleshooting Steps](#general-troubleshooting-steps)).
+2.  Ensure multiple replicas of `kruise-controller-manager` (if configured) can communicate for leader election (check Kubernetes events for leader election messages).
+3.  Check for resource exhaustion on nodes running the controller manager or on the API server itself.
+4.  Monitor API server latency and error rates.
+
+## Diagnostic Commands
+
+### Collecting Logs and Information for a Bug Report
+
+```bash
+# Controller manager deployment and pod details
+kubectl get deployment -n kruise-system kruise-controller-manager -o yaml > kruise-manager-deployment.yaml
+kubectl get pods -n kruise-system -l control-plane=controller-manager -o wide > kruise-manager-pods.txt
+kubectl describe pods -n kruise-system -l control-plane=controller-manager > kruise-manager-pods-describe.txt
+
+# Controller manager logs (collect a significant amount, e.g., last hour or since issue started if possible)
+kubectl logs -n kruise-system deploy/kruise-controller-manager -c manager --since=1h > kruise-manager.log
+
+# Describe problematic Kruise resource
+kubectl get <kind> <name> -n <namespace> -o yaml > my-resource.yaml
+kubectl describe <kind> <name> -n <namespace> > my-resource-describe.txt
+
+# Relevant events (from workload namespace and kruise-system)
+kubectl get events -n <namespace> --sort-by='.lastTimestamp' > workload-ns-events.txt
+kubectl get events -n kruise-system --sort-by='.lastTimestamp' > kruise-system-events.txt
+
+# Webhook configurations (adjust labels if your Kruise installation uses different ones)
+kubectl get mutatingwebhookconfiguration -l app.kubernetes.io/part-of=openkruise -o yaml > mutatingwebhooks.yaml
+kubectl get validatingwebhookconfiguration -l app.kubernetes.io/part-of=openkruise -o yaml > validatingwebhooks.yaml
+
+# CRD definitions for relevant Kruise kinds
+# kubectl get crd <crd-name.kruise.io> -o yaml > crd-<kind>.yaml


### PR DESCRIPTION
This PR introduces the Markdown files for a new "Operations Guide" under the `docs/operations/` directory. This guide is intended to help users and operators effectively monitor, troubleshoot, and maintain OpenKruise installations.

**Key Documentation Files Added:**

*   `docs/operations/README.md`: An introductory page for the operations guide.
*   `docs/operations/prometheus-metrics.md`:
    *   Details on enabling and accessing OpenKruise metrics.
    *   Categorization of key metrics.
    *   Guidance on setting up Prometheus `ServiceMonitor` and example alerting rules.
    *   A compact, example Grafana dashboard JSON.
*   `docs/operations/troubleshooting.md`:
    *   General troubleshooting methodology.
    *   Specific troubleshooting steps for controllers, webhooks, and various Kruise workloads.
    *   Common error messages and diagnostic commands.

**Purpose:**

These files provide the core content for an operational guide. The navigation for these documents on the `openkruise.io` website will be added via a separate Pull Request to the `openkruise/openkruise.io` repository.

**Related Issue (Clarification):**

This PR provides operational documentation. It **does not** directly address or fix feature request openkruise/kruise#1672 ("Support for configmaps grayscale publishing"), which is a feature implementation task. A pr from [openkruise.io](https://github.com/openkruise/openkruise.io) will be linked to this pr which would be a feature implementing pr.

**How to Review:**

*   Check the content of the new Markdown files in `docs/operations/` for clarity, accuracy, and completeness.
*   Verify the correctness of commands and YAML examples within the documentation.

Looking forward to feedback!


