### PR TITLE
feat: add daemon version to HTTP probe user-agent

### DIFF
--- a/pkg/daemon/podprobe/prober.go
+++ b/pkg/daemon/podprobe/prober.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/utils/exec"
 
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
+	"github.com/openkruise/kruise/pkg/util/version"
 )
 
 const maxProbeMessageLength = 1024
@@ -149,8 +150,7 @@ func formatURL(scheme string, host string, port int, path string) (*url.URL, err
 }
 
 func userAgent(purpose string) string {
-	// TODO: get kruise daemon version
-	return fmt.Sprintf("kube-%s", purpose)
+	return fmt.Sprintf("kruise-daemon/%s kube-%s", version.DaemonVersion, purpose)
 }
 
 // v1HeaderToHTTPHeader takes a list of HTTPHeader <name, value> string pairs

--- a/pkg/util/version/version.go
+++ b/pkg/util/version/version.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2025 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+var (
+	// DaemonVersion is the version of kruise-daemon, set via -ldflags at build time
+	DaemonVersion = "unknown"
+)


### PR DESCRIPTION
Fixes #2310 

### Ⅰ. Describe what this PR does

This PR adds the Kruise daemon version to the HTTP probe user-agent string for better observability and debugging.

**Changes:**
- Created [pkg/util/version/version.go](cci:7://file:///Users/aadishah/Desktop/kruise-main/kruise-main/pkg/util/version/version.go:0:0-0:0) with `DaemonVersion` variable
- Updated [userAgent()](cci:1://file:///Users/aadishah/Desktop/kruise-main/kruise-main/pkg/daemon/podprobe/prober.go:151:0-153:1) function in [pkg/daemon/podprobe/prober.go](cci:7://file:///Users/aadishah/Desktop/kruise-main/kruise-main/pkg/daemon/podprobe/prober.go:0:0-0:0) to include version
- User-agent format changed from `kube-probe` to `kruise-daemon/<version> kube-probe`

**Before:** `kube-probe`  
**After:** `kruise-daemon/unknown kube-probe` (version will be injected at build time via `-ldflags`)

### Ⅱ. Does this pull request fix one issue?

fixes #2310

### Ⅲ. Describe how to verify it

1. Check that [pkg/util/version/version.go](cci:7://file:///Users/aadishah/Desktop/kruise-main/kruise-main/pkg/util/version/version.go:0:0-0:0) exists with `DaemonVersion` variable
2. Verify [pkg/daemon/podprobe/prober.go](cci:7://file:///Users/aadishah/Desktop/kruise-main/kruise-main/pkg/daemon/podprobe/prober.go:0:0-0:0) imports the version package
3. Confirm [userAgent()](cci:1://file:///Users/aadishah/Desktop/kruise-main/kruise-main/pkg/daemon/podprobe/prober.go:151:0-153:1) function returns the correct format: `kruise-daemon/<version> kube-probe`
4. Run tests: `go test ./pkg/daemon/podprobe/...`
5. Verify no import cycles exist

### Ⅳ. Special notes for reviews

- Version is currently set to "unknown" as a default value
- Build-time injection via Makefile `-ldflags` can be added in a follow-up PR if needed
- Used `pkg/util/version` package to avoid import cycle (daemon package imports podprobe)

