### PR TITLE
fixed a typo in YYYYMMDD-template.md

### DIFF
--- a/docs/proposals/YYYYMMDD-template.md
+++ b/docs/proposals/YYYYMMDD-template.md
@@ -24,7 +24,7 @@ superseded-by:
 <!-- BEGIN Remove before PR -->
 To get started with this template:
 1. **Make a copy of this template.**
-  Copy this template into `docs/enhacements` and name it `YYYYMMDD-my-title.md`, where `YYYYMMDD` is the date the proposal was first drafted.
+  Copy this template into `docs/enhancements` and name it `YYYYMMDD-my-title.md`, where `YYYYMMDD` is the date the proposal was first drafted.
 1. **Fill out the required sections.**
 1. **Create a PR.**
   Aim for single topic PRs to keep discussions focused.

--- a/docs/proposals/YYYYMMDD-template.md
+++ b/docs/proposals/YYYYMMDD-template.md
@@ -24,7 +24,7 @@ superseded-by:
 <!-- BEGIN Remove before PR -->
 To get started with this template:
 1. **Make a copy of this template.**
-  Copy this template into `docs/enhancements` and name it `YYYYMMDD-my-title.md`, where `YYYYMMDD` is the date the proposal was first drafted.
+  Copy this template into `docs/proposals` and name it `YYYYMMDD-my-title.md`, where `YYYYMMDD` is the date the proposal was first drafted.
 1. **Fill out the required sections.**
 1. **Create a PR.**
   Aim for single topic PRs to keep discussions focused.
@@ -188,4 +188,3 @@ Consider the following in developing an upgrade strategy for this enhancement:
 - [ ] MM/DD/YYYY: First round of feedback from community
 - [ ] MM/DD/YYYY: Present proposal at a [community meeting]
 - [ ] MM/DD/YYYY: Open proposal PR
-


### PR DESCRIPTION
#2133 the typo in YYYYMMDD-template.md has been resolved

### Ⅰ. Describe what this PR does
Fixes a typo in the proposal template (docs/proposals/YYYYMMDD-template.md):
Changes "enhacements" to the correct spelling "enhancements" in the instructions.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" --> NONE

### Ⅲ. Describe how to verify it
Open docs/proposals/YYYYMMDD-template.md and check that the instructions now say docs/enhancements instead of docs/enhacements.

### Ⅳ. Special notes for reviews
N/A