### PR TITLE
fix: Null-dereference READ in sidecarset (#2078)

### DIFF
--- a/pkg/webhook/pod/mutating/sidecarset.go
+++ b/pkg/webhook/pod/mutating/sidecarset.go
@@ -437,10 +437,18 @@ func buildSidecars(isUpdated bool, pod *corev1.Pod, oldPod *corev1.Pod, matchedS
 				transferEnvs = util.MergeEnvVar(transferEnvs, injectedEnvs)
 				// insert volumes that initContainers used
 				for _, mount := range initContainer.VolumeMounts {
-					volumesInSidecars = append(volumesInSidecars, *volumesMap[mount.Name])
+					if vol, ok := volumesMap[mount.Name]; ok {
+						volumesInSidecars = append(volumesInSidecars, *vol)
+					} else {
+						klog.Warningf("InitContainer volumeMount %s cannot be found in volumes of sidecarSet %s", mount.Name, sidecarSet.Name)
+					}
 				}
 				for _, mount := range initContainer.VolumeDevices {
-					volumesInSidecars = append(volumesInSidecars, *volumesMap[mount.Name])
+					if vol, ok := volumesMap[mount.Name]; ok {
+						volumesInSidecars = append(volumesInSidecars, *vol)
+					} else {
+						klog.Warningf("InitContainer volumeDevice %s cannot be found in volumes of sidecarSet %s", mount.Name, sidecarSet.Name)
+					}
 				}
 				// merge VolumeMounts from sidecar.VolumeMounts and shared VolumeMounts
 				initContainer.VolumeMounts = util.MergeVolumeMounts(initContainer.Container, injectedMounts)
@@ -501,10 +509,18 @@ func buildSidecars(isUpdated bool, pod *corev1.Pod, oldPod *corev1.Pod, matchedS
 			isInjecting = true
 			// insert volume that sidecar container used
 			for _, mount := range sidecarContainer.VolumeMounts {
-				volumesInSidecars = append(volumesInSidecars, *volumesMap[mount.Name])
+				if vol, ok := volumesMap[mount.Name]; ok {
+					volumesInSidecars = append(volumesInSidecars, *vol)
+				} else {
+					klog.Warningf("Container volumeMount %s cannot be found in volumes of sidecarSet %s", mount.Name, sidecarSet.Name)
+				}
 			}
 			for _, mount := range sidecarContainer.VolumeDevices {
-				volumesInSidecars = append(volumesInSidecars, *volumesMap[mount.Name])
+				if vol, ok := volumesMap[mount.Name]; ok {
+					volumesInSidecars = append(volumesInSidecars, *vol)
+				} else {
+					klog.Warningf("Container volumeDevice %s cannot be found in volumes of sidecarSet %s", mount.Name, sidecarSet.Name)
+				}
 			}
 			// merge VolumeMounts from sidecar.VolumeMounts and shared VolumeMounts
 			sidecarContainer.VolumeMounts = util.MergeVolumeMounts(sidecarContainer.Container, injectedMounts)


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

Before accessing volumesMap[mount.Name], check if it is nil to avoid a null pointer access.

### Ⅱ. Does this pull request fix one issue?

#2078

### Ⅲ. Describe how to verify it

python3 infra/helper.py reproduce openkruise fuzz_sidecarset_mutating_pod ./clusterfuzz-testcase-minimized-fuzz_sidecarset_mutating_pod-4906265686114304

![image](https://github.com/user-attachments/assets/0a15b704-4191-4dc5-9dfb-b087186e6d5d)


### Ⅳ. Special notes for reviews

