### PR TITLE
advancedCronJob should ignore delete child job

### DIFF
--- a/pkg/webhook/advancedcronjob/validating/advancedcronjob_create_update_handler.go
+++ b/pkg/webhook/advancedcronjob/validating/advancedcronjob_create_update_handler.go
@@ -51,7 +51,6 @@ const (
 	validateAdvancedCronJobNameMsg = "AdvancedCronJob name must consist of alphanumeric characters or '-'"
 	validAdvancedCronJobNameFmt    = `^[a-zA-Z0-9\-]+$`
 	MaxActiveDeadLineSeconds       = 3600 * 24
-	MaxTTLSecondsAfterFinished     = 3600 * 24 * 3
 )
 
 var (
@@ -259,8 +258,8 @@ func validateImageListPullJobTemplateSpec(ilpJobSpec *appsv1beta1.ImageListPullJ
 		if ilpJobSpec.Spec.CompletionPolicy.ActiveDeadlineSeconds != nil && ilpJobSpec.Spec.PullPolicy != nil && ilpJobSpec.Spec.PullPolicy.TimeoutSeconds != nil && int64(*ilpJobSpec.Spec.PullPolicy.TimeoutSeconds) > *ilpJobSpec.Spec.CompletionPolicy.ActiveDeadlineSeconds {
 			return append(allErrs, field.Invalid(fldPath.Child("spec").Child("completionPolicy").Child("activeDeadlineSeconds"), ilpJobSpec.Spec.CompletionPolicy.ActiveDeadlineSeconds, fmt.Sprintf("completionPolicy.activeDeadlineSeconds must be greater than pullPolicy.timeoutSeconds(%d)", *ilpJobSpec.Spec.PullPolicy.TimeoutSeconds)))
 		}
-		if ilpJobSpec.Spec.CompletionPolicy.TTLSecondsAfterFinished != nil && *ilpJobSpec.Spec.CompletionPolicy.TTLSecondsAfterFinished > MaxTTLSecondsAfterFinished {
-			return append(allErrs, field.Invalid(fldPath.Child("spec").Child("completionPolicy").Child("ttlSecondsAfterFinished"), ilpJobSpec.Spec.CompletionPolicy.TTLSecondsAfterFinished, fmt.Sprintf("ttlSecondsAfterFinished must be less than %d, current value is: %d", MaxTTLSecondsAfterFinished, *ilpJobSpec.Spec.CompletionPolicy.TTLSecondsAfterFinished)))
+		if ilpJobSpec.Spec.CompletionPolicy.TTLSecondsAfterFinished != nil {
+			return append(allErrs, field.Invalid(fldPath.Child("spec").Child("completionPolicy").Child("ttlSecondsAfterFinished"), ilpJobSpec.Spec.CompletionPolicy.TTLSecondsAfterFinished, fmt.Sprintf("ttlSecondsAfterFinished is not supported in advancedCronJob")))
 		}
 	default:
 		return append(allErrs, field.Invalid(fldPath.Child("spec").Child("completionPolicy").Child("type"), ilpJobSpec.Spec.CompletionPolicy.Type, fmt.Sprintf("completionPolicy should be Always, but current value is: %s", ilpJobSpec.Spec.CompletionPolicy.Type)))

--- a/pkg/webhook/advancedcronjob/validating/advancedcronjob_create_update_handler_test.go
+++ b/pkg/webhook/advancedcronjob/validating/advancedcronjob_create_update_handler_test.go
@@ -445,9 +445,8 @@ func TestAdvancedCronJobCreateUpdateHandler_Handle(t *testing.T) {
 												Parallelism: nil,
 												PullPolicy:  nil,
 												CompletionPolicy: appsv1beta1.CompletionPolicy{
-													Type:                    appsv1beta1.Always,
-													ActiveDeadlineSeconds:   int64Ptr(100),
-													TTLSecondsAfterFinished: int32Ptr(100),
+													Type:                  appsv1beta1.Always,
+													ActiveDeadlineSeconds: int64Ptr(100),
 												},
 												SandboxConfig:   nil,
 												ImagePullPolicy: "",
@@ -462,6 +461,54 @@ func TestAdvancedCronJobCreateUpdateHandler_Handle(t *testing.T) {
 			},
 			expectedResult: true,
 			expectedError:  false,
+		},
+		{
+			name: "create v1beta1 AdvancedCronJob ImageListPullJobTemplate forbidden field",
+			request: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
+					Resource: metav1.GroupVersionResource{
+						Group:    appsv1beta1.GroupVersion.Group,
+						Version:  appsv1beta1.GroupVersion.Version,
+						Resource: "advancedcronjobs",
+					},
+					Object: runtime.RawExtension{
+						Raw: createAdvancedCronJobV1Beta1JSON(t, &appsv1beta1.AdvancedCronJob{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "test-acj-v1beta1",
+								Namespace: "default",
+							},
+							Spec: appsv1beta1.AdvancedCronJobSpec{
+								Schedule:          "0 0 * * *",
+								ConcurrencyPolicy: appsv1beta1.AllowConcurrent,
+								Template: appsv1beta1.CronJobTemplate{
+									ImageListPullJobTemplate: &appsv1beta1.ImageListPullJobTemplateSpec{
+										Spec: appsv1beta1.ImageListPullJobSpec{
+											Images: []string{
+												"busybox:latest",
+												"alpine:latest",
+											},
+											ImagePullJobTemplate: appsv1beta1.ImagePullJobTemplate{
+												Selector: &appsv1beta1.ImagePullJobNodeSelector{
+													Names: []string{
+														"node1",
+													},
+												},
+												CompletionPolicy: appsv1beta1.CompletionPolicy{
+													Type:                    appsv1beta1.Always,
+													TTLSecondsAfterFinished: int32Ptr(100),
+												},
+											},
+										},
+									},
+								},
+							},
+						}),
+					},
+				},
+			},
+			expectedResult: true,
+			expectedError:  true,
 		},
 		{
 			name: "update v1beta1 AdvancedCronJob ImageListPullJobTemplate",
@@ -514,9 +561,8 @@ func TestAdvancedCronJobCreateUpdateHandler_Handle(t *testing.T) {
 													BackoffLimit:   int32Ptr(1),
 												},
 												CompletionPolicy: appsv1beta1.CompletionPolicy{
-													Type:                    appsv1beta1.Always,
-													ActiveDeadlineSeconds:   int64Ptr(200),
-													TTLSecondsAfterFinished: int32Ptr(200),
+													Type:                  appsv1beta1.Always,
+													ActiveDeadlineSeconds: int64Ptr(200),
 												},
 												SandboxConfig:   nil,
 												ImagePullPolicy: appsv1beta1.PullAlways,
@@ -558,9 +604,8 @@ func TestAdvancedCronJobCreateUpdateHandler_Handle(t *testing.T) {
 												},
 												PullPolicy: nil,
 												CompletionPolicy: appsv1beta1.CompletionPolicy{
-													Type:                    appsv1beta1.Always,
-													ActiveDeadlineSeconds:   int64Ptr(100),
-													TTLSecondsAfterFinished: int32Ptr(100),
+													Type:                  appsv1beta1.Always,
+													ActiveDeadlineSeconds: int64Ptr(100),
 												},
 												SandboxConfig:   nil,
 												ImagePullPolicy: appsv1beta1.PullIfNotPresent,
@@ -633,7 +678,8 @@ func TestAdvancedCronJobCreateUpdateHandler_Handle(t *testing.T) {
 											},
 											ImagePullJobTemplate: appsv1beta1.ImagePullJobTemplate{
 												CompletionPolicy: appsv1beta1.CompletionPolicy{
-													Type: appsv1beta1.Always,
+													Type:                    appsv1beta1.Always,
+													TTLSecondsAfterFinished: int32Ptr(100),
 												},
 											},
 										},
@@ -689,9 +735,8 @@ func TestAdvancedCronJobCreateUpdateHandler_Handle(t *testing.T) {
 												Parallelism: nil,
 												PullPolicy:  nil,
 												CompletionPolicy: appsv1beta1.CompletionPolicy{
-													Type:                    appsv1beta1.Always,
-													ActiveDeadlineSeconds:   int64Ptr(100),
-													TTLSecondsAfterFinished: int32Ptr(100),
+													Type:                  appsv1beta1.Always,
+													ActiveDeadlineSeconds: int64Ptr(100),
 												},
 												SandboxConfig:   nil,
 												ImagePullPolicy: "",
@@ -749,9 +794,8 @@ func TestAdvancedCronJobCreateUpdateHandler_Handle(t *testing.T) {
 												Parallelism: nil,
 												PullPolicy:  nil,
 												CompletionPolicy: appsv1beta1.CompletionPolicy{
-													Type:                    appsv1beta1.Always,
-													ActiveDeadlineSeconds:   int64Ptr(100),
-													TTLSecondsAfterFinished: int32Ptr(100),
+													Type:                  appsv1beta1.Always,
+													ActiveDeadlineSeconds: int64Ptr(100),
 												},
 												SandboxConfig:   nil,
 												ImagePullPolicy: "",
@@ -810,9 +854,8 @@ func TestAdvancedCronJobCreateUpdateHandler_Handle(t *testing.T) {
 												Parallelism: nil,
 												PullPolicy:  nil,
 												CompletionPolicy: appsv1beta1.CompletionPolicy{
-													Type:                    appsv1beta1.Always,
-													ActiveDeadlineSeconds:   int64Ptr(100),
-													TTLSecondsAfterFinished: int32Ptr(100),
+													Type:                  appsv1beta1.Always,
+													ActiveDeadlineSeconds: int64Ptr(100),
 												},
 												SandboxConfig:   nil,
 												ImagePullPolicy: "",
@@ -869,9 +912,8 @@ func TestAdvancedCronJobCreateUpdateHandler_Handle(t *testing.T) {
 												Parallelism: nil,
 												PullPolicy:  nil,
 												CompletionPolicy: appsv1beta1.CompletionPolicy{
-													Type:                    appsv1beta1.Always,
-													ActiveDeadlineSeconds:   int64Ptr(100),
-													TTLSecondsAfterFinished: int32Ptr(100),
+													Type:                  appsv1beta1.Always,
+													ActiveDeadlineSeconds: int64Ptr(100),
 												},
 												SandboxConfig:   nil,
 												ImagePullPolicy: "",
@@ -925,7 +967,7 @@ func TestAdvancedCronJobCreateUpdateHandler_Handle(t *testing.T) {
 												CompletionPolicy: appsv1beta1.CompletionPolicy{
 													Type:                    appsv1beta1.Always,
 													ActiveDeadlineSeconds:   int64Ptr(MaxActiveDeadLineSeconds + 1),
-													TTLSecondsAfterFinished: int32Ptr(MaxTTLSecondsAfterFinished + 1),
+													TTLSecondsAfterFinished: int32Ptr(100),
 												},
 												SandboxConfig:   nil,
 												ImagePullPolicy: "",


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
advancedCronJob should ignore watching delete child job, in case the child job is deleted by itself or manually, then it is scheduled again as a missing job

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fix #2213 

### Ⅲ. Describe how to verify it
1. create AdvancedCronJob which should run at a fix time
```
apiVersion: apps.kruise.io/v1beta1
kind: AdvancedCronJob
metadata:
    name: acj-job
    namespace: default
spec:
    concurrencyPolicy: Replace
    failedJobsHistoryLimit: 5
    paused: false
    timeZone: Asia/Shanghai
    schedule: "46 21 * * *"
    successfulJobsHistoryLimit: 3
    template:
      broadcastJobTemplate:
        spec:
         template:
          spec:
           containers:
           - name: test
             image: alpine
             command: ["sleep", "10"]
           restartPolicy: Never
```

2. wait job start to run
3. manually delete it, kubectl delete broadcastjob acj-job-1761557880
4. the job should not be scheduled again

### Ⅳ. Special notes for reviews
I don't know how to write UT case for `watchBroadcastJob` easily, as there seems no existing mockManager, but the code is simple, I think maybe no need to do coverage
