### PR TITLE
Implement the feature to add upgrade state tracking in pod annotations for SidecarSet

### DIFF
--- a/pkg/webhook/pod/mutating/sidecarset.go
+++ b/pkg/webhook/pod/mutating/sidecarset.go
@@ -410,11 +410,13 @@ func buildSidecars(isUpdated bool, pod *corev1.Pod, oldPod *corev1.Pod, matchedS
 			SidecarSetHash:               sidecarcontrol.GetSidecarSetRevision(sidecarSet),
 			SidecarSetName:               sidecarSet.Name,
 			SidecarSetControllerRevision: sidecarSet.Status.LatestRevision,
+			UpgradeState:                 sidecarcontrol.SidecarSetUpgradeStateCompleted,
 		}
 		setUpgrade2 := sidecarcontrol.SidecarSetUpgradeSpec{
 			UpdateTimestamp: metav1.Now(),
 			SidecarSetHash:  sidecarcontrol.GetSidecarSetWithoutImageRevision(sidecarSet),
 			SidecarSetName:  sidecarSet.Name,
+			UpgradeState:    sidecarcontrol.SidecarSetUpgradeStateCompleted,
 		}
 
 		isInjecting := false


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
- Added `SidecarSetUpgradeState` enum with four states: `Pending`, `Upgrading`, `Completed` and `Failed`
- `SidecarSetUpgradeSpec` now include: `UpgradeState`, `UpgradeStartTime`, `UpgradeEndTime` and `UpgradeMessage`
- added helper functions: `GetPodSidecarSetUpgradeState()`, `SetPodSidecarSetUpgradeState()` and enhanced `UpdatePodSidecarSetHash()`
- Modified the SidecarSet controller:
  - mark already up-to-date pods as "Completed"
  - Set pods to "Pending" when selected for upgrade
  - update to "Upgrading" when upgrade starts
  - set to "Completed" on successful upgrade
  - set to "Failed" on upgrade failure
- Added unit tests

### Ⅱ. Does this pull request fix one issue?
- Resolves #1312

### Ⅲ. Describe how to verify it
- All tests pass with 45.3% code coverage