### PR TITLE
docs: Update embargo.md with project name and security contacts

### DIFF
--- a/embargo.md
+++ b/embargo.md
@@ -1,9 +1,9 @@
 # Notice of Embargo
 
 This is an embargoed notification that a vulnerability has been discovered in
-<!-- TODO: $PROJECT -->. This notice has been sent to subscribed distributors and service
+OpenKruise/Kruise. This notice has been sent to subscribed distributors and service
 providers in order to allow for timely patching. You are receiving this
-notification as you have agreed to abide by the embargo policy (<!-- TODO: $LINK -->) on this
+notification as you have agreed to abide by the embargo policy (https://github.com/openkruise/kruise/security/policy) on this
 project. Do not forward this information to other parties without complying with
 the instructions of the embargo policy.
 
@@ -57,4 +57,4 @@ when it will be available or links to where the patch will be available.*
 * issue public patches before the disclosure date
 
 This list will be notified immediately if the disclosure date is at risk or
-changes. Questions should be directed to the security contacts <!-- TODO: $LINK -->.
+changes. Questions should be directed to the security contacts at kubernetes-security@service.aliyun.com.


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
This PR updates the embargo notice template by:
1. Replacing placeholder text with the actual project name "OpenKruise/Kruise"
2. Adding a direct link to the project's security policy
3. Including the security contact email address

### Ⅱ. Does this pull request fix one issue?
NONE

### Ⅲ. Describe how to verify it
1. Review the changes to ensure:
   - The project name is correctly set to "OpenKruise/Kruise"
   - The security policy link points to: https://github.com/openkruise/kruise/security/policy
   - The security contact email is set to: kubernetes-security@service.aliyun.com
   - All template placeholders have been properly replaced

### Ⅳ. Special notes for reviews
- This is a documentation-only change
- The changes follow the existing template structure
- No functional changes or code modifications are included