### PR TITLE
Add unit tests for client cache helper

### DIFF
--- a/pkg/util/client/cache_test.go
+++ b/pkg/util/client/cache_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2025 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestIsDisableDeepCopy(t *testing.T) {
+	tests := []struct {
+		name     string
+		opts     []client.ListOption
+		expected bool
+	}{
+		{
+			name:     "option is present alone",
+			opts:     []client.ListOption{DisableDeepCopy},
+			expected: true,
+		},
+		{
+			name:     "only other options are present",
+			opts:     []client.ListOption{client.Limit(10)},
+			expected: false,
+		},
+		{
+			name:     "slice is empty",
+			opts:     []client.ListOption{},
+			expected: false,
+		},
+		{
+			name:     "slice is nil",
+			opts:     nil,
+			expected: false,
+		},
+		{
+			name:     "option is present with others",
+			opts:     []client.ListOption{DisableDeepCopy, &client.MatchingLabels{"foo": "bar"}},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isDisableDeepCopy(tt.opts))
+		})
+	}
+}


### PR DESCRIPTION
## What this PR does

This PR adds unit tests for the `isDisableDeepCopy` helper function in `pkg/util/client/cache.go`.

in support of issue #2074 

## Why this change was made

The `pkg/util/client/cache.go` file contains a mix of complex "glue code" and simple, standalone logic. This PR follows best practices by focusing unit tests on the testable logic.

The initial approach to test the entire file proved impractical because functions like `NewCache` and `internalCache.List` are tightly coupled with the `controller-runtime` library. Attempting to mock these dependencies is brittle and provides little value.

## How to test

All new tests pass successfully and can be verified by running:

```bash
go test ./pkg/util/client -v

