### PR TITLE
fix(cloneset): transition pod lifecycle from PreparingNormal to Normal after scheduling when PreNormal hook is not specified

### DIFF
--- a/pkg/controller/cloneset/sync/cloneset_update_test.go
+++ b/pkg/controller/cloneset/sync/cloneset_update_test.go
@@ -593,7 +593,7 @@ func TestUpdate(t *testing.T) {
 						apps.DefaultDeploymentUniqueLabelKey: "rev_new",
 						appspub.LifecycleStateKey:            string(appspub.LifecycleStatePreparingNormal),
 					}},
-					Spec: v1.PodSpec{ReadinessGates: []v1.PodReadinessGate{{ConditionType: appspub.InPlaceUpdateReady}}},
+					Spec: v1.PodSpec{ReadinessGates: []v1.PodReadinessGate{{ConditionType: appspub.InPlaceUpdateReady}}, NodeName: "127.0.0.1"},
 					Status: v1.PodStatus{Phase: v1.PodRunning, Conditions: []v1.PodCondition{
 						{Type: v1.PodReady, Status: v1.ConditionFalse},
 						{Type: appspub.InPlaceUpdateReady, Status: v1.ConditionTrue},
@@ -607,7 +607,7 @@ func TestUpdate(t *testing.T) {
 						apps.DefaultDeploymentUniqueLabelKey: "rev_new",
 						appspub.LifecycleStateKey:            string(appspub.LifecycleStateNormal),
 					}},
-					Spec: v1.PodSpec{ReadinessGates: []v1.PodReadinessGate{{ConditionType: appspub.InPlaceUpdateReady}}},
+					Spec: v1.PodSpec{ReadinessGates: []v1.PodReadinessGate{{ConditionType: appspub.InPlaceUpdateReady}}, NodeName: "127.0.0.1"},
 					Status: v1.PodStatus{Phase: v1.PodRunning, Conditions: []v1.PodCondition{
 						{Type: v1.PodReady, Status: v1.ConditionFalse},
 						{Type: appspub.InPlaceUpdateReady, Status: v1.ConditionTrue},
@@ -947,6 +947,41 @@ func TestUpdate(t *testing.T) {
 						},
 						ContainerStatuses: []v1.ContainerStatus{{Name: "c1", ImageID: "image-id-xyz"}},
 					},
+				},
+			},
+		},
+		{
+			name:           "create: preparingNormal->Normal without hook, pod is not scheduled, should stay at preparingNormal",
+			cs:             &appsv1alpha1.CloneSet{Spec: appsv1alpha1.CloneSetSpec{Replicas: getInt32Pointer(1)}},
+			updateRevision: &apps.ControllerRevision{ObjectMeta: metav1.ObjectMeta{Name: "rev_new"}},
+			pods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "pod-0", Labels: map[string]string{
+						apps.ControllerRevisionHashLabelKey:  "rev_new",
+						apps.DefaultDeploymentUniqueLabelKey: "rev_new",
+						appspub.LifecycleStateKey:            string(appspub.LifecycleStatePreparingNormal),
+					}},
+					Spec: v1.PodSpec{ReadinessGates: []v1.PodReadinessGate{{ConditionType: appspub.InPlaceUpdateReady}}},
+					Status: v1.PodStatus{Phase: v1.PodRunning, Conditions: []v1.PodCondition{
+						{Type: v1.PodReady, Status: v1.ConditionFalse},
+						{Type: v1.ContainersReady, Status: v1.ConditionFalse},
+						{Type: appspub.InPlaceUpdateReady, Status: v1.ConditionTrue},
+					}},
+				},
+			},
+			expectedPods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "pod-0", Labels: map[string]string{
+						apps.ControllerRevisionHashLabelKey:  "rev_new",
+						apps.DefaultDeploymentUniqueLabelKey: "rev_new",
+						appspub.LifecycleStateKey:            string(appspub.LifecycleStatePreparingNormal),
+					}},
+					Spec: v1.PodSpec{ReadinessGates: []v1.PodReadinessGate{{ConditionType: appspub.InPlaceUpdateReady}}},
+					Status: v1.PodStatus{Phase: v1.PodRunning, Conditions: []v1.PodCondition{
+						{Type: v1.PodReady, Status: v1.ConditionFalse},
+						{Type: v1.ContainersReady, Status: v1.ConditionFalse},
+						{Type: appspub.InPlaceUpdateReady, Status: v1.ConditionTrue},
+					}},
 				},
 			},
 		},

--- a/pkg/util/pods.go
+++ b/pkg/util/pods.go
@@ -441,3 +441,7 @@ func IsRestartableInitContainer(initContainer *v1.Container) bool {
 
 	return *initContainer.RestartPolicy == v1.ContainerRestartPolicyAlways
 }
+
+func HasPodScheduled(pod *v1.Pod) bool {
+	return len(pod.Spec.NodeName) > 0
+}

--- a/pkg/util/pods_test.go
+++ b/pkg/util/pods_test.go
@@ -1121,3 +1121,39 @@ func TestFindPortByName(t *testing.T) {
 		})
 	}
 }
+
+func TestHasPodScheduled(t *testing.T) {
+	cases := []struct {
+		name      string
+		pod       *v1.Pod
+		scheduled bool
+	}{
+		{
+			name: "pod has scheduled",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod1"},
+				Spec:       v1.PodSpec{NodeName: "host1"},
+				Status:     v1.PodStatus{Phase: v1.PodRunning},
+			},
+			scheduled: true,
+		},
+		{
+			name: "pod has not scheduled",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod2"},
+				Spec:       v1.PodSpec{NodeName: ""},
+				Status:     v1.PodStatus{Phase: v1.PodPending},
+			},
+			scheduled: false,
+		},
+	}
+
+	for _, cs := range cases {
+		t.Run(cs.name, func(t *testing.T) {
+			scheduled := HasPodScheduled(cs.pod)
+			if scheduled != cs.scheduled {
+				t.Errorf("expect: %v, but: %v", cs.scheduled, scheduled)
+			}
+		})
+	}
+}

--- a/test/e2e/apps/cloneset.go
+++ b/test/e2e/apps/cloneset.go
@@ -133,6 +133,52 @@ var _ = SIGDescribe("CloneSet", func() {
 			_, err = c.CoreV1().Pods(cs.Namespace).Update(context.TODO(), pod, metav1.UpdateOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
+
+		framework.ConformanceIt("creates with unschedulable scheduler", func() {
+			cs := tester.NewCloneSetWithSpecificScheduler("clone-"+randStr, 1, "unschedulable")
+
+			cs, err := tester.CreateCloneSet(cs)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			gomega.Eventually(func() int32 {
+				cs, err = tester.GetCloneSet(cs.Name)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				return cs.Status.Replicas
+			}, 120*time.Second, 3*time.Second).Should(gomega.Equal(int32(1)))
+
+			// pod is pending and lifecycle should stay at preparingNormal.
+			gomega.Consistently(func() string {
+				pods, err := tester.ListPodsForCloneSet(cs.Name)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				pod := pods[0]
+				if pod.Status.Phase == v1.PodPending {
+					return pod.Labels[appspub.LifecycleStateKey]
+				}
+
+				return ""
+			}, 10*time.Second, time.Second).Should(gomega.Equal(string(appspub.LifecycleStatePreparingNormal)))
+
+			// update schedulerName.
+			err = tester.UpdateCloneSet(cs.Name, func(cs *appsv1alpha1.CloneSet) { cs.Spec.Template.Spec.SchedulerName = "" })
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			gomega.Eventually(func() int32 {
+				cs, err = tester.GetCloneSet(cs.Name)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				return cs.Status.ReadyReplicas
+			}, 120*time.Second, 3*time.Second).Should(gomega.Equal(int32(1)))
+
+			gomega.Eventually(func() string {
+				pods, err := tester.ListPodsForCloneSet(cs.Name)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(pods).To(gomega.HaveLen(1))
+				for _, pod := range pods {
+					return pod.Labels[appspub.LifecycleStateKey]
+				}
+				return ""
+			}, 120*time.Second, 3*time.Second).Should(gomega.Equal(string(appspub.LifecycleStateNormal)))
+		})
 	})
 
 	framework.KruiseDescribe("CloneSet Scaling", func() {

--- a/test/e2e/framework/cloneset_util.go
+++ b/test/e2e/framework/cloneset_util.go
@@ -103,6 +103,12 @@ func (t *CloneSetTester) NewCloneSetWithLifecycle(name string, replicas int32, l
 	return cloneSet
 }
 
+func (t *CloneSetTester) NewCloneSetWithSpecificScheduler(name string, replicas int32, scheduler string) *appsv1alpha1.CloneSet {
+	cloneSet := t.newCloneSet(name, replicas)
+	cloneSet.Spec.Template.Spec.SchedulerName = scheduler
+	return cloneSet
+}
+
 func (t *CloneSetTester) CreateCloneSet(cs *appsv1alpha1.CloneSet) (*appsv1alpha1.CloneSet, error) {
 	return t.kc.AppsV1alpha1().CloneSets(t.ns).Create(context.TODO(), cs, metav1.CreateOptions{})
 }


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

Carry on with the work on PR #1489 

Special thanks to @chenpeicheng9 for laying the groundwork on #1489.
 
This PR refines initial implementation by converting pod to normal state after the pod scheduled since PreNormal Hook is not maintained.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

fixes #1485 

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

