### PR TITLE
expose defaultTTlSecondsForAlways for nodeimage

### DIFF
--- a/pkg/controller/imagepulljob/imagepulljob_utils.go
+++ b/pkg/controller/imagepulljob/imagepulljob_utils.go
@@ -62,7 +62,7 @@ func getTTLSecondsForAlways(job *appsv1beta1.ImagePullJob) *int32 {
 		}
 		ret = timeoutSeconds * backoffLimit
 	}
-	ret += 300 + rand.Int31n(300)
+	ret += util.GetDefaultTtlsecondsForAlwaysNodeimage() + rand.Int31n(300)
 	return &ret
 }
 

--- a/pkg/util/nodeimage.go
+++ b/pkg/util/nodeimage.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2025 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"errors"
+	"fmt"
+)
+
+const maxDefaultTtlsecondsForAlwaysNodeimage = 3600 * 24 * 31
+
+var defaultTtlsecondsForAlwaysNodeimage int32
+
+func SetDefaultTtlForAlwaysNodeimage(t int) error {
+	if t > maxDefaultTtlsecondsForAlwaysNodeimage || t < 0 {
+		return errors.New(fmt.Sprintf("default-ttlseconds-for-always-nodeimage must be positive and less than %d, current value is %d", maxDefaultTtlsecondsForAlwaysNodeimage, t))
+	}
+
+	defaultTtlsecondsForAlwaysNodeimage = int32(t)
+	return nil
+}
+
+func GetDefaultTtlsecondsForAlwaysNodeimage() int32 {
+	return defaultTtlsecondsForAlwaysNodeimage
+}

--- a/pkg/util/nodeimage_test.go
+++ b/pkg/util/nodeimage_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2025 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+)
+
+func TestSetDefaultTtlForAlwaysNodeimage(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     int
+		wantError bool
+	}{
+		{
+			name:      "valid value",
+			input:     1000,
+			wantError: false,
+		},
+		{
+			name:      "zero value",
+			input:     0,
+			wantError: false,
+		},
+		{
+			name:      "negative value",
+			input:     -1,
+			wantError: true,
+		},
+		{
+			name:      "max boundary value",
+			input:     maxDefaultTtlsecondsForAlwaysNodeimage,
+			wantError: false,
+		},
+		{
+			name:      "exceeds max value",
+			input:     maxDefaultTtlsecondsForAlwaysNodeimage + 1,
+			wantError: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := SetDefaultTtlForAlwaysNodeimage(tt.input)
+			if tt.wantError {
+				if err == nil {
+					t.Fatalf("expected error but got nil")
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("got error: %s", err)
+				}
+				if int32(tt.input) != GetDefaultTtlsecondsForAlwaysNodeimage() {
+					t.Fatalf("expected: %d, got: %d", tt.input, GetDefaultTtlsecondsForAlwaysNodeimage())
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
expose defaultTTlSecondsForAlways as a environment for nodeimage, that can allow user to controller the default ttl for nodeimage status, in case user don't want to use the same ttl for imagepulljob

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fix #2214
fix #2213

### Ⅲ. Describe how to verify it
1. kubectl edit deploy kruise-controller-manager, add parameter `--default-ttlseconds-for-always-nodeimage` for container manager
2. create imagepulljob
3. check the nodeimage ttlSecondsAfterFinished value
4. for detailed calculation methods, please refer to the test case

### Ⅳ. Special notes for reviews

