### PR TITLE
[Fix] Kruise-daemon restart container only image has chenged

### DIFF
--- a/pkg/daemon/containermeta/container_meta_controller.go
+++ b/pkg/daemon/containermeta/container_meta_controller.go
@@ -364,9 +364,10 @@ func (c *Controller) manageContainerMetaSet(pod *v1.Pod, kubePodStatus *kubeletc
 				}
 			}
 
+			// Trigger restarting only if image has not been changed, else kubelet will restart container
 			// Trigger restarting only if it is in-place updating
 			_, condition := podutil.GetPodCondition(&pod.Status, appspub.InPlaceUpdateReady)
-			if condition != nil && condition.Status == v1.ConditionFalse {
+			if condition != nil && condition.Status == v1.ConditionFalse && status.Image == containerSpec.Image {
 				// Trigger restarting when expected env hash is not equal to current hash
 				if containerMeta.Hashes.ExtractedEnvFromMetadataHash > 0 && containerMeta.Hashes.ExtractedEnvFromMetadataHash != envHasher.GetExpectHash(containerSpec, pod) {
 					// Maybe checking PlainHash inconsistent here can skip to trigger restart. But it is not a good idea for some special scenarios.


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
 Kubelet will restart container when image has changed, so Kruise-daemon should avoid extra restarting and preStop hook.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
Fix #1263
### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

