### PR TITLE
Add unit test for pkg/util/logger.go

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -280,8 +280,6 @@ golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.38.0 h1:vRMAPTMaeGqVhG5QyLJHqNDwecKTomGeqbnfZyKlBI8=
 golang.org/x/net v0.38.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
-golang.org/x/oauth2 v0.23.0 h1:PbgcYx2W7i4LvjJWEbf0ngHV6qJYr86PkAV3bXdLEbs=
-golang.org/x/oauth2 v0.23.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
 golang.org/x/oauth2 v0.24.1-0.20250104024449-49a531d12a9a h1:ZS62xVARqh4jGWGOmCkR/908OsNHQYP4F8MbAXQW4rE=
 golang.org/x/oauth2 v0.24.1-0.20250104024449-49a531d12a9a/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/pkg/util/logger.go
+++ b/pkg/util/logger.go
@@ -48,7 +48,7 @@ func init() {
 	flag.StringVar(&protectionLogPath, "protection-log-path", "/log", "protection log path, for example pub, delete_protection")
 }
 func InitProtectionLogger() error {
-	err := os.MkdirAll(protectionLogPath, 0644)
+	err := os.MkdirAll(protectionLogPath, 0755)
 	if err != nil {
 		return fmt.Errorf("MkdirAll(%s) failed: %s", protectionLogPath, err.Error())
 	}

--- a/pkg/util/logger_test.go
+++ b/pkg/util/logger_test.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2025 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitProtectionLogger_Success(t *testing.T) {
+	// Save and restore original global state to ensure test isolation.
+	origLogPath := protectionLogPath
+	origLogger := protectionLogger
+	defer func() {
+		protectionLogPath = origLogPath
+		protectionLogger = origLogger
+	}()
+
+	// Create a temporary directory that is automatically cleaned up.
+	tempDir := t.TempDir()
+	protectionLogPath = tempDir
+
+	err := InitProtectionLogger()
+	require.NoError(t, err, "InitProtectionLogger() should not fail in a valid directory")
+
+	logFile := filepath.Join(tempDir, "protection.log")
+	assert.FileExists(t, logFile, "Log file should be created after successful initialization")
+}
+
+func TestLoggerProtectionInfo_LogsCorrectly(t *testing.T) {
+	// Save and restore original global state.
+	origLogPath := protectionLogPath
+	origLogger := protectionLogger
+	defer func() {
+		protectionLogPath = origLogPath
+		protectionLogger = origLogger
+	}()
+
+	tempDir := t.TempDir()
+	protectionLogPath = tempDir
+	err := InitProtectionLogger()
+	require.NoError(t, err, "Logger initialization is a prerequisite for this test")
+
+	testData := ProtectionLoggerInfo{
+		Event:     "TestEvent",
+		Kind:      "Pod",
+		Namespace: "default",
+		Name:      "test-pod",
+		UserAgent: "unit-test",
+	}
+	LoggerProtectionInfo(testData.Event, testData.Kind, testData.Namespace, testData.Name, testData.UserAgent)
+
+	// Read the log file and verify its content.
+	logFile := filepath.Join(tempDir, "protection.log")
+	content, err := os.ReadFile(logFile)
+	require.NoError(t, err, "Failed to read log file")
+
+	var loggedInfo ProtectionLoggerInfo
+	err = json.Unmarshal(content[:len(content)-1], &loggedInfo)
+	require.NoError(t, err, "Logged content should be valid JSON")
+
+	assert.Equal(t, testData, loggedInfo, "Logged data should match the input data")
+}
+
+func TestLoggerProtectionInfo_UninitializedNoOp(t *testing.T) {
+	origLogPath := protectionLogPath
+	origLogger := protectionLogger
+	defer func() {
+		protectionLogPath = origLogPath
+		protectionLogger = origLogger
+	}()
+
+	protectionLogger = nil
+	protectionLogPath = t.TempDir()
+
+	LoggerProtectionInfo("event", "kind", "ns", "name", "agent")
+
+	logFile := filepath.Join(protectionLogPath, "protection.log")
+	assert.NoFileExists(t, logFile, "Log file should not be created without initialization")
+}
+
+func TestInitProtectionLogger_MkdirFailure(t *testing.T) {
+	// Save and restore original global state.
+	origLogPath := protectionLogPath
+	origLogger := protectionLogger
+	defer func() {
+		protectionLogPath = origLogPath
+		protectionLogger = origLogger
+	}()
+
+	tempDir := t.TempDir()
+	blockingFile := filepath.Join(tempDir, "file.txt")
+	err := os.WriteFile(blockingFile, []byte("blocker"), 0644)
+	require.NoError(t, err)
+
+	// Attempt to initialize the logger in a path that is blocked by the file.
+	protectionLogPath = filepath.Join(blockingFile, "subdir")
+	err = InitProtectionLogger()
+
+	assert.Error(t, err, "Expected an error but got nil")
+	assert.True(t, strings.Contains(err.Error(), "MkdirAll"), "Error message should mention MkdirAll")
+	assert.Nil(t, protectionLogger, "Logger should remain nil after a failed initialization")
+}
+
+func TestInitProtectionLogger_OpenFileFailure(t *testing.T) {
+	// Save and restore original global state.
+	origLogPath := protectionLogPath
+	origLogger := protectionLogger
+	defer func() {
+		protectionLogPath = origLogPath
+		protectionLogger = origLogger
+	}()
+
+	// Create a temporary directory for the logs.
+	tempDir := t.TempDir()
+	protectionLogPath = tempDir
+
+	err := os.MkdirAll(filepath.Join(tempDir, "protection.log"), 0755)
+	require.NoError(t, err)
+
+	err = InitProtectionLogger()
+
+	assert.Error(t, err, "Expected an error but got nil")
+	assert.True(t, strings.Contains(err.Error(), "openFile"), "Error message should mention openFile")
+	assert.Nil(t, protectionLogger, "Logger should remain nil after a failed initialization")
+}


### PR DESCRIPTION
### What this PR does / why we need it

This PR introduces comprehensive unit tests for the protection logger located in `pkg/util/logger.go`. The logger previously had no test coverage, making it difficult to verify its behavior or prevent future regressions.

While adding tests, a bug was discovered where `os.MkdirAll` was called with file permissions (`0644`) instead of directory permissions. This could lead to failures in environments with stricter permission checks. This PR corrects the directory permissions to the standard `0755`.

The new test suite covers:
- Successful logger initialization.
- Correct JSON formatting of log messages.
- Graceful failure when the log directory cannot be created.
- Graceful failure when the log file cannot be opened.
- A no-op safety check when the logger is used without being initialized.

### Which issue(s) this PR fixes

In Support of Issue #2074 

### Special notes for your reviewer

The key changes to review are:
1.  The permission change in `InitProtectionLogger` from `0644` to `0755` for `os.MkdirAll`.
2.  The addition of the new test file `pkg/util/logger_test.go` with its comprehensive test cases.

