### PR TITLE
Refactor: Replace deprecated wait.PollImmediate with wait.PollUntilContextTimeout across codebase

### DIFF
--- a/test/e2e/apps/daemonset.go
+++ b/test/e2e/apps/daemonset.go
@@ -63,7 +63,9 @@ var _ = SIGDescribe("DaemonSet", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By("Check that daemon pods launch on every node of the cluster.")
-			err = wait.PollImmediate(framework.DaemonSetRetryPeriod, framework.DaemonSetRetryTimeout, tester.CheckRunningOnAllNodes(ds))
+			err = wait.PollUntilContextTimeout(context.TODO(), framework.DaemonSetRetryPeriod, framework.DaemonSetRetryTimeout, true, func(context.Context) (bool, error) {
+				return tester.CheckRunningOnAllNodes(ds)()
+			})
 
 			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "error waiting for daemon pod to start")
 			err = tester.CheckDaemonStatus(dsName)
@@ -78,7 +80,9 @@ var _ = SIGDescribe("DaemonSet", func() {
 			err = c.CoreV1().Pods(ns).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			err = wait.PollImmediate(framework.DaemonSetRetryPeriod, framework.DaemonSetRetryTimeout, tester.CheckRunningOnAllNodes(ds))
+			err = wait.PollUntilContextTimeout(context.TODO(), framework.DaemonSetRetryPeriod, framework.DaemonSetRetryTimeout, true, func(context.Context) (bool, error) {
+				return tester.CheckRunningOnAllNodes(ds)()
+			})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "error waiting for daemon pod to revive")
 		})
 
@@ -97,7 +101,9 @@ var _ = SIGDescribe("DaemonSet", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By("Initially, daemon pods should not be running on any nodes.")
-			err = wait.PollImmediate(framework.DaemonSetRetryPeriod, framework.DaemonSetRetryTimeout, tester.CheckRunningOnNoNodes(ds))
+			err = wait.PollUntilContextTimeout(context.TODO(), framework.DaemonSetRetryPeriod, framework.DaemonSetRetryTimeout, true, func(context.Context) (bool, error) {
+				return tester.CheckRunningOnNoNodes(ds)()
+			})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "error waiting for daemon pods to be running on no nodes")
 
 			ginkgo.By("Change node label to blue, check that daemon pod is launched.")
@@ -107,7 +113,9 @@ var _ = SIGDescribe("DaemonSet", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "error setting labels on node")
 			daemonSetLabels, _ := tester.SeparateDaemonSetNodeLabels(newNode.Labels)
 			gomega.Expect(len(daemonSetLabels)).To(gomega.Equal(1))
-			err = wait.PollImmediate(framework.DaemonSetRetryPeriod, framework.DaemonSetRetryTimeout, tester.CheckDaemonPodOnNodes(ds, []string{newNode.Name}))
+			err = wait.PollUntilContextTimeout(context.TODO(), framework.DaemonSetRetryPeriod, framework.DaemonSetRetryTimeout, true, func(context.Context) (bool, error) {
+				return tester.CheckDaemonPodOnNodes(ds, []string{newNode.Name})()
+			})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "error waiting for daemon pods to be running on new nodes")
 			err = tester.CheckDaemonStatus(dsName)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -116,7 +124,9 @@ var _ = SIGDescribe("DaemonSet", func() {
 			nodeSelector[framework.DaemonSetColorLabel] = "green"
 			greenNode, err := tester.SetDaemonSetNodeLabels(nodeList.Items[0].Name, nodeSelector)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "error removing labels on node")
-			gomega.Expect(wait.PollImmediate(framework.DaemonSetRetryPeriod, framework.DaemonSetRetryTimeout, tester.CheckRunningOnNoNodes(ds))).
+			gomega.Expect(wait.PollUntilContextTimeout(context.TODO(), framework.DaemonSetRetryPeriod, framework.DaemonSetRetryTimeout, true, func(context.Context) (bool, error) {
+				return tester.CheckRunningOnNoNodes(ds)()
+			})).
 				NotTo(gomega.HaveOccurred(), "error waiting for daemon pod to not be running on nodes")
 
 			ginkgo.By("Update DaemonSet node selector to green, and change its update strategy to RollingUpdate")
@@ -126,7 +136,9 @@ var _ = SIGDescribe("DaemonSet", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "error patching daemon set")
 			daemonSetLabels, _ = tester.SeparateDaemonSetNodeLabels(greenNode.Labels)
 			gomega.Expect(len(daemonSetLabels)).To(gomega.Equal(1))
-			err = wait.PollImmediate(framework.DaemonSetRetryPeriod, framework.DaemonSetRetryTimeout, tester.CheckDaemonPodOnNodes(ds, []string{greenNode.Name}))
+			err = wait.PollUntilContextTimeout(context.TODO(), framework.DaemonSetRetryPeriod, framework.DaemonSetRetryTimeout, true, func(context.Context) (bool, error) {
+				return tester.CheckDaemonPodOnNodes(ds, []string{greenNode.Name})()
+			})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "error waiting for daemon pods to be running on new nodes")
 			err = tester.CheckDaemonStatus(dsName)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -144,7 +156,9 @@ var _ = SIGDescribe("DaemonSet", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By("Check that daemon pods launch on every node of the cluster.")
-			err = wait.PollImmediate(framework.DaemonSetRetryPeriod, framework.DaemonSetRetryTimeout, tester.CheckRunningOnAllNodes(ds))
+			err = wait.PollUntilContextTimeout(context.TODO(), framework.DaemonSetRetryPeriod, framework.DaemonSetRetryTimeout, true, func(context.Context) (bool, error) {
+				return tester.CheckRunningOnAllNodes(ds)()
+			})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "error waiting for daemon pod to start")
 			err = tester.CheckDaemonStatus(dsName)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -157,11 +171,15 @@ var _ = SIGDescribe("DaemonSet", func() {
 			pod.Status.Phase = v1.PodFailed
 			_, err = c.CoreV1().Pods(ns).UpdateStatus(context.TODO(), &pod, metav1.UpdateOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "error failing a daemon pod")
-			err = wait.PollImmediate(framework.DaemonSetRetryPeriod, framework.DaemonSetRetryTimeout, tester.CheckRunningOnAllNodes(ds))
+			err = wait.PollUntilContextTimeout(context.TODO(), framework.DaemonSetRetryPeriod, framework.DaemonSetRetryTimeout, true, func(context.Context) (bool, error) {
+				return tester.CheckRunningOnAllNodes(ds)()
+			})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "error waiting for daemon pod to revive")
 
 			ginkgo.By("Wait for the failed daemon pod to be completely deleted.")
-			err = wait.PollImmediate(framework.DaemonSetRetryPeriod, framework.DaemonSetRetryTimeout, tester.WaitFailedDaemonPodDeleted(&pod))
+			err = wait.PollUntilContextTimeout(context.TODO(), framework.DaemonSetRetryPeriod, framework.DaemonSetRetryTimeout, true, func(context.Context) (bool, error) {
+				return tester.WaitFailedDaemonPodDeleted(&pod)()
+			})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "error waiting for the failed daemon pod to be completely deleted")
 		})
 
@@ -180,7 +198,9 @@ var _ = SIGDescribe("DaemonSet", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By("Check that daemon pods launch on every node of the cluster.")
-			err = wait.PollImmediate(framework.DaemonSetRetryPeriod, framework.DaemonSetRetryTimeout, tester.CheckRunningOnAllNodes(ds))
+			err = wait.PollUntilContextTimeout(context.TODO(), framework.DaemonSetRetryPeriod, framework.DaemonSetRetryTimeout, true, func(context.Context) (bool, error) {
+				return tester.CheckRunningOnAllNodes(ds)()
+			})
 
 			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "error waiting for daemon pod to start")
 			err = tester.CheckDaemonStatus(dsName)
@@ -202,7 +222,9 @@ var _ = SIGDescribe("DaemonSet", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "error to update daemon")
 
 			ginkgo.By("Compare container info")
-			err = wait.PollImmediate(framework.DaemonSetRetryPeriod, framework.DaemonSetRetryTimeout, tester.GetNewPodsToCheckImage(label, NewWebserverImage))
+			err = wait.PollUntilContextTimeout(context.TODO(), framework.DaemonSetRetryPeriod, framework.DaemonSetRetryTimeout, true, func(context.Context) (bool, error) {
+				return tester.GetNewPodsToCheckImage(label, NewWebserverImage)()
+			})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "error for pod image")
 
 			ginkgo.By("Get all New daemon node")
@@ -210,7 +232,9 @@ var _ = SIGDescribe("DaemonSet", func() {
 			gomega.Expect(len(newNodeList.Items)).To(gomega.BeNumerically(">", 0))
 
 			ginkgo.By("Compare Node info")
-			err = wait.PollImmediate(framework.DaemonSetRetryPeriod, framework.DaemonSetRetryTimeout, tester.CheckPodStayInNode(oldNodeList, newNodeList))
+			err = wait.PollUntilContextTimeout(context.TODO(), framework.DaemonSetRetryPeriod, framework.DaemonSetRetryTimeout, true, func(context.Context) (bool, error) {
+				return tester.CheckPodStayInNode(oldNodeList, newNodeList)()
+			})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "error for node info")
 
 			ginkgo.By("Get all new daemon pods")
@@ -260,7 +284,9 @@ var _ = SIGDescribe("DaemonSet", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By("Check that daemon pods launch on every node of the cluster")
-			err = wait.PollImmediate(framework.DaemonSetRetryPeriod, framework.DaemonSetRetryTimeout, tester.CheckRunningOnAllNodes(ds))
+			err = wait.PollUntilContextTimeout(context.TODO(), framework.DaemonSetRetryPeriod, framework.DaemonSetRetryTimeout, true, func(context.Context) (bool, error) {
+				return tester.CheckRunningOnAllNodes(ds)()
+			})
 
 			for _, tc := range cases {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred(), "error waiting for daemon pod to start")
@@ -285,7 +311,9 @@ var _ = SIGDescribe("DaemonSet", func() {
 				time.Sleep(5 * time.Second)
 
 				ginkgo.By("Compare container info")
-				err = wait.PollImmediate(framework.DaemonSetRetryPeriod, framework.DaemonSetRetryTimeout, tester.GetNewPodsToCheckImage(label, NewWebserverImage))
+				err = wait.PollUntilContextTimeout(context.TODO(), framework.DaemonSetRetryPeriod, framework.DaemonSetRetryTimeout, true, func(context.Context) (bool, error) {
+					return tester.GetNewPodsToCheckImage(label, NewWebserverImage)()
+				})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred(), "error for pod image")
 
 				ginkgo.By("Get all New daemon node")
@@ -293,11 +321,15 @@ var _ = SIGDescribe("DaemonSet", func() {
 				gomega.Expect(len(newNodeList.Items)).To(gomega.BeNumerically(">", 0))
 
 				ginkgo.By("Compare Node info")
-				err = wait.PollImmediate(framework.DaemonSetRetryPeriod, framework.DaemonSetRetryTimeout, tester.CheckPodStayInNode(oldNodeList, newNodeList))
+				err = wait.PollUntilContextTimeout(context.TODO(), framework.DaemonSetRetryPeriod, framework.DaemonSetRetryTimeout, true, func(context.Context) (bool, error) {
+					return tester.CheckPodStayInNode(oldNodeList, newNodeList)()
+				})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred(), "error for node info")
 
 				ginkgo.By("Wait for daemonset ready")
-				err = wait.PollImmediate(framework.DaemonSetRetryPeriod, framework.DaemonSetRetryTimeout, tester.CheckDaemonReady(dsName))
+				err = wait.PollUntilContextTimeout(context.TODO(), framework.DaemonSetRetryPeriod, framework.DaemonSetRetryTimeout, true, func(context.Context) (bool, error) {
+					return tester.CheckDaemonReady(dsName)()
+				})
 
 				ginkgo.By("Get all new daemon pods")
 				newPodList, err := tester.ListDaemonPods(label)
@@ -336,7 +368,9 @@ var _ = SIGDescribe("DaemonSet", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By("Check that daemon pods launch on every node of the cluster")
-			err = wait.PollImmediate(framework.DaemonSetRetryPeriod, framework.DaemonSetRetryTimeout, tester.CheckRunningOnAllNodes(ds))
+			err = wait.PollUntilContextTimeout(context.TODO(), framework.DaemonSetRetryPeriod, framework.DaemonSetRetryTimeout, true, func(context.Context) (bool, error) {
+				return tester.CheckRunningOnAllNodes(ds)()
+			})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "error waiting for daemon pod to start")
 
 			err = tester.CheckDaemonStatus(dsName)
@@ -430,7 +464,9 @@ var _ = SIGDescribe("DaemonSet", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By("Check that daemon pods launch on every node of the cluster.")
-			err = wait.PollImmediate(framework.DaemonSetRetryPeriod, framework.DaemonSetRetryTimeout, tester.CheckRunningOnAllNodes(ds))
+			err = wait.PollUntilContextTimeout(context.TODO(), framework.DaemonSetRetryPeriod, framework.DaemonSetRetryTimeout, true, func(context.Context) (bool, error) {
+				return tester.CheckRunningOnAllNodes(ds)()
+			})
 
 			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "error waiting for daemon pod to start")
 			err = tester.CheckDaemonStatus(dsName)
@@ -458,7 +494,7 @@ var _ = SIGDescribe("DaemonSet", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "error to update daemon")
 
 			ginkgo.By("Check all surging Pods created")
-			err = wait.PollImmediate(time.Second, time.Minute, func() (done bool, err error) {
+			err = wait.PollUntilContextTimeout(context.TODO(), time.Second, time.Minute, true, func(context.Context) (bool, error) {
 				nodeToDaemonPods, err := tester.GetNodesToDaemonPods(label)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				gomega.Expect(nodeToDaemonPods).To(gomega.HaveLen(int(ds.Status.DesiredNumberScheduled)))
@@ -480,7 +516,7 @@ var _ = SIGDescribe("DaemonSet", func() {
 			})
 
 			ginkgo.By("Check all old Pods deleted")
-			err = wait.PollImmediate(time.Second, time.Minute, func() (done bool, err error) {
+			err = wait.PollUntilContextTimeout(context.TODO(), time.Second, time.Minute, true, func(context.Context) (bool, error) {
 				nodeToDaemonPods, err := tester.GetNodesToDaemonPods(label)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				gomega.Expect(nodeToDaemonPods).To(gomega.HaveLen(int(ds.Status.DesiredNumberScheduled)))

--- a/test/e2e/apps/inplace_vpa.go
+++ b/test/e2e/apps/inplace_vpa.go
@@ -472,7 +472,9 @@ var _ = SIGDescribe("InplaceVPA", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By("Check that daemon pods launch on every node of the cluster")
-			err = wait.PollImmediate(framework.DaemonSetRetryPeriod, framework.DaemonSetRetryTimeout, tester.CheckRunningOnAllNodes(ds))
+			err = wait.PollUntilContextTimeout(context.TODO(), framework.DaemonSetRetryPeriod, framework.DaemonSetRetryTimeout, true, func(ctx context.Context) (bool, error) {
+				return tester.CheckRunningOnAllNodes(ds)()
+			})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "error waiting for daemon pod to start")
 
 			err = tester.CheckDaemonStatus(dsName)

--- a/test/e2e/apps/podprobemarker.go
+++ b/test/e2e/apps/podprobemarker.go
@@ -321,8 +321,8 @@ var _ = SIGDescribe("PodProbeMarker", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			// Firstly, probe.sh return false
-			err = wait.PollImmediate(1*time.Second, 10*time.Second,
-				func() (done bool, err error) {
+			err = wait.PollUntilContextTimeout(context.TODO(), 1*time.Second, 10*time.Second, true,
+				func(ctx context.Context) (done bool, err error) {
 					pods, err := tester.ListActivePods(ns)
 					if err != nil {
 						return false, err
@@ -345,8 +345,8 @@ var _ = SIGDescribe("PodProbeMarker", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			// Secondly, probe.sh return true & msg is 'data'
-			err = wait.PollImmediate(1*time.Second, 20*time.Second,
-				func() (done bool, err error) {
+			err = wait.PollUntilContextTimeout(context.TODO(), 1*time.Second, 20*time.Second, true,
+				func(ctx context.Context) (done bool, err error) {
 					pods, err := tester.ListActivePods(ns)
 					if err != nil {
 						return false, err
@@ -373,8 +373,8 @@ var _ = SIGDescribe("PodProbeMarker", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			// Thirdly, probe.sh return true & msg is 'gate'
-			err = wait.PollImmediate(1*time.Second, 20*time.Second,
-				func() (done bool, err error) {
+			err = wait.PollUntilContextTimeout(context.TODO(), 1*time.Second, 20*time.Second, true,
+				func(ctx context.Context) (done bool, err error) {
 					pods, err := tester.ListActivePods(ns)
 					if err != nil {
 						return false, err

--- a/test/e2e/framework/broadcastjob_util.go
+++ b/test/e2e/framework/broadcastjob_util.go
@@ -69,8 +69,8 @@ func (t *BroadcastJobTester) GetPodsOfJob(job *appsv1alpha1.BroadcastJob) (pods 
 }
 
 func (t *BroadcastJobTester) WaitForBroadcastJobCreated(job *appsv1alpha1.BroadcastJob) {
-	pollErr := wait.PollImmediate(time.Second, time.Minute,
-		func() (bool, error) {
+	pollErr := wait.PollUntilContextTimeout(context.TODO(), time.Second, time.Minute, true,
+		func(ctx context.Context) (bool, error) {
 			_, err := t.kc.AppsV1alpha1().BroadcastJobs(job.Namespace).Get(context.TODO(), job.Name, metav1.GetOptions{})
 			if err != nil {
 				return false, err

--- a/test/e2e/framework/daemonset_util.go
+++ b/test/e2e/framework/daemonset_util.go
@@ -120,8 +120,8 @@ func (t *DaemonSetTester) PatchDaemonSet(name string, patchType types.PatchType,
 }
 
 func (t *DaemonSetTester) WaitForDaemonSetDeleted(namespace, name string) {
-	pollErr := wait.PollImmediate(time.Second, time.Minute,
-		func() (bool, error) {
+	pollErr := wait.PollUntilContextTimeout(context.TODO(), time.Second, time.Minute, true,
+		func(ctx context.Context) (bool, error) {
 			_, err := t.kc.AppsV1alpha1().DaemonSets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 			if err != nil {
 				if apierrors.IsNotFound(err) {
@@ -195,7 +195,7 @@ func (t *DaemonSetTester) SetDaemonSetNodeLabels(nodeName string, labels map[str
 	nodeClient := t.c.CoreV1().Nodes()
 	var newNode *v1.Node
 	var newLabels map[string]string
-	err := wait.PollImmediate(DaemonSetRetryPeriod, DaemonSetRetryTimeout, func() (bool, error) {
+	err := wait.PollUntilContextTimeout(context.TODO(), DaemonSetRetryPeriod, DaemonSetRetryTimeout, false, func(ctx context.Context) (bool, error) {
 		node, err := nodeClient.Get(context.TODO(), nodeName, metav1.GetOptions{})
 		if err != nil {
 			return false, err

--- a/test/e2e/framework/ephemeraljob_utils.go
+++ b/test/e2e/framework/ephemeraljob_utils.go
@@ -84,8 +84,8 @@ func (t *EphemeralJobTester) GetPodsByEjob(name string) ([]*v1.Pod, error) {
 }
 
 func (t *EphemeralJobTester) WaitForEphemeralJobCreated(job *appsv1alpha1.EphemeralJob) {
-	pollErr := wait.PollImmediate(time.Second, time.Minute,
-		func() (bool, error) {
+	pollErr := wait.PollUntilContextTimeout(context.TODO(), time.Second, time.Minute, false,
+		func(ctx context.Context) (bool, error) {
 			_, err := t.kc.AppsV1alpha1().EphemeralJobs(job.Namespace).Get(context.TODO(), job.Name, metav1.GetOptions{})
 			if err != nil {
 				return false, err
@@ -98,8 +98,8 @@ func (t *EphemeralJobTester) WaitForEphemeralJobCreated(job *appsv1alpha1.Epheme
 }
 
 func (t *EphemeralJobTester) WaitForEphemeralJobDeleted(job *appsv1alpha1.EphemeralJob) {
-	pollErr := wait.PollImmediate(time.Second, time.Minute,
-		func() (bool, error) {
+	pollErr := wait.PollUntilContextTimeout(context.TODO(), time.Second, time.Minute, false,
+		func(ctx context.Context) (bool, error) {
 			_, err := t.kc.AppsV1alpha1().EphemeralJobs(job.Namespace).Get(context.TODO(), job.Name, metav1.GetOptions{})
 			if err != nil {
 				if errors.IsNotFound(err) {
@@ -202,8 +202,8 @@ func (t *EphemeralJobTester) CheckEphemeralJobExist(job *appsv1alpha1.EphemeralJ
 }
 
 func (s *EphemeralJobTester) WaitForDeploymentRunning(deployment *apps.Deployment) {
-	pollErr := wait.PollImmediate(time.Second, time.Minute*5,
-		func() (bool, error) {
+	pollErr := wait.PollUntilContextTimeout(context.TODO(), time.Second, time.Minute*5, false,
+		func(ctx context.Context) (bool, error) {
 			inner, err := s.c.AppsV1().Deployments(deployment.Namespace).Get(context.TODO(), deployment.Name, metav1.GetOptions{})
 			if err != nil {
 				return false, nil
@@ -240,8 +240,8 @@ func (s *EphemeralJobTester) DeleteDeployment(deployment *apps.Deployment) {
 }
 
 func (s *EphemeralJobTester) WaitForDeploymentDeleted(deployment *apps.Deployment) {
-	pollErr := wait.PollImmediate(time.Second, time.Minute,
-		func() (bool, error) {
+	pollErr := wait.PollUntilContextTimeout(context.TODO(), time.Second, time.Minute, false,
+		func(ctx context.Context) (bool, error) {
 			_, err := s.c.AppsV1().Deployments(deployment.Namespace).Get(context.TODO(), deployment.Name, metav1.GetOptions{})
 			if err != nil {
 				if errors.IsNotFound(err) {

--- a/test/e2e/framework/persistent_pod_state_util.go
+++ b/test/e2e/framework/persistent_pod_state_util.go
@@ -104,8 +104,8 @@ func (s *PersistentPodStateTester) NewBaseStatefulset(namespace string) *appsv1.
 }
 
 func (s *PersistentPodStateTester) WaitForStatefulsetRunning(sts *appsv1.StatefulSet) {
-	pollErr := wait.PollImmediate(time.Second, time.Minute*5,
-		func() (bool, error) {
+	pollErr := wait.PollUntilContextTimeout(context.TODO(), time.Second, time.Minute*5, true,
+		func(ctx context.Context) (bool, error) {
 			inner, err := s.c.AppsV1().StatefulSets(sts.Namespace).Get(context.TODO(), sts.Name, metav1.GetOptions{})
 			if err != nil {
 				return false, nil
@@ -383,8 +383,8 @@ func (s *PersistentPodStateTester) CreateStatefulsetLikePods(sts *StatefulSetLik
 }
 
 func (s *PersistentPodStateTester) waitStatefulsetLikePodsRunning(sts *StatefulSetLikeTest) {
-	pollErr := wait.PollImmediate(time.Second*3, time.Minute*5,
-		func() (bool, error) {
+	pollErr := wait.PollUntilContextTimeout(context.TODO(), time.Second*3, time.Minute*5, true,
+		func(ctx context.Context) (bool, error) {
 			options := metav1.ListOptions{LabelSelector: "app=staticip"}
 			items, err := s.c.CoreV1().Pods(sts.Namespace).List(context.TODO(), options)
 			if err != nil {

--- a/test/e2e/framework/pod_probe_marker_util.go
+++ b/test/e2e/framework/pod_probe_marker_util.go
@@ -344,8 +344,8 @@ func (s *PodProbeMarkerTester) CreateStatefulSet(sts *appsv1beta1.StatefulSet) {
 }
 
 func (s *PodProbeMarkerTester) WaitForStatefulSetRunning(sts *appsv1beta1.StatefulSet) {
-	pollErr := wait.PollImmediate(time.Second, 2*time.Minute,
-		func() (bool, error) {
+	pollErr := wait.PollUntilContextTimeout(context.TODO(), time.Second, 2*time.Minute, true,
+		func(ctx context.Context) (bool, error) {
 			inner, err := s.kc.AppsV1beta1().StatefulSets(sts.Namespace).Get(context.TODO(), sts.Name, metav1.GetOptions{})
 			if err != nil {
 				return false, nil

--- a/test/e2e/framework/podunavailablebudget_util.go
+++ b/test/e2e/framework/podunavailablebudget_util.go
@@ -203,8 +203,8 @@ func (t *PodUnavailableBudgetTester) CreateCloneSet(cloneset *appsv1alpha1.Clone
 }
 
 func (t *PodUnavailableBudgetTester) WaitForPubCreated(pub *policyv1alpha1.PodUnavailableBudget) {
-	pollErr := wait.PollImmediate(time.Second, time.Minute,
-		func() (bool, error) {
+	pollErr := wait.PollUntilContextTimeout(context.TODO(), time.Second, time.Minute, true,
+		func(ctx context.Context) (bool, error) {
 			_, err := t.kc.PolicyV1alpha1().PodUnavailableBudgets(pub.Namespace).Get(context.TODO(), pub.Name, metav1.GetOptions{})
 			if err != nil {
 				return false, err
@@ -217,8 +217,8 @@ func (t *PodUnavailableBudgetTester) WaitForPubCreated(pub *policyv1alpha1.PodUn
 }
 
 func (t *PodUnavailableBudgetTester) WaitForCloneSetRunning(cloneset *appsv1alpha1.CloneSet) {
-	pollErr := wait.PollImmediate(time.Second, time.Minute*5,
-		func() (bool, error) {
+	pollErr := wait.PollUntilContextTimeout(context.TODO(), time.Second, time.Minute*5, true,
+		func(ctx context.Context) (bool, error) {
 			inner, err := t.kc.AppsV1alpha1().CloneSets(cloneset.Namespace).Get(context.TODO(), cloneset.Name, metav1.GetOptions{})
 			if err != nil {
 				return false, err
@@ -234,8 +234,8 @@ func (t *PodUnavailableBudgetTester) WaitForCloneSetRunning(cloneset *appsv1alph
 }
 
 func (t *PodUnavailableBudgetTester) WaitForDeploymentReadyAndRunning(deployment *apps.Deployment) {
-	pollErr := wait.PollImmediate(time.Second, time.Minute*5,
-		func() (bool, error) {
+	pollErr := wait.PollUntilContextTimeout(context.TODO(), time.Second, time.Minute*5, true,
+		func(ctx context.Context) (bool, error) {
 			inner, err := t.c.AppsV1().Deployments(deployment.Namespace).Get(context.TODO(), deployment.Name, metav1.GetOptions{})
 			if err != nil {
 				return false, err
@@ -253,8 +253,8 @@ func (t *PodUnavailableBudgetTester) WaitForDeploymentReadyAndRunning(deployment
 }
 
 func (t *PodUnavailableBudgetTester) WaitForCloneSetMinReadyAndRunning(cloneSets []*appsv1alpha1.CloneSet, minReady int32) {
-	pollErr := wait.PollImmediate(time.Second, time.Minute*10,
-		func() (bool, error) {
+	pollErr := wait.PollUntilContextTimeout(context.TODO(), time.Second, time.Minute*10, true,
+		func(ctx context.Context) (bool, error) {
 			var readyReplicas int32 = 0
 			completed := 0
 			for _, cloneSet := range cloneSets {
@@ -333,8 +333,8 @@ func (t *PodUnavailableBudgetTester) DeleteCloneSets(namespace string) {
 }
 
 func (t *PodUnavailableBudgetTester) WaitForDeploymentDeleted(deployment *apps.Deployment) {
-	pollErr := wait.PollImmediate(time.Second, time.Minute,
-		func() (bool, error) {
+	pollErr := wait.PollUntilContextTimeout(context.TODO(), time.Second, time.Minute, true,
+		func(ctx context.Context) (bool, error) {
 			_, err := t.c.AppsV1().Deployments(deployment.Namespace).Get(context.TODO(), deployment.Name, metav1.GetOptions{})
 			if err != nil {
 				if errors.IsNotFound(err) {
@@ -350,8 +350,8 @@ func (t *PodUnavailableBudgetTester) WaitForDeploymentDeleted(deployment *apps.D
 }
 
 func (t *PodUnavailableBudgetTester) WaitForCloneSetDeleted(cloneset *appsv1alpha1.CloneSet) {
-	pollErr := wait.PollImmediate(time.Second, time.Minute,
-		func() (bool, error) {
+	pollErr := wait.PollUntilContextTimeout(context.TODO(), time.Second, time.Minute, true,
+		func(ctx context.Context) (bool, error) {
 			_, err := t.kc.AppsV1alpha1().CloneSets(cloneset.Namespace).Get(context.TODO(), cloneset.Name, metav1.GetOptions{})
 			if err != nil {
 				if errors.IsNotFound(err) {
@@ -367,8 +367,8 @@ func (t *PodUnavailableBudgetTester) WaitForCloneSetDeleted(cloneset *appsv1alph
 }
 
 func (s *SidecarSetTester) WaitForSidecarSetMinReadyAndUpgrade(sidecarSet *appsv1alpha1.SidecarSet, exceptStatus *appsv1alpha1.SidecarSetStatus, minReady int32) {
-	pollErr := wait.PollImmediate(time.Second, time.Minute*5,
-		func() (bool, error) {
+	pollErr := wait.PollUntilContextTimeout(context.TODO(), time.Second, time.Minute*5, true,
+		func(ctx context.Context) (bool, error) {
 			inner, err := s.kc.AppsV1alpha1().SidecarSets().Get(context.TODO(), sidecarSet.Name, metav1.GetOptions{})
 			if err != nil {
 				return false, err

--- a/test/e2e/framework/resourcedistribution_utils.go
+++ b/test/e2e/framework/resourcedistribution_utils.go
@@ -282,8 +282,8 @@ func (s *ResourceDistributionTester) DeleteResourceDistribution(resourceDistribu
 }
 
 func (s *ResourceDistributionTester) WaitForResourceDistributionCreated(name string, timeout time.Duration) {
-	pollErr := wait.PollImmediate(time.Second, timeout,
-		func() (bool, error) {
+	pollErr := wait.PollUntilContextTimeout(context.TODO(), time.Second, timeout, false,
+		func(ctx context.Context) (bool, error) {
 			_, err := s.kc.AppsV1alpha1().ResourceDistributions().Get(context.TODO(), name, metav1.GetOptions{})
 			if err != nil {
 				return false, err
@@ -296,8 +296,8 @@ func (s *ResourceDistributionTester) WaitForResourceDistributionCreated(name str
 }
 
 func (s *ResourceDistributionTester) WaitForNamespaceCreated(namespace *corev1.Namespace) {
-	pollErr := wait.PollImmediate(time.Second, time.Minute,
-		func() (bool, error) {
+	pollErr := wait.PollUntilContextTimeout(context.TODO(), time.Second, time.Minute, false,
+		func(ctx context.Context) (bool, error) {
 			_, err := s.c.CoreV1().Namespaces().Get(context.TODO(), namespace.Name, metav1.GetOptions{})
 			if err != nil {
 				return false, err
@@ -310,8 +310,8 @@ func (s *ResourceDistributionTester) WaitForNamespaceCreated(namespace *corev1.N
 }
 
 func (s *ResourceDistributionTester) WaitForSecretCreated(namespace, name string, timeout time.Duration) {
-	pollErr := wait.PollImmediate(time.Second, timeout,
-		func() (bool, error) {
+	pollErr := wait.PollUntilContextTimeout(context.TODO(), time.Second, timeout, false,
+		func(ctx context.Context) (bool, error) {
 			_, err := s.c.CoreV1().Secrets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 			Logf("wait for secret(%s) err %v", namespace, err)
 			if err != nil && errors.IsNotFound(err) {
@@ -327,8 +327,8 @@ func (s *ResourceDistributionTester) WaitForSecretCreated(namespace, name string
 }
 
 func (s *ResourceDistributionTester) WaitForNamespaceDeleted(namespace *corev1.Namespace) {
-	pollErr := wait.PollImmediate(time.Second, time.Minute,
-		func() (bool, error) {
+	pollErr := wait.PollUntilContextTimeout(context.TODO(), time.Second, time.Minute, false,
+		func(ctx context.Context) (bool, error) {
 			_, err := s.c.CoreV1().Namespaces().Get(context.TODO(), namespace.Name, metav1.GetOptions{})
 			if err != nil {
 				if errors.IsNotFound(err) {
@@ -344,8 +344,8 @@ func (s *ResourceDistributionTester) WaitForNamespaceDeleted(namespace *corev1.N
 }
 
 func (s *ResourceDistributionTester) WaitForResourceDistributionDeleted(resourceDistribution *appsv1alpha1.ResourceDistribution) {
-	pollErr := wait.PollImmediate(time.Second, time.Minute,
-		func() (bool, error) {
+	pollErr := wait.PollUntilContextTimeout(context.TODO(), time.Second, time.Minute, false,
+		func(ctx context.Context) (bool, error) {
 			_, err := s.kc.AppsV1alpha1().ResourceDistributions().Get(context.TODO(), resourceDistribution.Name, metav1.GetOptions{})
 			if err != nil {
 				if errors.IsNotFound(err) {

--- a/test/e2e/framework/sidecarset_utils.go
+++ b/test/e2e/framework/sidecarset_utils.go
@@ -201,8 +201,8 @@ func (s *SidecarSetTester) UpdatePod(pod *corev1.Pod) {
 }
 
 func (s *SidecarSetTester) WaitForSidecarSetUpgradeComplete(sidecarSet *appsv1alpha1.SidecarSet, exceptStatus *appsv1alpha1.SidecarSetStatus) {
-	pollErr := wait.PollImmediate(time.Second, time.Minute*5,
-		func() (bool, error) {
+	pollErr := wait.PollUntilContextTimeout(context.TODO(), time.Second, time.Minute*5, false,
+		func(ctx context.Context) (bool, error) {
 			inner, err := s.kc.AppsV1alpha1().SidecarSets().Get(context.TODO(), sidecarSet.Name, metav1.GetOptions{})
 			if err != nil {
 				return false, err
@@ -274,8 +274,8 @@ func (s *SidecarSetTester) DeleteDeployment(deployment *apps.Deployment) {
 }
 
 func (s *SidecarSetTester) WaitForSidecarSetCreated(sidecarSet *appsv1alpha1.SidecarSet) {
-	pollErr := wait.PollImmediate(time.Second, time.Minute,
-		func() (bool, error) {
+	pollErr := wait.PollUntilContextTimeout(context.TODO(), time.Second, time.Minute, true,
+		func(ctx context.Context) (bool, error) {
 			_, err := s.kc.AppsV1alpha1().SidecarSets().Get(context.TODO(), sidecarSet.Name, metav1.GetOptions{})
 			if err != nil {
 				return false, err
@@ -288,8 +288,8 @@ func (s *SidecarSetTester) WaitForSidecarSetCreated(sidecarSet *appsv1alpha1.Sid
 }
 
 func (s *SidecarSetTester) WaitForDeploymentRunning(deployment *apps.Deployment) {
-	pollErr := wait.PollImmediate(time.Second, time.Minute*5,
-		func() (bool, error) {
+	pollErr := wait.PollUntilContextTimeout(context.TODO(), time.Second, time.Minute*5, true,
+		func(ctx context.Context) (bool, error) {
 			inner, err := s.c.AppsV1().Deployments(deployment.Namespace).Get(context.TODO(), deployment.Name, metav1.GetOptions{})
 			if err != nil {
 				return false, nil
@@ -306,8 +306,8 @@ func (s *SidecarSetTester) WaitForDeploymentRunning(deployment *apps.Deployment)
 }
 
 func (s *SidecarSetTester) WaitForDeploymentDeleted(deployment *apps.Deployment) {
-	pollErr := wait.PollImmediate(time.Second, time.Minute,
-		func() (bool, error) {
+	pollErr := wait.PollUntilContextTimeout(context.TODO(), time.Second, time.Minute, true,
+		func(ctx context.Context) (bool, error) {
 			_, err := s.c.AppsV1().Deployments(deployment.Namespace).Get(context.TODO(), deployment.Name, metav1.GetOptions{})
 			if err != nil {
 				if errors.IsNotFound(err) {
@@ -323,8 +323,8 @@ func (s *SidecarSetTester) WaitForDeploymentDeleted(deployment *apps.Deployment)
 }
 
 func (s *SidecarSetTester) WaitForSidecarSetDeleted(sidecarSet *appsv1alpha1.SidecarSet) {
-	pollErr := wait.PollImmediate(time.Second, time.Minute,
-		func() (bool, error) {
+	pollErr := wait.PollUntilContextTimeout(context.TODO(), time.Second, time.Minute, true,
+		func(ctx context.Context) (bool, error) {
 			_, err := s.kc.AppsV1alpha1().SidecarSets().Get(context.TODO(), sidecarSet.Name, metav1.GetOptions{})
 			if err != nil {
 				if errors.IsNotFound(err) {
@@ -417,8 +417,8 @@ func (s *SidecarSetTester) CreateCloneSet(cloneset *appsv1alpha1.CloneSet) *apps
 }
 
 func (s *SidecarSetTester) WaitForCloneSetRunning(cloneset *appsv1alpha1.CloneSet) {
-	pollErr := wait.PollImmediate(time.Second, time.Minute*5,
-		func() (bool, error) {
+	pollErr := wait.PollUntilContextTimeout(context.TODO(), time.Second, time.Minute*5, false,
+		func(ctx context.Context) (bool, error) {
 			inner, err := s.kc.AppsV1alpha1().CloneSets(cloneset.Namespace).Get(context.TODO(), cloneset.Name, metav1.GetOptions{})
 			if err != nil {
 				return false, err


### PR DESCRIPTION

### Ⅰ. Describe what this PR does

this PR replaces all usages of the deprecated `wait.PollImmediate` function with `wait.PollUntilContextTimeout` in the entire codebase. the old one will be removed in upcoming releases. 

### Ⅱ. Does this pull request fix one issue?
NONE

### Ⅲ. Describe how to verify it

- Run the test suite (`make test` ), there are no errors locally.

![Screenshot from 2025-06-04 00-44-17](https://github.com/user-attachments/assets/0016b94d-c0c5-406a-8b23-ca41b740dbfe)


- All E2E test passed locally, ran via `make kruise-e2e-test `

![Screenshot from 2025-06-04 01-12-52](https://github.com/user-attachments/assets/26d935ec-a18b-4ea2-ab78-d3d4d1d5d889)



- Code compiles without any deprecation warnings for `wait.PollImmediate`.

### Ⅳ. Special notes for reviews

- LMK if any context handling needs further improvement.
