### PR TITLE
fix: update deployment link to version 1.8.0 in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ You can view the full documentation from the [OpenKruise website](https://openkr
 
 - install Kruise on a Serverless K8S cluster in 3 minutes, try:
 
-  <a href="https://acs.console.aliyun.com/quick-deploy?repo=openkruise/charts&branch=master&paths=%5B%22versions/kruise/1.7.3%22%5D" target="_blank">
+  <a href="https://acs.console.aliyun.com/quick-deploy?repo=openkruise/charts&branch=master&paths=%5B%22versions/kruise/1.8.0%22%5D" target="_blank">
     <img src="https://img.alicdn.com/imgextra/i1/O1CN01aiPSuA1Wiz7wkgF5u_!!6000000002823-55-tps-399-70.svg" width="200" alt="Deploy on Alibaba Cloud">
   </a>
 


### PR DESCRIPTION


### Ⅰ. Describe what this PR does

This PR updates the deployment instructions in the `README.md` to point to the latest Kruise version.

### Ⅱ. Does this pull request fix one issue?

none

### Ⅲ. Describe how to verify it

Check the `README.md` file and verify that the quick-deploy link now uses Kruise version `1.8.0` instead of `1.7.3`.

### Ⅳ. Special notes for reviews

none