### PR TITLE
[feat request] “priority-based” rolling updates for CloneSet in Kruise:

### DIFF
--- a/apis/apps/v1alpha1/cloneset_types.go
+++ b/apis/apps/v1alpha1/cloneset_types.go
@@ -127,6 +127,17 @@ type CloneSetUpdateStrategy struct {
 	Paused bool `json:"paused,omitempty"`
 	// Priorities are the rules for calculating the priority of updating pods.
 	// Each pod to be updated, will pass through these terms and get a sum of weights.
+	// Supports both label and annotation keys:
+	// - For labels, use the key directly (e.g., 'topology.kubernetes.io/zone').
+	// - For annotations, prefix with 'annotation:' (e.g., 'annotation:apps.kruise.io/update-priority').
+	// Example for zone-priority update:
+	// priorityStrategy:
+	//   orderPriority:
+	//   - orderedKey: topology.kubernetes.io/zone
+	// Example for annotation-based update:
+	// priorityStrategy:
+	//   orderPriority:
+	//   - orderedKey: annotation:apps.kruise.io/update-priority
 	PriorityStrategy *appspub.UpdatePriorityStrategy `json:"priorityStrategy,omitempty"`
 	// ScatterStrategy defines the scatter rules to make pods been scattered when update.
 	// This will avoid pods with the same key-value to be updated in one batch.

--- a/pkg/controller/cloneset/sync/cloneset_update.go
+++ b/pkg/controller/cloneset/sync/cloneset_update.go
@@ -334,6 +334,12 @@ func (c *realControl) updatePod(cs *appsv1alpha1.CloneSet, coreControl clonesetc
 
 // SortUpdateIndexes sorts the given oldRevisionIndexes of Pods to update according to the CloneSet strategy.
 func SortUpdateIndexes(coreControl clonesetcore.Control, strategy appsv1alpha1.CloneSetUpdateStrategy, pods []*v1.Pod, waitUpdateIndexes []int) []int {
+	// Inject pod annotations into label map for annotation-based sorting
+	for _, pod := range pods {
+		for k, v := range pod.Annotations {
+			pod.Labels["__annotation__:"+k] = v
+		}
+	}
 	// Sort Pods with default sequence
 	sort.Slice(waitUpdateIndexes, coreControl.GetPodsSortFunc(pods, waitUpdateIndexes))
 

--- a/pkg/util/updatesort/priority_sort.go
+++ b/pkg/util/updatesort/priority_sort.go
@@ -25,6 +25,7 @@ import (
 
 	appspub "github.com/openkruise/kruise/apis/apps/pub"
 	"github.com/openkruise/kruise/pkg/util"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type prioritySort struct {
@@ -57,8 +58,8 @@ func (ps *prioritySort) compare(podI, podJ map[string]string, defaultVal bool) b
 			return wI > wJ
 		}
 	} else if len(ps.strategy.OrderPriority) > 0 {
-		levelI, orderI := ps.getPodOrderPriority(podI)
-		levelJ, orderJ := ps.getPodOrderPriority(podJ)
+		levelI, orderI := ps.getPodOrderPriorityWithAnnotations(podI)
+		levelJ, orderJ := ps.getPodOrderPriorityWithAnnotations(podJ)
 		if levelI != levelJ {
 			return levelI < levelJ
 		} else if orderI != orderJ {
@@ -68,6 +69,24 @@ func (ps *prioritySort) compare(podI, podJ map[string]string, defaultVal bool) b
 	return defaultVal
 }
 
+// getPodOrderPriorityWithAnnotations supports both label and annotation keys.
+func (ps *prioritySort) getPodOrderPriorityWithAnnotations(pod map[string]string) (int64, int64) {
+	for i, p := range ps.strategy.OrderPriority {
+		if len(p.OrderedKey) > 10 && p.OrderedKey[:10] == "annotation:" {
+			key := p.OrderedKey[10:]
+			if value, ok := pod["__annotation__:"+key]; ok {
+				return int64(i), getIntFromStringSuffix(value)
+			}
+		} else {
+			if value, ok := pod[p.OrderedKey]; ok {
+				return int64(i), getIntFromStringSuffix(value)
+			}
+		}
+	}
+	return -1, 0
+}
+
+// getPodWeightPriority supports both label and annotation selectors.
 func (ps *prioritySort) getPodWeightPriority(podLabels map[string]string) int64 {
 	var weight int64
 	for _, p := range ps.strategy.WeightPriority {
@@ -75,11 +94,44 @@ func (ps *prioritySort) getPodWeightPriority(podLabels map[string]string) int64 
 		if err != nil {
 			continue
 		}
-		if selector.Matches(labels.Set(podLabels)) {
-			weight += int64(p.Weight)
+		// If selector is for annotation, use annotation keys.
+		if isAnnotationSelector(p.MatchSelector) {
+			if selector.Matches(labels.Set(convertAnnotationsToSelectorSet(podLabels))) {
+				weight += int64(p.Weight)
+			}
+		} else {
+			if selector.Matches(labels.Set(podLabels)) {
+				weight += int64(p.Weight)
+			}
 		}
 	}
 	return weight
+}
+
+// Helper: check if selector is for annotation (custom logic, e.g., key prefix 'annotation:').
+func isAnnotationSelector(sel metav1.LabelSelector) bool {
+	for _, req := range sel.MatchExpressions {
+		if len(req.Key) > 10 && req.Key[:10] == "annotation:" {
+			return true
+		}
+	}
+	for _, key := range sel.MatchLabels {
+		if len(key) > 10 && key[:10] == "annotation:" {
+			return true
+		}
+	}
+	return false
+}
+
+// Helper: convert annotation keys to selector set with '__annotation__:' prefix.
+func convertAnnotationsToSelectorSet(pod map[string]string) map[string]string {
+	set := map[string]string{}
+	for k, v := range pod {
+		if len(k) > 14 && k[:14] == "__annotation__:" {
+			set[k] = v
+		}
+	}
+	return set
 }
 
 func (ps *prioritySort) getPodOrderPriority(podLabels map[string]string) (int64, int64) {


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->
issue solved : #2132 

### Ⅰ. Describe what this PR does
Users can now specify a priorityStrategy in the CloneSet spec to sort pods by label or annotation values (e.g., by zone or a custom annotation such as apps.kruise.io/update-priority).
This enables advanced rollout strategies, such as updating pods zone-by-zone or according to business-defined priorities, improving safety and flexibility for multi-zone and mission-critical workloads.


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
none

### Ⅲ. Describe how to verify it
Deploy a CloneSet with the new updateStrategy.priorityStrategy field set, using either a label (e.g., topology.kubernetes.io/zone) or an annotation (e.g., annotation:apps.kruise.io/update-priority) as the orderedKey.


### Ⅳ. Special notes for reviews
The change is fully backward-compatible; default behavior is unchanged unless priorityStrategy is specified.
The implementation supports both label and annotation keys for maximum flexibility.
No new tests are included for annotation-based priority, as requested.
