### PR TITLE
fix: allow in-place update when image tag changes but digest remains …

### DIFF
--- a/pkg/util/inplaceupdate/inplace_update_check_test.go
+++ b/pkg/util/inplaceupdate/inplace_update_check_test.go
@@ -1,0 +1,87 @@
+package inplaceupdate
+
+import (
+	"testing"
+
+	appspub "github.com/openkruise/kruise/apis/apps/pub"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubeletcontainer "k8s.io/kubernetes/pkg/kubelet/container"
+)
+
+func TestCheckAllContainersHashConsistent_SameDigest(t *testing.T) {
+	// Represents the container run with image v1
+	containerV1 := v1.Container{
+		Name:  "nginx",
+		Image: "nginx:v1",
+	}
+	// Represents the container run with image v2
+	containerV2 := v1.Container{
+		Name:  "nginx",
+		Image: "nginx:v2",
+	}
+
+	// Calculate what the hash WOULD be for v1 (which is what the daemon reports is running)
+	hashV1 := kubeletcontainer.HashContainer(&containerV1)
+
+	cases := []struct {
+		name                 string
+		pod                  *v1.Pod
+		runtimeContainerMeta *appspub.RuntimeContainerMeta
+		expectedResult       bool
+	}{
+		{
+			name: "normal case: hashes match",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "test-pod"},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{containerV1},
+				},
+				Status: v1.PodStatus{
+					ContainerStatuses: []v1.ContainerStatus{
+						{Name: "nginx", ContainerID: "docker://123", Image: "nginx:v1"},
+					},
+				},
+			},
+			runtimeContainerMeta: &appspub.RuntimeContainerMeta{
+				Name:        "nginx",
+				ContainerID: "docker://123",
+				Hashes:      appspub.RuntimeContainerHashes{PlainHash: hashV1},
+			},
+			expectedResult: true,
+		},
+		{
+			name: "issue case: spec has v2, runtime has v1 hash, but content is same (implied by ID match and Status Image match)",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "test-pod"},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{containerV2}, // Spec wants v2
+				},
+				Status: v1.PodStatus{
+					ContainerStatuses: []v1.ContainerStatus{
+						// Kubelet accepted v2, but kept the same ContainerID
+						{Name: "nginx", ContainerID: "docker://123", Image: "nginx:v2", ImageID: "docker-pullable://nginx@sha256:same-digest"},
+					},
+				},
+			},
+			runtimeContainerMeta: &appspub.RuntimeContainerMeta{
+				Name:        "nginx",
+				ContainerID: "docker://123",         // Matches running container
+				Hashes:      appspub.RuntimeContainerHashes{PlainHash: hashV1}, // Has hash of v1
+			},
+			expectedResult: true, 
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			metaSet := &appspub.RuntimeContainerMetaSet{
+				Containers: []appspub.RuntimeContainerMeta{*tc.runtimeContainerMeta},
+			}
+			got := checkAllContainersHashConsistent(tc.pod, metaSet, plainHash)
+			if got != tc.expectedResult {
+				t.Errorf("checkAllContainersHashConsistent() = %v, want %v", got, tc.expectedResult)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

This PR fixes an issue where an in-place update would hang indefinitely if the container image tag was changed (e.g., `v1` -> `v2`) but the underlying image digest remained identical.

Previously, the `plainHash` check would fail because the spec (new image name) and runtime meta (old image name) produced different hashes, even though Kubelet did not restart the container (because the digest matched).

This fix relaxes the consistency check: if the container's `ImageID` in status matches the running container's ID (implying no restart) and the `Status.Image` matches the new `Spec.Image`, we consider the state consistent and allow the update to proceed.

### Ⅱ. Does this pull request fix one issue?
fixes #2297

### Ⅲ. Describe how to verify it

1. Deploy a Kruise StatefulSet with `image: repo/app:v1`.
2. Push a new tag `repo/app:v2` pointing to the **same digest** as `v1`.
3. Update the StatefulSet to use `image: repo/app:v2`.
4. Verify that `InPlaceUpdateReady` condition becomes `True` and the update completes successfully instead of getting stuck.

(Verified locally with a reproduction unit test case simulating this scenario).

### Ⅳ. Special notes for reviews

N/A