### PR TITLE
 Fix the panic issue when the `--namespace` flag is set

### DIFF
--- a/pkg/controller/daemonset/daemonset_controller.go
+++ b/pkg/controller/daemonset/daemonset_controller.go
@@ -172,10 +172,27 @@ func newReconciler(mgr manager.Manager) (reconcile.Reconciler, error) {
 		return nil, err
 	}
 
-	dsLister := kruiseappslisters.NewDaemonSetLister(dsInformer.(cache.SharedIndexInformer).GetIndexer())
-	historyLister := appslisters.NewControllerRevisionLister(revInformer.(cache.SharedIndexInformer).GetIndexer())
-	podLister := corelisters.NewPodLister(podInformer.(cache.SharedIndexInformer).GetIndexer())
-	nodeLister := corelisters.NewNodeLister(nodeInformer.(cache.SharedIndexInformer).GetIndexer())
+	dsSharedInformer, ok := dsInformer.(cache.SharedIndexInformer)
+	if !ok {
+		return nil, fmt.Errorf("dsInformer %T from cache is not a SharedIndexInformer", dsInformer)
+	}
+	revSharedInformer, ok := revInformer.(cache.SharedIndexInformer)
+	if !ok {
+		return nil, fmt.Errorf("revInformer %T from cache is not a SharedIndexInformer", revInformer)
+	}
+	podSharedInformer, ok := podInformer.(cache.SharedIndexInformer)
+	if !ok {
+		return nil, fmt.Errorf("podInformer %T from cache is not a SharedIndexInformer", podInformer)
+	}
+	nodeSharedInformer, ok := nodeInformer.(cache.SharedIndexInformer)
+	if !ok {
+		return nil, fmt.Errorf("nodeInformer %T from cache is not a SharedIndexInformer", nodeInformer)
+	}
+
+	dsLister := kruiseappslisters.NewDaemonSetLister(dsSharedInformer.GetIndexer())
+	historyLister := appslisters.NewControllerRevisionLister(revSharedInformer.GetIndexer())
+	podLister := corelisters.NewPodLister(podSharedInformer.GetIndexer())
+	nodeLister := corelisters.NewNodeLister(nodeSharedInformer.GetIndexer())
 	failedPodsBackoff := flowcontrol.NewBackOff(1*time.Second, 15*time.Minute)
 	revisionAdapter := revisionadapter.NewDefaultImpl()
 

--- a/pkg/controller/statefulset/statefulset_controller.go
+++ b/pkg/controller/statefulset/statefulset_controller.go
@@ -133,12 +133,29 @@ func newReconciler(mgr manager.Manager) (reconcile.Reconciler, error) {
 		return nil, err
 	}
 
-	statefulSetLister := kruiseappslisters.NewStatefulSetLister(statefulSetInformer.(toolscache.SharedIndexInformer).GetIndexer())
-	podLister := corelisters.NewPodLister(podInformer.(toolscache.SharedIndexInformer).GetIndexer())
-	pvcLister := corelisters.NewPersistentVolumeClaimLister(pvcInformer.(toolscache.SharedIndexInformer).GetIndexer())
+	statefulSetSharedInformer, ok := statefulSetInformer.(toolscache.SharedIndexInformer)
+	if !ok {
+		return nil, fmt.Errorf("statefulSetInformer %T from cache is not a SharedIndexInformer", statefulSetInformer)
+	}
+	podSharedInformer, ok := podInformer.(toolscache.SharedIndexInformer)
+	if !ok {
+		return nil, fmt.Errorf("podInformer %T from cache is not a SharedIndexInformer", podInformer)
+	}
+	pvcSharedInformer, ok := pvcInformer.(toolscache.SharedIndexInformer)
+	if !ok {
+		return nil, fmt.Errorf("pvcInformer %T from cache is not a SharedIndexInformer", pvcInformer)
+	}
+
+	statefulSetLister := kruiseappslisters.NewStatefulSetLister(statefulSetSharedInformer.GetIndexer())
+	podLister := corelisters.NewPodLister(podSharedInformer.GetIndexer())
+	pvcLister := corelisters.NewPersistentVolumeClaimLister(pvcSharedInformer.GetIndexer())
 	var scLister storagelisters.StorageClassLister
 	if utilfeature.DefaultFeatureGate.Enabled(features.StatefulSetAutoResizePVCGate) {
-		scLister = storagelisters.NewStorageClassLister(scInformer.(toolscache.SharedIndexInformer).GetIndexer())
+		scSharedInformer, ok := scInformer.(toolscache.SharedIndexInformer)
+		if !ok {
+			return nil, fmt.Errorf("scInformer %T from cache is not a SharedIndexInformer", scInformer)
+		}
+		scLister = storagelisters.NewStorageClassLister(scSharedInformer.GetIndexer())
 	}
 
 	genericClient := client.GetGenericClientWithName("statefulset-controller")


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
The panic occurs because when a namespace is specified in the manager configuration (via `--namespace` flag), the controller-runtime cache returns a `multiNamespaceInformer` instead of a `SharedIndexInformer`. The `multiNamespaceInformer` does not implement the `GetController` method that's part of the `SharedIndexInformer` interface, it causses the type assertion to fail with a panic.

The issue was in two controllers:
```
pkg/controller/daemonset/daemonset_controller.go
pkg/controller/statefulset/statefulset_controller.go
```

I implemented proper type checking before the type assertion, following the pattern used in `pkg/util/client/no_deepcopy_lister.go`

### Ⅱ. Does this pull request fix one issue?
- fixes #1764

### Ⅲ. Describe how to verify it
- both controllers compile successfully
- DaemonSet controller tests pass
- main binary builds successfully