### PR TITLE
fix: update NodeImage when ImagePullJob policy changes and Add test 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ golangci-lint: ## Download golangci-lint locally if necessary.
 
 GINKGO = $(shell pwd)/bin/ginkgo
 ginkgo: ## Download ginkgo locally if necessary.
-	$(call go-get-tool,$(GINKGO),github.com/onsi/ginkgo/v2/ginkgo@latest)
+	$(call go-get-tool,$(GINKGO),github.com/onsi/ginkgo/v2/ginkgo@v2.23.4)
 
 # go-get-tool will 'go get' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))

--- a/pkg/controller/imagepulljob/imagepulljob_controller.go
+++ b/pkg/controller/imagepulljob/imagepulljob_controller.go
@@ -367,9 +367,16 @@ func (r *ReconcileImagePullJob) syncNodeImages(job *appsv1beta1.ImagePullJob, ne
 					continue
 				}
 				if util.ContainsObjectRef(tagSpec.OwnerReferences, *ownerRef) {
-					skip = true
-					return nil
+					if tagSpec.ImagePullPolicy == job.Spec.ImagePullPolicy && reflect.DeepEqual(tagSpec.PullPolicy, pullPolicy) {
+						skip = true
+						return nil
+					}
+					tagSpec.ImagePullPolicy = job.Spec.ImagePullPolicy
+					tagSpec.PullPolicy = pullPolicy
+					found = true
+					break
 				}
+
 				// increase version to start a new round of image downloads
 				tagSpec.Version++
 				// merge owner reference

--- a/pkg/controller/imagepulljob/imagepulljob_controller_test.go
+++ b/pkg/controller/imagepulljob/imagepulljob_controller_test.go
@@ -1996,3 +1996,83 @@ func TestClaimImagePullJobSecrets_UpdateExistingSecret(t *testing.T) {
 	assert.Contains(t, updatedSecret.Annotations[SecretAnnotationReferenceJobs], "default/test-job")
 	assert.Contains(t, updatedSecret.Annotations[SecretAnnotationReferenceJobs], "default/other-job")
 }
+
+func TestReconcileImagePullJob_syncNodeImages_UpdateTimeout(t *testing.T) {
+	// Create a job with timeout 600
+	timeout := int32(600)
+	job := &appsv1beta1.ImagePullJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-job",
+			Namespace: "default",
+			UID:       types.UID("job-uid"),
+		},
+		Spec: appsv1beta1.ImagePullJobSpec{
+			Image: "nginx:latest",
+			ImagePullJobTemplate: appsv1beta1.ImagePullJobTemplate{
+				PullPolicy: &appsv1beta1.PullPolicy{
+					TimeoutSeconds: &timeout,
+				},
+			},
+		},
+	}
+
+	// Create a NodeImage that already has the tag, OwnerReference pointing to the job,
+	// BUT has a DIFFERENT timeout (e.g. 300) in its PullPolicy.
+	// This simulates the state where the Job was updated but NodeImage is not yet.
+	oldTimeout := int32(300)
+	nodeImage := &appsv1beta1.NodeImage{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "node-1",
+			Namespace: "", // Cluster scoped
+		},
+		Spec: appsv1beta1.NodeImageSpec{
+			Images: map[string]appsv1beta1.ImageSpec{
+				"nginx": {
+					Tags: []appsv1beta1.ImageTagSpec{
+						{
+							Tag: "latest",
+							OwnerReferences: []v1.ObjectReference{
+								{
+									APIVersion: appsv1beta1.SchemeGroupVersion.String(),
+									Kind:       "ImagePullJob",
+									Name:       "test-job",
+									UID:        "job-uid",
+								},
+							},
+							ImagePullPolicy: appsv1beta1.ImagePullPolicy(appsv1beta1.PullIfNotPresent),
+							PullPolicy: &appsv1beta1.ImageTagPullPolicy{
+								TimeoutSeconds: &oldTimeout,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// scheme is globally defined in imagepulljob_event_handler_test.go which is in the same package
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(job, nodeImage).Build()
+
+	r := &ReconcileImagePullJob{
+		Client: fakeClient,
+		scheme: scheme,
+		clock:  k8stesting.NewFakeClock(time.Now()),
+	}
+
+	// Call syncNodeImages
+	err := r.syncNodeImages(job, &appsv1beta1.ImagePullJobStatus{Active: 0}, []string{"node-1"}, nil)
+	assert.NoError(t, err)
+
+	// Fetch updated NodeImage
+	updatedNodeImage := &appsv1beta1.NodeImage{}
+	err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: "node-1"}, updatedNodeImage)
+	assert.NoError(t, err)
+
+	// Check if TimeoutSeconds is updated to 600
+	imageSpec := updatedNodeImage.Spec.Images["nginx"]
+	tagSpec := imageSpec.Tags[0]
+
+	if tagSpec.PullPolicy == nil || tagSpec.PullPolicy.TimeoutSeconds == nil || *tagSpec.PullPolicy.TimeoutSeconds != 600 {
+		t.Fatalf("Regression Test Failed: Expected timeout 600, got %v", tagSpec.PullPolicy.TimeoutSeconds)
+	}
+}


### PR DESCRIPTION


<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
This PR fixes a bug where changes to an ImagePullJob's configuration were not being propagated to the corresponding 
NodeImage resources if the NodeImage already had an OwnerReference pointing to the Job.This change updates the logic in 
syncNodeImages to explicitly compare the ImagePullPolicy and PullPolicy of the Job against the Node. If they mismatch, the 
NodeImage is updated with the new configuration.         
A new test TestReconcileImagePullJob_syncNodeImages_UpdateTimeout has been added to imagepulljob_controller_test.go to check that changes to the ImagePullJob timeout are correctly applied.

### Ⅱ. Does this pull request fix one issue?
fixes #2221

### Ⅲ. Describe how to verify it :
Run the newly added regression test:
go test -v ./pkg/controller/imagepulljob/ -run TestReconcileImagePullJob_syncNodeImages_UpdateTimeout


### Ⅳ. Special notes for reviews

