### PR TITLE
feature: add RESIZE action for pub protection.

### DIFF
--- a/apis/policy/v1alpha1/podunavailablebudget_types.go
+++ b/apis/policy/v1alpha1/podunavailablebudget_types.go
@@ -27,14 +27,22 @@ import (
 type PubOperation string
 
 const (
-	// PubProtectOperationAnnotation indicates the pub protected Operation[DELETE,UPDATE,EVICT]
-	// if annotations[kruise.io/pub-protect-operations]=EVICT indicates the pub only protect evict pod
-	// if the annotations do not exist, the default DELETE,EVICT,UPDATE are protected
+	// PubProtectOperationAnnotation indicates the pub protected Operation[DELETE,UPDATE,EVICT,RESIZE].
+	// if annotations[kruise.io/pub-protect-operations]=EVICT indicates the pub only protect evict pod.
+	// if the annotations do not exist, the default DELETE,EVICT,UPDATE,RESIZE are protected.
+	// RESIZE is a special UPDATE operation that represents changes to container resources. When the
+	// pod feature gate InPlacePodVerticalScaling is not enabled, it will degrade to the UPDATE strategy.
+	// When the pod feature gate InPlacePodVerticalScaling is enabled, it will protect against cases
+	// where in-place resizing is not possible. Specifically, these scenarios include:
+	// - 1. Changes to resources when restartPolicy == restartContainer.
+	// - 2. Changes to static pod resources.
+	// - 3. Changes to pod QoS.
 	PubProtectOperationAnnotation = "kruise.io/pub-protect-operations"
 	// pod webhook operation
 	PubUpdateOperation PubOperation = "UPDATE"
 	PubDeleteOperation PubOperation = "DELETE"
 	PubEvictOperation  PubOperation = "EVICT"
+	PubResizeOperation PubOperation = "RESIZE"
 	// PubProtectTotalReplicasAnnotation is the target replicas.
 	// By default, PUB will get the target replicas through workload.spec.replicas. but there are some scenarios that may workload doesn't
 	// implement scale subresources or Pod doesn't have workload management. In this scenario, you can set pub.kruise.io/protect-total-replicas

--- a/apis/policy/v1alpha1/podunavailablebudget_types.go
+++ b/apis/policy/v1alpha1/podunavailablebudget_types.go
@@ -31,7 +31,8 @@ const (
 	// if annotations[kruise.io/pub-protect-operations]=EVICT indicates the pub only protect evict pod.
 	// if the annotations do not exist, the default DELETE,EVICT,UPDATE are protected.
 	// RESIZE: Pod vertical scaling action. If it's enabled, all resize action will be protected. RESIZE
-	// is an extension of UPDATE, so if RESIZE is enabled, UPDATE will also be protected.
+	// is an extension of UPDATE, if RESIZE is disabled and UPDATE is enabled, any UPDATE operation will
+	// be protected only as it will definitely cause container restarts.
 	// UPDATE: Kruise will carefully differentiate whether this update will cause interruptions. When
 	// the FeatureGate InPlacePodVerticalScaling is enabled, pod inplace vertical scaling will be
 	// considered non-disruption only when allowedResources(cpu、memory) changes、restartPolicy

--- a/apis/policy/v1alpha1/podunavailablebudget_types.go
+++ b/apis/policy/v1alpha1/podunavailablebudget_types.go
@@ -27,16 +27,16 @@ import (
 type PubOperation string
 
 const (
-	// PubProtectOperationAnnotation indicates the pub protected Operation[DELETE,UPDATE,EVICT,RESIZE].
+	// PubProtectOperationAnnotation indicates the pub protected Operation[DELETE,UPDATE,EVICT].
 	// if annotations[kruise.io/pub-protect-operations]=EVICT indicates the pub only protect evict pod.
-	// if the annotations do not exist, the default DELETE,EVICT,UPDATE,RESIZE are protected.
-	// RESIZE is a special UPDATE operation that represents changes to container resources. When the
-	// pod feature gate InPlacePodVerticalScaling is not enabled, it will degrade to the UPDATE strategy.
-	// When the pod feature gate InPlacePodVerticalScaling is enabled, it will protect against cases
-	// where in-place resizing is not possible. Specifically, these scenarios include:
-	// - 1. Changes to resources when restartPolicy == restartContainer.
-	// - 2. Changes to static pod resources.
-	// - 3. Changes to pod QoS.
+	// if the annotations do not exist, the default DELETE,EVICT,UPDATE are protected.
+	// RESIZE: Pod vertical scaling action. If it's enabled, all resize action will be protected. RESIZE
+	// is an extension of UPDATE, so if RESIZE is enabled, UPDATE will also be protected.
+	// UPDATE: Kruise will carefully differentiate whether this update will cause interruptions. When
+	// the FeatureGate InPlacePodVerticalScaling is enabled, pod inplace vertical scaling will be
+	// considered non-disruption only when allowedResources(cpu、memory) changes、restartPolicy
+	// is not restartContainer、is not static pod and QoS not changed. But if featureGate
+	// InPlacePodVerticalScaling is disabled, all resize action will be considered as disruption.
 	PubProtectOperationAnnotation = "kruise.io/pub-protect-operations"
 	// pod webhook operation
 	PubUpdateOperation PubOperation = "UPDATE"

--- a/pkg/control/pubcontrol/api.go
+++ b/pkg/control/pubcontrol/api.go
@@ -46,6 +46,8 @@ type pubControl interface {
 	// webhook
 	// determine if this change to pod might cause unavailability
 	IsPodUnavailableChanged(oldPod, newPod *corev1.Pod) bool
+	// determine if this change can resize inplace
+	CanResizeInplace(oldPod, newPod *corev1.Pod) bool
 	// get pub for pod
 	GetPubForPod(pod *corev1.Pod) (*policyv1alpha1.PodUnavailableBudget, error)
 	// get pod controller of

--- a/pkg/control/pubcontrol/pub_control_test.go
+++ b/pkg/control/pubcontrol/pub_control_test.go
@@ -154,6 +154,119 @@ func TestIsPodUnavailableChanged(t *testing.T) {
 			expect: false,
 		},
 		{
+			name: "resources changed but with unavailable label",
+			getOldPod: func() *corev1.Pod {
+				demo := podDemo.DeepCopy()
+				demo.Spec.Containers[0].Resources = corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("2Gi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("2"),
+						corev1.ResourceMemory: resource.MustParse("4Gi"),
+					},
+				}
+				return demo
+			},
+			getNewPod: func() *corev1.Pod {
+				demo := podDemo.DeepCopy()
+				demo.Labels = map[string]string{
+					fmt.Sprintf("%sdata", pub.PubUnavailablePodLabelPrefix): "true",
+				}
+				demo.Spec.Containers[0].Resources = corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("3"),
+						corev1.ResourceMemory: resource.MustParse("3Gi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("2"),
+						corev1.ResourceMemory: resource.MustParse("4Gi"),
+					},
+				}
+				return demo
+			},
+			getPub: func() *policyv1alpha1.PodUnavailableBudget {
+				pub := pubDemo.DeepCopy()
+				return pub
+			},
+			expect: true,
+		},
+		{
+			name: "storage resources changed 1",
+			getOldPod: func() *corev1.Pod {
+				demo := podDemo.DeepCopy()
+				demo.Spec.Containers[0].Resources = corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("2Gi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("2"),
+						corev1.ResourceMemory: resource.MustParse("4Gi"),
+					},
+				}
+				return demo
+			},
+			getNewPod: func() *corev1.Pod {
+				demo := podDemo.DeepCopy()
+				demo.Spec.Containers[0].Resources = corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("2Gi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:     resource.MustParse("2"),
+						corev1.ResourceMemory:  resource.MustParse("4Gi"),
+						corev1.ResourceStorage: resource.MustParse("1Gi"),
+					},
+				}
+				return demo
+			},
+			getPub: func() *policyv1alpha1.PodUnavailableBudget {
+				pub := pubDemo.DeepCopy()
+				return pub
+			},
+			expect: true,
+		},
+		{
+			name: "storage resources changed 2",
+			getOldPod: func() *corev1.Pod {
+				demo := podDemo.DeepCopy()
+				demo.Spec.Containers[0].Resources = corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:     resource.MustParse("1"),
+						corev1.ResourceMemory:  resource.MustParse("2Gi"),
+						corev1.ResourceStorage: resource.MustParse("1Gi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("2"),
+						corev1.ResourceMemory: resource.MustParse("4Gi"),
+					},
+				}
+				return demo
+			},
+			getNewPod: func() *corev1.Pod {
+				demo := podDemo.DeepCopy()
+				demo.Spec.Containers[0].Resources = corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("2Gi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("2"),
+						corev1.ResourceMemory: resource.MustParse("4Gi"),
+					},
+				}
+				return demo
+			},
+			getPub: func() *policyv1alpha1.PodUnavailableBudget {
+				pub := pubDemo.DeepCopy()
+				return pub
+			},
+			expect: true,
+		},
+		{
 			name: "resources changed but static pod",
 			getOldPod: func() *corev1.Pod {
 				demo := podDemo.DeepCopy()

--- a/pkg/control/pubcontrol/pub_control_test.go
+++ b/pkg/control/pubcontrol/pub_control_test.go
@@ -21,8 +21,15 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/kubelet/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/openkruise/kruise/apis/apps/pub"
+	policyv1alpha1 "github.com/openkruise/kruise/apis/policy/v1alpha1"
+	"github.com/openkruise/kruise/pkg/features"
+	"github.com/openkruise/kruise/pkg/util/controllerfinder"
+	"github.com/openkruise/kruise/pkg/util/feature"
 )
 
 func TestIsPodUnavailableChanged(t *testing.T) {
@@ -30,6 +37,7 @@ func TestIsPodUnavailableChanged(t *testing.T) {
 		name      string
 		getOldPod func() *corev1.Pod
 		getNewPod func() *corev1.Pod
+		getPub    func() *policyv1alpha1.PodUnavailableBudget
 		expect    bool
 	}{
 		{
@@ -42,6 +50,10 @@ func TestIsPodUnavailableChanged(t *testing.T) {
 				demo := podDemo.DeepCopy()
 				demo.Annotations["add"] = "annotations"
 				return demo
+			},
+			getPub: func() *policyv1alpha1.PodUnavailableBudget {
+				pub := pubDemo.DeepCopy()
+				return pub
 			},
 			expect: false,
 		},
@@ -56,6 +68,10 @@ func TestIsPodUnavailableChanged(t *testing.T) {
 				demo.Labels[fmt.Sprintf("%sdata", pub.PubUnavailablePodLabelPrefix)] = "true"
 				return demo
 			},
+			getPub: func() *policyv1alpha1.PodUnavailableBudget {
+				pub := pubDemo.DeepCopy()
+				return pub
+			},
 			expect: true,
 		},
 		{
@@ -69,16 +85,410 @@ func TestIsPodUnavailableChanged(t *testing.T) {
 				demo.Spec.Containers[0].Image = "nginx:v2"
 				return demo
 			},
+			getPub: func() *policyv1alpha1.PodUnavailableBudget {
+				pub := pubDemo.DeepCopy()
+				return pub
+			},
 			expect: true,
+		},
+		{
+			name: "qos changed",
+			getOldPod: func() *corev1.Pod {
+				demo := podDemo.DeepCopy()
+				return demo
+			},
+			getNewPod: func() *corev1.Pod {
+				demo := podDemo.DeepCopy()
+				demo.Spec.Containers[0].Resources = corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
+					},
+				}
+				return demo
+			},
+			getPub: func() *policyv1alpha1.PodUnavailableBudget {
+				pub := pubDemo.DeepCopy()
+				return pub
+			},
+			expect: true,
+		},
+		{
+			name: "resources changed",
+			getOldPod: func() *corev1.Pod {
+				demo := podDemo.DeepCopy()
+				demo.Spec.Containers[0].Resources = corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("2Gi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("2"),
+						corev1.ResourceMemory: resource.MustParse("4Gi"),
+					},
+				}
+				return demo
+			},
+			getNewPod: func() *corev1.Pod {
+				demo := podDemo.DeepCopy()
+				demo.Spec.Containers[0].Resources = corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("3"),
+						corev1.ResourceMemory: resource.MustParse("3Gi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("2"),
+						corev1.ResourceMemory: resource.MustParse("4Gi"),
+					},
+				}
+				return demo
+			},
+			getPub: func() *policyv1alpha1.PodUnavailableBudget {
+				pub := pubDemo.DeepCopy()
+				return pub
+			},
+			expect: false,
+		},
+		{
+			name: "resources changed but static pod",
+			getOldPod: func() *corev1.Pod {
+				demo := podDemo.DeepCopy()
+				demo.Spec.Containers[0].Resources = corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("2Gi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("2"),
+						corev1.ResourceMemory: resource.MustParse("4Gi"),
+					},
+				}
+				return demo
+			},
+			getNewPod: func() *corev1.Pod {
+				demo := podDemo.DeepCopy()
+				if demo.Annotations == nil {
+					demo.Annotations = make(map[string]string)
+				}
+				demo.Annotations[types.ConfigSourceAnnotationKey] = types.FileSource
+				demo.Spec.Containers[0].Resources = corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("3"),
+						corev1.ResourceMemory: resource.MustParse("3Gi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("2"),
+						corev1.ResourceMemory: resource.MustParse("4Gi"),
+					},
+				}
+				return demo
+			},
+			getPub: func() *policyv1alpha1.PodUnavailableBudget {
+				pub := pubDemo.DeepCopy()
+				return pub
+			},
+			expect: true,
+		},
+		{
+			name: "resources changed but resizePolicy is restart",
+			getOldPod: func() *corev1.Pod {
+				demo := podDemo.DeepCopy()
+				demo.Spec.Containers[0].ResizePolicy = []corev1.ContainerResizePolicy{
+					{
+						ResourceName:  corev1.ResourceCPU,
+						RestartPolicy: corev1.RestartContainer,
+					},
+				}
+				demo.Spec.Containers[0].Resources = corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("2Gi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("2"),
+						corev1.ResourceMemory: resource.MustParse("4Gi"),
+					},
+				}
+				return demo
+			},
+			getNewPod: func() *corev1.Pod {
+				demo := podDemo.DeepCopy()
+				demo.Spec.Containers[0].ResizePolicy = []corev1.ContainerResizePolicy{
+					{
+						ResourceName:  corev1.ResourceCPU,
+						RestartPolicy: corev1.RestartContainer,
+					},
+				}
+				demo.Spec.Containers[0].Resources = corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("2"),
+						corev1.ResourceMemory: resource.MustParse("2Gi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("2"),
+						corev1.ResourceMemory: resource.MustParse("4Gi"),
+					},
+				}
+				return demo
+			},
+			getPub: func() *policyv1alpha1.PodUnavailableBudget {
+				pub := pubDemo.DeepCopy()
+				return pub
+			},
+			expect: true,
+		},
+		{
+			name: "resources changed mixed resizePolicy",
+			getOldPod: func() *corev1.Pod {
+				demo := podDemo.DeepCopy()
+				demo.Spec.Containers[0].ResizePolicy = []corev1.ContainerResizePolicy{
+					{
+						ResourceName:  corev1.ResourceCPU,
+						RestartPolicy: corev1.RestartContainer,
+					},
+					{
+						ResourceName:  corev1.ResourceMemory,
+						RestartPolicy: corev1.NotRequired,
+					},
+				}
+				demo.Spec.Containers[0].Resources = corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("2Gi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("2"),
+						corev1.ResourceMemory: resource.MustParse("4Gi"),
+					},
+				}
+				return demo
+			},
+			getNewPod: func() *corev1.Pod {
+				demo := podDemo.DeepCopy()
+				demo.Spec.Containers[0].ResizePolicy = []corev1.ContainerResizePolicy{
+					{
+						ResourceName:  corev1.ResourceCPU,
+						RestartPolicy: corev1.RestartContainer,
+					},
+					{
+						ResourceName:  corev1.ResourceMemory,
+						RestartPolicy: corev1.NotRequired,
+					},
+				}
+				demo.Spec.Containers[0].Resources = corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("3Gi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("2"),
+						corev1.ResourceMemory: resource.MustParse("5Gi"),
+					},
+				}
+				return demo
+			},
+			getPub: func() *policyv1alpha1.PodUnavailableBudget {
+				pub := pubDemo.DeepCopy()
+				return pub
+			},
+			expect: false,
+		},
+	}
+
+	feature.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.InPlacePodVerticalScaling, true)
+	defer feature.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.InPlacePodVerticalScaling, false)
+	for _, cs := range cases {
+		t.Run(cs.name, func(t *testing.T) {
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cs.getPub()).
+				WithStatusSubresource(&policyv1alpha1.PodUnavailableBudget{}).Build()
+			finder := &controllerfinder.ControllerFinder{Client: fakeClient}
+			control := commonControl{
+				Client:           fakeClient,
+				controllerFinder: finder,
+			}
+			is := control.IsPodUnavailableChanged(cs.getOldPod(), cs.getNewPod())
+			if cs.expect != is {
+				t.Fatalf("IsPodUnavailableChanged failed")
+			}
+		})
+	}
+}
+
+func TestIsNeedProtectResizeAction(t *testing.T) {
+	cases := []struct {
+		name           string
+		getPod         func() *corev1.Pod
+		getPub         func() *policyv1alpha1.PodUnavailableBudget
+		enabledFeature bool
+		expect         bool
+	}{
+		{
+			name:           "feature not enabled",
+			getPod:         func() *corev1.Pod { return podDemo.DeepCopy() },
+			getPub:         func() *policyv1alpha1.PodUnavailableBudget { return pubDemo.DeepCopy() },
+			enabledFeature: false,
+			expect:         false,
+		},
+		{
+			name:   "pub not protect resize action",
+			getPod: func() *corev1.Pod { return podDemo.DeepCopy() },
+			getPub: func() *policyv1alpha1.PodUnavailableBudget {
+				pub := pubDemo.DeepCopy()
+				if pub.Annotations == nil {
+					pub.Annotations = map[string]string{}
+				}
+				pub.Annotations[policyv1alpha1.PubProtectOperationAnnotation] = string(policyv1alpha1.PubUpdateOperation)
+				return pub
+			},
+			enabledFeature: true,
+			expect:         false,
+		},
+		{
+			name:   "pub protect resize action",
+			getPod: func() *corev1.Pod { return podDemo.DeepCopy() },
+			getPub: func() *policyv1alpha1.PodUnavailableBudget {
+				pub := pubDemo.DeepCopy()
+				if pub.Annotations == nil {
+					pub.Annotations = map[string]string{}
+				}
+				pub.Annotations[policyv1alpha1.PubProtectOperationAnnotation] = string(policyv1alpha1.PubResizeOperation)
+				return pub
+			},
+			enabledFeature: true,
+			expect:         true,
+		},
+		{
+			name:   "pub protect resize action by default",
+			getPod: func() *corev1.Pod { return podDemo.DeepCopy() },
+			getPub: func() *policyv1alpha1.PodUnavailableBudget {
+				pub := pubDemo.DeepCopy()
+				pub.Annotations = nil
+				return pub
+			},
+			enabledFeature: true,
+			expect:         true,
+		},
+	}
+
+	defer feature.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.InPlacePodVerticalScaling, false)
+	for _, cs := range cases {
+		t.Run(cs.name, func(t *testing.T) {
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cs.getPub()).
+				WithStatusSubresource(&policyv1alpha1.PodUnavailableBudget{}).Build()
+			finder := &controllerfinder.ControllerFinder{Client: fakeClient}
+			control := commonControl{
+				Client:           fakeClient,
+				controllerFinder: finder,
+			}
+			feature.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.InPlacePodVerticalScaling, cs.enabledFeature)
+			is := control.isNeedProtectResizeAction(cs.getPod())
+			if cs.expect != is {
+				t.Fatalf("IsPodUnavailableChanged failed")
+			}
+		})
+	}
+}
+
+func TestIsResourceChanged(t *testing.T) {
+	cases := []struct {
+		name               string
+		getOldResourceList func() corev1.ResourceList
+		getNewResourceList func() corev1.ResourceList
+		resourceName       corev1.ResourceName
+		expect             bool
+	}{
+		{
+			name: "resource not exist in old",
+			getOldResourceList: func() corev1.ResourceList {
+				return corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("2Gi"),
+				}
+			},
+			getNewResourceList: func() corev1.ResourceList {
+				return corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("2Gi"),
+				}
+			},
+			resourceName: corev1.ResourceCPU,
+			expect:       true,
+		},
+		{
+			name: "resource not exist in new",
+			getOldResourceList: func() corev1.ResourceList {
+				return corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("2Gi"),
+				}
+			},
+			getNewResourceList: func() corev1.ResourceList {
+				return corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("2Gi"),
+				}
+			},
+			resourceName: corev1.ResourceCPU,
+			expect:       true,
+		},
+		{
+			name: "resource not exist in new and old",
+			getOldResourceList: func() corev1.ResourceList {
+				return corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("2Gi"),
+				}
+			},
+			getNewResourceList: func() corev1.ResourceList {
+				return corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("2Gi"),
+				}
+			},
+			resourceName: corev1.ResourceCPU,
+			expect:       false,
+		},
+		{
+			name: "resource changed",
+			getOldResourceList: func() corev1.ResourceList {
+				return corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("2Gi"),
+				}
+			},
+			getNewResourceList: func() corev1.ResourceList {
+				return corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("2"),
+					corev1.ResourceMemory: resource.MustParse("2Gi"),
+				}
+			},
+			resourceName: corev1.ResourceCPU,
+			expect:       true,
+		},
+		{
+			name: "resource not changed",
+			getOldResourceList: func() corev1.ResourceList {
+				return corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("2Gi"),
+				}
+			},
+			getNewResourceList: func() corev1.ResourceList {
+				return corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("2"),
+					corev1.ResourceMemory: resource.MustParse("2Gi"),
+				}
+			},
+			resourceName: corev1.ResourceMemory,
+			expect:       false,
 		},
 	}
 
 	for _, cs := range cases {
 		t.Run(cs.name, func(t *testing.T) {
-			control := commonControl{}
-			is := control.IsPodUnavailableChanged(cs.getOldPod(), cs.getNewPod())
+			is := isResourceChanged(cs.getOldResourceList(), cs.getNewResourceList(), cs.resourceName)
 			if cs.expect != is {
-				t.Fatalf("IsPodUnavailableChanged failed")
+				t.Fatalf("IsResourceChanged failed")
 			}
 		})
 	}

--- a/pkg/control/pubcontrol/pub_control_utils.go
+++ b/pkg/control/pubcontrol/pub_control_utils.go
@@ -266,10 +266,6 @@ func isNeedPubProtection(pub *policyv1alpha1.PodUnavailableBudget, operation pol
 
 	operations := func() sets.Set[string] {
 		operations := sets.New(strings.Split(operationValue, ",")...)
-		// if resize set in pub protect operation, then protect update and resize
-		if operations.Has(string(policyv1alpha1.PubResizeOperation)) {
-			operations.Insert(string(policyv1alpha1.PubUpdateOperation))
-		}
 		// if disable featureGate InPlacePodVerticalScaling, update will contain resize
 		if !enableInPlacePodVerticalScaling && operations.Has(string(policyv1alpha1.PubUpdateOperation)) {
 			operations.Insert(string(policyv1alpha1.PubResizeOperation))

--- a/pkg/control/pubcontrol/pub_control_utils.go
+++ b/pkg/control/pubcontrol/pub_control_utils.go
@@ -252,8 +252,17 @@ func IsReferenceEqual(ref1, ref2 *policyv1alpha1.TargetReference) bool {
 func isNeedPubProtection(pub *policyv1alpha1.PodUnavailableBudget, operation policyv1alpha1.PubOperation) bool {
 	operationValue, ok := pub.Annotations[policyv1alpha1.PubProtectOperationAnnotation]
 	if !ok || operationValue == "" {
+		// not protect resize as default
+		if operation == policyv1alpha1.PubResizeOperation {
+			return false
+		}
 		return true
 	}
 	operations := sets.NewString(strings.Split(operationValue, ",")...)
+
+	// if resize set in pub protect operation, then protect update and resize
+	if operation == policyv1alpha1.PubUpdateOperation {
+		return operations.Has(string(operation)) || operations.Has(string(policyv1alpha1.PubResizeOperation))
+	}
 	return operations.Has(string(operation))
 }

--- a/pkg/control/pubcontrol/pub_control_utils_test.go
+++ b/pkg/control/pubcontrol/pub_control_utils_test.go
@@ -517,7 +517,7 @@ func TestIsNeedPubProtection(t *testing.T) {
 			expectProtect: true,
 		},
 		{
-			name: "pub protect update when resize set",
+			name: "pub won't protect update when resize set",
 			getPub: func() *policyv1alpha1.PodUnavailableBudget {
 				pub := pubDemo.DeepCopy()
 				pub.Annotations = map[string]string{
@@ -526,7 +526,7 @@ func TestIsNeedPubProtection(t *testing.T) {
 				return pub
 			},
 			operation:     policyv1alpha1.PubUpdateOperation,
-			expectProtect: true,
+			expectProtect: false,
 		},
 		{
 			name: "pub not protect update when resize not set",

--- a/pkg/features/kruise_features.go
+++ b/pkg/features/kruise_features.go
@@ -144,6 +144,12 @@ const (
 
 	// EnableSortSidecarContainerByName enable sidecarSet to sort by container name when injecting sidecar containers
 	EnableSortSidecarContainerByName featuregate.Feature = "EnableSortSidecarContainerByName"
+
+	// Enabling this feature means that the Kubernetes cluster has activated the in-place pod resize
+	// feature (https://kubernetes.io/blog/2025/05/16/kubernetes-v1-33-in-place-pod-resize-beta/).
+	// Under this feature, kruise will think all legal pod-vertical-scaling actions must success.
+	// PodUnavailableBudget will specifically protect the resize actions of individual Pods.
+	InPlacePodVerticalScaling featuregate.Feature = "InPlacePodVerticalScaling"
 )
 
 var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
@@ -183,6 +189,7 @@ var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	InPlaceWorkloadVerticalScaling:           {Default: false, PreRelease: featuregate.Alpha},
 	EnablePodProbeMarkerOnServerless:         {Default: false, PreRelease: featuregate.Alpha},
 	EnableSortSidecarContainerByName:         {Default: false, PreRelease: featuregate.Alpha},
+	InPlacePodVerticalScaling:                {Default: false, PreRelease: featuregate.Alpha},
 }
 
 func init() {

--- a/pkg/util/inplaceupdate/inplace_update_vertical.go
+++ b/pkg/util/inplaceupdate/inplace_update_vertical.go
@@ -57,6 +57,10 @@ func init() {
 	}
 }
 
+func GetNativeVerticalUpdateImpl() *NativeVerticalUpdate {
+	return verticalUpdateImpl.(*NativeVerticalUpdate)
+}
+
 // NativeVerticalUpdate represents the vertical scaling of k8s standard
 type NativeVerticalUpdate struct{}
 

--- a/pkg/webhook/podunavailablebudget/validating/pub_create_update_handler.go
+++ b/pkg/webhook/podunavailablebudget/validating/pub_create_update_handler.go
@@ -89,7 +89,7 @@ func (h *PodUnavailableBudgetCreateUpdateHandler) validatingPodUnavailableBudget
 		operations := strings.Split(operationsValue, ",")
 		for _, operation := range operations {
 			if operation != string(policyv1alpha1.PubUpdateOperation) && operation != string(policyv1alpha1.PubDeleteOperation) &&
-				operation != string(policyv1alpha1.PubEvictOperation) {
+				operation != string(policyv1alpha1.PubEvictOperation) && operation != string(policyv1alpha1.PubResizeOperation) {
 				allErrs = append(allErrs, field.InternalError(field.NewPath("metadata"), fmt.Errorf("annotation[%s] is invalid", policyv1alpha1.PubProtectOperationAnnotation)))
 			}
 		}

--- a/pkg/webhook/podunavailablebudget/validating/pub_validating_test.go
+++ b/pkg/webhook/podunavailablebudget/validating/pub_validating_test.go
@@ -154,7 +154,7 @@ func TestValidatingPub(t *testing.T) {
 				pub := pubDemo.DeepCopy()
 				pub.Spec.Selector = nil
 				pub.Spec.MinAvailable = nil
-				pub.Annotations[policyv1alpha1.PubProtectOperationAnnotation] = string(policyv1alpha1.PubEvictOperation + "," + policyv1alpha1.PubDeleteOperation)
+				pub.Annotations[policyv1alpha1.PubProtectOperationAnnotation] = string(policyv1alpha1.PubEvictOperation + "," + policyv1alpha1.PubDeleteOperation + "," + policyv1alpha1.PubUpdateOperation + "," + policyv1alpha1.PubResizeOperation)
 				return pub
 			},
 			expectErrList: 0,


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
1. Add feature-gate `InPlacePodVerticalScaling` to reflect whether kubernetes can do pod in-place vertical scaling
2. Add `kruise.io/pub-protect-operations: RESIZE` for `podUnavailableBudget` Object

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fix #2049
### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

