### PR TITLE
fix: handle empty selector as match-all for ImagePullJob

### DIFF
--- a/pkg/util/imagejob/imagejob_reader.go
+++ b/pkg/util/imagejob/imagejob_reader.go
@@ -204,14 +204,12 @@ func GetActiveJobsForNodeImage(reader client.Reader, nodeImage, oldNodeImage *ap
 			if err != nil {
 				return nil, nil, fmt.Errorf("parse selector for %s/%s error: %v", job.Namespace, job.Name, err)
 			}
-			if !selector.Empty() {
-				if selector.Matches(labels.Set(nodeImage.Labels)) {
-					matched = true
-				}
-				if oldNodeImage != nil {
-					if selector.Matches(labels.Set(oldNodeImage.Labels)) {
-						oldMatched = true
-					}
+			if selector.Matches(labels.Set(nodeImage.Labels)) {
+				matched = true
+			}
+			if oldNodeImage != nil {
+				if selector.Matches(labels.Set(oldNodeImage.Labels)) {
+					oldMatched = true
 				}
 			}
 		}

--- a/pkg/util/imagejob/imagejob_reader_test.go
+++ b/pkg/util/imagejob/imagejob_reader_test.go
@@ -169,7 +169,7 @@ var (
 			ObjectMeta: metav1.ObjectMeta{Name: "job7"},
 			Spec: appsv1beta1.ImagePullJobSpec{
 				ImagePullJobTemplate: appsv1beta1.ImagePullJobTemplate{
-					Selector: &appsv1beta1.ImagePullJobNodeSelector{LabelSelector: metav1.LabelSelector{}},
+					Selector: &appsv1beta1.ImagePullJobNodeSelector{LabelSelector: metav1.LabelSelector{}}, // Empty selector should match nothing
 				},
 			},
 		},
@@ -247,8 +247,9 @@ func testGetNodeImagesForJob(g *gomega.GomegaWithT) {
 	g.Expect(getNodeImagesForJob(initialJobs[2])).Should(gomega.Equal([]string{"node3", "node5"}))
 	g.Expect(getNodeImagesForJob(initialJobs[3])).Should(gomega.Equal([]string{"node1", "node4"}))
 	g.Expect(getNodeImagesForJob(initialJobs[4])).Should(gomega.Equal([]string{"node2"}))
-	g.Expect(getNodeImagesForJob(initialJobs[6])).Should(gomega.Equal([]string{"node1", "node2", "node3", "node4", "node5"}))
 	// g.Expect(getNodeImagesForJob(initialJobs[5])).Should(gomega.Equal([]string{"node2"}))
+	// Empty selector should match nothing
+	g.Expect(getNodeImagesForJob(initialJobs[6])).Should(gomega.Equal([]string{}))
 }
 
 func testGetActiveJobsForPod(g *gomega.GomegaWithT) {
@@ -282,9 +283,10 @@ func testGetActiveJobsForNodeImage(g *gomega.GomegaWithT) {
 		return names.List()
 	}
 
-	g.Expect(getActiveJobsForNodeImage(initialNodeImages[0])).Should(gomega.Equal([]string{"job1", "job4", "job7"}))
-	g.Expect(getActiveJobsForNodeImage(initialNodeImages[1])).Should(gomega.Equal([]string{"job1", "job2", "job5", "job7"}))
-	g.Expect(getActiveJobsForNodeImage(initialNodeImages[2])).Should(gomega.Equal([]string{"job1", "job3", "job7"}))
-	g.Expect(getActiveJobsForNodeImage(initialNodeImages[3])).Should(gomega.Equal([]string{"job1", "job2", "job4", "job7"}))
-	g.Expect(getActiveJobsForNodeImage(initialNodeImages[4])).Should(gomega.Equal([]string{"job1", "job3", "job5", "job7"}))
+	g.Expect(getActiveJobsForNodeImage(initialNodeImages[0])).Should(gomega.Equal([]string{"job1", "job4"}))
+	g.Expect(getActiveJobsForNodeImage(initialNodeImages[1])).Should(gomega.Equal([]string{"job1", "job2", "job5"}))
+	g.Expect(getActiveJobsForNodeImage(initialNodeImages[2])).Should(gomega.Equal([]string{"job1", "job3"}))
+	g.Expect(getActiveJobsForNodeImage(initialNodeImages[3])).Should(gomega.Equal([]string{"job1", "job2", "job4"}))
+	g.Expect(getActiveJobsForNodeImage(initialNodeImages[4])).Should(gomega.Equal([]string{"job1", "job3", "job5"}))
+	// Empty selector should not match any node (job7 should not appear in any results)
 }

--- a/pkg/util/imagejob/imagejob_reader_test.go
+++ b/pkg/util/imagejob/imagejob_reader_test.go
@@ -165,6 +165,14 @@ var (
 			ObjectMeta: metav1.ObjectMeta{Name: "job6", Finalizers: []string{"apps.kruise.io/fake-block"}},
 			Spec:       appsv1beta1.ImagePullJobSpec{},
 		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "job7"},
+			Spec: appsv1beta1.ImagePullJobSpec{
+				ImagePullJobTemplate: appsv1beta1.ImagePullJobTemplate{
+					Selector: &appsv1beta1.ImagePullJobNodeSelector{LabelSelector: metav1.LabelSelector{}},
+				},
+			},
+		},
 	}
 )
 
@@ -239,6 +247,7 @@ func testGetNodeImagesForJob(g *gomega.GomegaWithT) {
 	g.Expect(getNodeImagesForJob(initialJobs[2])).Should(gomega.Equal([]string{"node3", "node5"}))
 	g.Expect(getNodeImagesForJob(initialJobs[3])).Should(gomega.Equal([]string{"node1", "node4"}))
 	g.Expect(getNodeImagesForJob(initialJobs[4])).Should(gomega.Equal([]string{"node2"}))
+	g.Expect(getNodeImagesForJob(initialJobs[6])).Should(gomega.Equal([]string{"node1", "node2", "node3", "node4", "node5"}))
 	// g.Expect(getNodeImagesForJob(initialJobs[5])).Should(gomega.Equal([]string{"node2"}))
 }
 
@@ -273,9 +282,9 @@ func testGetActiveJobsForNodeImage(g *gomega.GomegaWithT) {
 		return names.List()
 	}
 
-	g.Expect(getActiveJobsForNodeImage(initialNodeImages[0])).Should(gomega.Equal([]string{"job1", "job4"}))
-	g.Expect(getActiveJobsForNodeImage(initialNodeImages[1])).Should(gomega.Equal([]string{"job1", "job2", "job5"}))
-	g.Expect(getActiveJobsForNodeImage(initialNodeImages[2])).Should(gomega.Equal([]string{"job1", "job3"}))
-	g.Expect(getActiveJobsForNodeImage(initialNodeImages[3])).Should(gomega.Equal([]string{"job1", "job2", "job4"}))
-	g.Expect(getActiveJobsForNodeImage(initialNodeImages[4])).Should(gomega.Equal([]string{"job1", "job3", "job5"}))
+	g.Expect(getActiveJobsForNodeImage(initialNodeImages[0])).Should(gomega.Equal([]string{"job1", "job4", "job7"}))
+	g.Expect(getActiveJobsForNodeImage(initialNodeImages[1])).Should(gomega.Equal([]string{"job1", "job2", "job5", "job7"}))
+	g.Expect(getActiveJobsForNodeImage(initialNodeImages[2])).Should(gomega.Equal([]string{"job1", "job3", "job7"}))
+	g.Expect(getActiveJobsForNodeImage(initialNodeImages[3])).Should(gomega.Equal([]string{"job1", "job2", "job4", "job7"}))
+	g.Expect(getActiveJobsForNodeImage(initialNodeImages[4])).Should(gomega.Equal([]string{"job1", "job3", "job5", "job7"}))
 }


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Fixes an issue where ImagePullJob with an empty node selector (selector: {}) was treated as matching no nodes.
The job now correctly treats an empty selector as matching all nodes, consistent with Kubernetes selector semantics.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes:#2286

### Ⅲ. Describe how to verify it
Added a new test case using an empty selector.
Updated existing tests to ensure:
- selector: {} behaves the same as no selector.
- Jobs with empty selectors are correctly associated with all nodes.
All related unit tests pass in CI.

### Ⅳ. Special notes for reviews

