### PR TITLE
feat(daemon): add rest-config-qps and rest-config-burst flags

### DIFF
--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -52,6 +52,9 @@ var (
 	// preventing the consumption of all available disk IOPS or network bandwidth,
 	// which could otherwise impact the performance of other running pods.
 	maxWorkersForPullImage = flag.Int("max-workers-for-pull-image", -1, "The maximum number of workers for pulling images.")
+
+	restConfigQPS   = flag.Int("rest-config-qps", 0, "QPS of rest config. Defaults to 0, which means using the default value of client-go.")
+	restConfigBurst = flag.Int("rest-config-burst", 0, "Burst of rest config. Defaults to 0, which means using the default value of client-go.")
 )
 
 func main() {
@@ -65,6 +68,12 @@ func main() {
 
 	cfg := config.GetConfigOrDie()
 	cfg.UserAgent = "kruise-daemon"
+	if *restConfigQPS > 0 {
+		cfg.QPS = float32(*restConfigQPS)
+	}
+	if *restConfigBurst > 0 {
+		cfg.Burst = *restConfigBurst
+	}
 	if err := client.NewRegistry(cfg); err != nil {
 		klog.Fatalf("Failed to init clientset registry: %v", err)
 	}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

Add `--rest-config-qps` and `--rest-config-burst` flags for kruise-daemon to allow users to customize client-side rate limiting parameters.

This helps resolve client-side throttling issues when running in large-scale clusters with high ImagePullJob / nodepodprobe concurrency.

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. Describe how to verify it

1. Build kruise-daemon with the changes
2. Run with custom flags: `--rest-config-qps=100 --rest-config-burst=200`
3. Verify the client uses the specified QPS and Burst values

### Ⅳ. Special notes for reviews

- Default values remain unchanged (QPS=5, Burst=10) to maintain backward compatibility
- Implementation follows the same pattern as kruise-manager in `main.go`