### PR TITLE
Fix the envtest setup to always use the latest version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,11 +157,8 @@ $(TESTBIN):
 ENVTEST ?= $(TESTBIN)/setup-envtest
 
 .PHONY: envtest
-envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
-$(ENVTEST): $(TESTBIN)
-ifeq (, $(shell ls $(TESTBIN)/setup-envtest 2>/dev/null))
-	GOBIN=$(TESTBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20250517180713-32e5e9e948a5
-endif
+envtest: $(TESTBIN) ## Download/update envtest-setup to latest version.
+	GOBIN=$(TESTBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 
 # create-cluster creates a kube cluster with kind.
 .PHONY: create-cluster


### PR DESCRIPTION
### 1. Describe what this PR does
- Modified the `envtest` target in Makefile to always update `setup-envtest` to the latest version
- Removed conditional installation that only installed if the binary didn't exist
- changed from pinned version `@v0.0.0-20250517180713-32e5e9e948a5` to `@latest`
- it ensures automatic support for new kubernetes versions as they become available

### 2. Describe how to verify it
- clean existing envtest binary:
  - `rm -f testbin/setup-envtest`
- Run the envtest target:
  - `make envtest`
- verify latest version is installed:
  - `./testbin/setup-envtest --help`
- Test Kubernetes 1.32.0 support:
  - `./testbin/setup-envtest use 1.32.0` (should successfully download and set up Kubernetes 1.32.0 envtest binaries)
- Run unit tests:
  - `make test`  (All tests should pass)