### PR TITLE
docs: correct typos and grammar across various documents and comments.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,7 +80,7 @@
 - Remove Docker runtime dependency ([#1870](https://github.com/openkruise/kruise/pull/1870),[@furykerry](https://github.com/furykerry))
 - Improve test parallelism and reliability ([#1743](https://github.com/openkruise/kruise/pull/1743), [@MichaelRren](https://github.com/MichaelRren))
 - Enhance WorkloadSpread validation logic ([#1740](https://github.com/openkruise/kruise/pull/1740), [@AiRanthem](https://github.com/AiRanthem))
-- Launche Kruise Guru on Gurubase.io ([#1800](https://github.com/openkruise/kruise/pull/1800), [@kursataktas](https://github.com/kursataktas))
+- Launch Kruise Guru on Gurubase.io ([#1800](https://github.com/openkruise/kruise/pull/1800), [@kursataktas](https://github.com/kursataktas))
 - Improve documentation accuracy ([#1824](https://github.com/openkruise/kruise/pull/1824), [@furykerry](https://github.com/furykerry))
 - Fix KIND installation issues ([#1688](https://github.com/openkruise/kruise/pull/1688),[@ABNER-1](https://github.com/ABNER-1))
 - Avoid overriding namespace config after deploying ([#1772](https://github.com/openkruise/kruise/pull/1772),[@hantmac](https://github.com/hantmac))
@@ -107,7 +107,7 @@
 - Support specified-delete in AdvancedStatefulSet and handle specified deleted pod under maxUnavailable constrain. ([#1734](https://github.com/openkruise/kruise/pull/1734), [@ABNER-1](https://github.com/ABNER-1))
 
 ## v1.5.5
-> Chang log since v1.5.4
+> Change log since v1.5.4
 
 ### Advanced Workload
 - Support specified-delete in AdvancedStatefulSet and handle specified deleted pod under maxUnavailable constrain. ([#1734](https://github.com/openkruise/kruise/pull/1734), [@ABNER-1](https://github.com/ABNER-1))
@@ -178,7 +178,7 @@
 - Fix new version of Pods released by cloneSet that doesn't match spec.updateStrategy.partition. ([#1549](https://github.com/openkruise/kruise/pull/1549), [@qswksp](https://github.com/qswksp))
 
 ## v1.5.4
-> Chang log since v1.5.3
+> Change log since v1.5.3
 
 ### CloneSet
 - Fix new version of Pods released by cloneSet that doesn't match spec.updateStrategy.partition. ([#1549](https://github.com/openkruise/kruise/pull/1549), [@qswksp](https://github.com/qswksp))
@@ -200,7 +200,7 @@
 - Fix when StatefulSet reserveOrdinals exist and whenScaled=Delete, scale down pvc failed. ([#1531](https://github.com/openkruise/kruise/pull/1531), [@zmberg](https://github.com/zmberg))
 
 ## v1.5.3
-> Chang log since v1.5.2
+> Change log since v1.5.2
 
 ### Advanced Workload
 - Fix when StatefulSet reserveOrdinals exist and whenScaled=Delete, scale down pvc failed. ([#1531](https://github.com/openkruise/kruise/pull/1531), [@zmberg](https://github.com/zmberg))
@@ -260,15 +260,15 @@
   - Fix unnecessary use of fmt.Sprintf. ([#1403](https://github.com/openkruise/kruise/pull/1403), [testwill](https://github.com/testwill))
 
 ## v1.5.2
-> Chang log since v1.5.1
+> Change log since v1.5.1
 
 ### CVE FIX: Enhance kruise-daemon security ([#1482](https://github.com/openkruise/kruise/pull/1482), [veophi](https://github.com/veophi))
 
 ### Start kruise-manager as a non-root user
-We start kruise-manger with a non-root user to further enhance the security of kruise-manager. ([#1491](https://github.com/openkruise/kruise/pull/1491), [@zmberg](https://github.com/zmberg))
+We start kruise-manager with a non-root user to further enhance the security of kruise-manager. ([#1491](https://github.com/openkruise/kruise/pull/1491), [@zmberg](https://github.com/zmberg))
 
 ## v1.5.1
-> Chang log since v1.5.0
+> Change log since v1.5.0
 
 In version 1.5.1, the focus was on enhancing UnitedDeployment and addressing various bug fixes:
 
@@ -441,13 +441,13 @@ For more detail, please refer to its [documentation](https://openkruise.io/docs/
 - Optimize event handler performance for PodUnavailableBudget. ([#1027](https://github.com/openkruise/kruise/pull/1027), [@FillZpp](https://github.com/FillZpp))
 
 ### Advanced DaemonSet
-- Allow optional filed max unavilable in ads, and set default value 1. ([#1007](https://github.com/openkruise/kruise/pull/1007), [@ABNER-1](https://github.com/ABNER-1))
+- Allow optional field max unavailable in ads, and set default value 1. ([#1007](https://github.com/openkruise/kruise/pull/1007), [@ABNER-1](https://github.com/ABNER-1))
 - Fix DaemonSet surging with minReadySeconds. ([#1014](https://github.com/openkruise/kruise/pull/1014), [@FillZpp](https://github.com/FillZpp))
 - Optimize Advanced DaemonSet internal new pod for imitating scheduling. ([#1011](https://github.com/openkruise/kruise/pull/1011), [@FillZpp](https://github.com/FillZpp))
 - Advanced DaemonSet support pre-download image. ([#1057](https://github.com/openkruise/kruise/pull/1057), [@ABNER-1](https://github.com/ABNER-1))
 
 ### Advanced StatefulSet
-- Fix panic cased by statefulset pvc auto deletion. ([#999](https://github.com/openkruise/kruise/pull/999), [@veophi](https://github.com/veophi))
+- Fix panic caused by statefulset pvc auto deletion. ([#999](https://github.com/openkruise/kruise/pull/999), [@veophi](https://github.com/veophi))
 
 ### Others
 - Optimize performance of LabelSelector conversion. ([#1068](https://github.com/openkruise/kruise/pull/1068), [@FillZpp](https://github.com/FillZpp))

--- a/apis/apps/v1alpha1/persistent_pod_state_types.go
+++ b/apis/apps/v1alpha1/persistent_pod_state_types.go
@@ -43,7 +43,7 @@ const (
 
 // PersistentPodStateSpec defines the desired state of PersistentPodState
 type PersistentPodStateSpec struct {
-	// TargetReference contains enough information to let you identify an workload for PersistentPodState
+	// TargetReference contains enough information to let you identify a workload for PersistentPodState
 	// Selector and TargetReference are mutually exclusive, TargetReference is priority to take effect
 	// current only support StatefulSet
 	TargetReference TargetReference `json:"targetRef"`

--- a/apis/apps/v1alpha1/uniteddeployment_types.go
+++ b/apis/apps/v1alpha1/uniteddeployment_types.go
@@ -151,7 +151,7 @@ type UnitedDeploymentUpdateStrategy struct {
 	ManualUpdate *ManualUpdate `json:"manualUpdate,omitempty"`
 }
 
-// ManualUpdate is a update strategy which allows users to control the update progress
+// ManualUpdate is an update strategy which allows users to control the update progress
 // by providing the partition of each subset.
 type ManualUpdate struct {
 	// Indicates number of subset partition.

--- a/apis/apps/v1alpha1/well_know_annotations.go
+++ b/apis/apps/v1alpha1/well_know_annotations.go
@@ -3,6 +3,6 @@ package v1alpha1
 const (
 	// AnnotationUsingEnhancedLiveness indicates that the enhanced liveness probe of pod is enabled.
 	AnnotationUsingEnhancedLiveness = "apps.kruise.io/using-enhanced-liveness"
-	// AnnotationUsingEnhancedLiveness indicates the backup probe (json types) of the pod native container livnessprobe configuration.
+	// AnnotationUsingEnhancedLiveness indicates the backup probe (json types) of the pod native container livenessProbe configuration.
 	AnnotationNativeContainerProbeContext = "apps.kruise.io/container-probe-context"
 )

--- a/apis/apps/v1alpha1/workloadspread_types.go
+++ b/apis/apps/v1alpha1/workloadspread_types.go
@@ -43,7 +43,7 @@ type WorkloadSpreadSpec struct {
 	ScheduleStrategy WorkloadSpreadScheduleStrategy `json:"scheduleStrategy,omitempty"`
 }
 
-// TargetReference contains enough information to let you identify an workload
+// TargetReference contains enough information to let you identify a workload
 type TargetReference struct {
 	// API version of the referent.
 	APIVersion string `json:"apiVersion"`

--- a/apis/apps/v1beta1/well_know_annotations.go
+++ b/apis/apps/v1beta1/well_know_annotations.go
@@ -3,6 +3,6 @@ package v1beta1
 const (
 	// AnnotationUsingEnhancedLiveness indicates that the enhanced liveness probe of pod is enabled.
 	AnnotationUsingEnhancedLiveness = "apps.kruise.io/using-enhanced-liveness"
-	// AnnotationUsingEnhancedLiveness indicates the backup probe (json types) of the pod native container livnessprobe configuration.
+	// AnnotationUsingEnhancedLiveness indicates the backup probe (json types) of the pod native container livenessProbe configuration.
 	AnnotationNativeContainerProbeContext = "apps.kruise.io/container-probe-context"
 )

--- a/apis/policy/v1alpha1/podunavailablebudget_types.go
+++ b/apis/policy/v1alpha1/podunavailablebudget_types.go
@@ -58,7 +58,7 @@ type PodUnavailableBudgetSpec struct {
 	// Selector label query over pods managed by the budget
 	Selector *metav1.LabelSelector `json:"selector,omitempty"`
 
-	// TargetReference contains enough information to let you identify an workload for PodUnavailableBudget
+	// TargetReference contains enough information to let you identify a workload for PodUnavailableBudget
 	// Selector and TargetReference are mutually exclusive, TargetReference is priority to take effect
 	TargetReference *TargetReference `json:"targetRef,omitempty"`
 
@@ -72,7 +72,7 @@ type PodUnavailableBudgetSpec struct {
 	MinAvailable *intstr.IntOrString `json:"minAvailable,omitempty"`
 }
 
-// TargetReference contains enough information to let you identify an workload for PodUnavailableBudget
+// TargetReference contains enough information to let you identify a workload for PodUnavailableBudget
 type TargetReference struct {
 	// API version of the referent.
 	APIVersion string `json:"apiVersion,omitempty"`

--- a/docs/proposals/20210628-workloadspread.md
+++ b/docs/proposals/20210628-workloadspread.md
@@ -223,11 +223,11 @@ When a Pod that belongs to a subset changes status phase to 'succeed' or 'failed
 
 ### Reschedule strategy
 
-Reschedule strategy will delete unscheduled Pods that still in pending status. Some subsets have no sufficient resource can lead to some Pods unscheduable.
+Reschedule strategy will delete unscheduled Pods that still in pending status. Some subsets have no sufficient resource can lead to some Pods unschedulable.
 WorkloadSpread has multiple subset, so the unschedulable pods should be rescheduled to other subsets.
 
-Controller will mark the subset containing unscheduable pods to unscheduable status and Webhook cannot inject Pod into this subset by check subset's status.
-And then controller cleans up all unscheduable Pods to trigger workload creating new replicas, and webhook will skip unscheduable subset and chose suitable subset to inject.
+Controller will mark the subset containing unschedulable pods to unschedulable status and Webhook cannot inject Pod into this subset by check subset's status.
+And then controller cleans up all unschedulable Pods to trigger workload creating new replicas, and webhook will skip unschedulable subset and chose suitable subset to inject.
 
 The unscheduled subset can be kept for 10 minutes and then should be recovered schedulable to schedule Pod again by controller.
 

--- a/docs/proposals/20240327-enhancedlivenessprobe.md
+++ b/docs/proposals/20240327-enhancedlivenessprobe.md
@@ -76,8 +76,8 @@ which support to check the nodePodProbe(e.g., tcp/http/exec checking) as the sam
 the webhook will admit the pod resource to remove the native livenessProbe and patch the configuration to the pod annotations `apps.kruise.io/container-probe-context: '{...json format for liveness probe with specified containers in pod...}''`.
 
 **LivenessNodeProbeController**
-> For using the nodPodProbe controller processing,
-> the livenessProbe config filed in the pod annotations should be converted to the nodePodProbe custom defined resource in Kruise suite.
+> For using the nodePodProbe controller processing,
+> the livenessProbe config field in the pod annotations should be converted to the nodePodProbe custom defined resource in Kruise suite.
 > This controller can create and update the nodePodProbe resource.
 > In Figure 1, the controller reconcile illustrates the nodePodProbe process for the pod different action(creation/update/deletion event).
 > For example with the pod creation, if there is not the nodePodProbe resource related with the pod assigned, the new resource will be created by the controller.
@@ -245,7 +245,7 @@ kind: Pod
 metadata:
   annotations:
   ...
-    // [user defined] using this enhanced livnessProbe, otherwise the native checking
+    // [user defined] using this enhanced livenessProbe, otherwise the native checking
     apps.kruise.io/using-enhanced-liveness: "true"
   ...
 
@@ -271,9 +271,9 @@ metadata:
 | enhanced(this solution)                                                                                                                                                                         | native                            |
 |-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------|
 | ● specified component detection(nodePodProbe controller in kruise-daemonset)  + global component decision(enhancedLivenessProbeController in kruise-manager) in cluster                         | ● single machine detection + single machine decision(all in kubelet) |
-| ● kruiseDaemon/ProbeDetector detection enabled in bypaas,  strong expansibility                                                                                                                 | ● no                              |
-| ● the global perspective of the application, the maxUnavailable protection policy and the capactiy building of the resilience protection system(Kruise-manager/EnhancedLivenessProbeController) | ● no                              |
-| ● the architecture is easy to expand, without invasive modification of native components, adapt easily to different scaenarios with strong scalability                                          | ● strong coupling, poor scalability |
+| ● kruiseDaemon/ProbeDetector detection enabled in bypass,  strong expansibility                                                                                                                 | ● no                              |
+| ● the global perspective of the application, the maxUnavailable protection policy and the capacity building of the resilience protection system(Kruise-manager/EnhancedLivenessProbeController) | ● no                              |
+| ● the architecture is easy to expand, without invasive modification of native components, adapt easily to different scenarios with strong scalability                                          | ● strong coupling, poor scalability |
 
 ### Other Notes
 ● Since the probe detection is implemented by the nodePodProbe controller in Kruise-daemonset, for the pod without ownerreference, this solution can also take effect on the enhancement ability for restarting containers when in failure livenessProbe status.

--- a/docs/tutorial/v1/images/guestbook/Makefile
+++ b/docs/tutorial/v1/images/guestbook/Makefile
@@ -14,7 +14,7 @@ release: clean build push clean
 build:
 	docker build --pull -t "${REGISTRY}/guestbook:${VERSION}" .
 
-# push the image to an registry
+# push the image to a registry
 push: build
 	docker push ${REGISTRY}/guestbook:${VERSION}
 

--- a/pkg/controller/broadcastjob/broadcastjob_controller.go
+++ b/pkg/controller/broadcastjob/broadcastjob_controller.go
@@ -490,7 +490,7 @@ func (r *ReconcileBroadcastJob) reconcilePods(job *appsv1beta1.BroadcastJob,
 // isJobComplete returns true if all pods on all desiredNodes are either succeeded or failed or deletionTimestamp !=nil.
 func isJobComplete(job *appsv1beta1.BroadcastJob, desiredNodes map[string]*corev1.Pod) bool {
 	if job.Spec.CompletionPolicy.Type == appsv1beta1.Never {
-		// the job will not terminate, if the the completion policy is never
+		// the job will not terminate, if the completion policy is never
 		return false
 	}
 	// if no desiredNodes, job pending

--- a/pkg/controller/cloneset/cloneset_event_handler.go
+++ b/pkg/controller/cloneset/cloneset_event_handler.go
@@ -115,9 +115,9 @@ func (e *podEventHandler) Update(ctx context.Context, evt event.TypedUpdateEvent
 	if curPod.DeletionTimestamp != nil {
 		// when a pod is deleted gracefully it's deletion timestamp is first modified to reflect a grace period,
 		// and after such time has passed, the kubelet actually deletes it from the store. We receive an update
-		// for modification of the deletion timestamp and expect an rs to create more replicas asap, not wait
+		// for modification of the deletion timestamp and expect a rs to create more replicas asap, not wait
 		// until the kubelet actually deletes the pod. This is different from the Phase of a pod changing, because
-		// an rs never initiates a phase change, and so is never asleep waiting for the same.
+		// a rs never initiates a phase change, and so is never asleep waiting for the same.
 		e.Delete(ctx, event.TypedDeleteEvent[*v1.Pod]{Object: evt.ObjectNew}, q)
 		if labelChanged {
 			// we don't need to check the oldPod.DeletionTimestamp because DeletionTimestamp cannot be unset.

--- a/pkg/controller/cloneset/revision/cloneset_revision.go
+++ b/pkg/controller/cloneset/revision/cloneset_revision.go
@@ -36,7 +36,7 @@ var (
 	patchCodec = scheme.Codecs.LegacyCodec(appsv1beta1.SchemeGroupVersion)
 )
 
-// Interface is a interface to new and apply ControllerRevision.
+// Interface is an interface to new and apply ControllerRevision.
 type Interface interface {
 	NewRevision(cs *appsv1beta1.CloneSet, revision int64, collisionCount *int32) (*apps.ControllerRevision, error)
 	ApplyRevision(cs *appsv1beta1.CloneSet, revision *apps.ControllerRevision) (*appsv1beta1.CloneSet, error)

--- a/pkg/controller/cloneset/sync/cloneset_scale.go
+++ b/pkg/controller/cloneset/sync/cloneset_scale.go
@@ -156,7 +156,7 @@ func (r *realControl) Scale(
 
 func (r *realControl) managePreparingDelete(cs *appsv1beta1.CloneSet, pods, podsInPreDelete []*v1.Pod, numToDelete int) (bool, error) {
 	//  We do not allow regret once the pod enter PreparingDelete state if MarkPodNotReady is set.
-	// Actually, there is a bug cased by this transformation from PreparingDelete to Normal,
+	// Actually, there is a bug caused by this transformation from PreparingDelete to Normal,
 	// i.e., Lifecycle Updated Hook may be lost if the pod was transformed from Updating state
 	// to PreparingDelete.
 	if lifecycle.IsLifecycleMarkPodNotReady(cs.Spec.Lifecycle) {

--- a/pkg/controller/cloneset/utils/pod_sorter_test.go
+++ b/pkg/controller/cloneset/utils/pod_sorter_test.go
@@ -82,7 +82,7 @@ func TestSortingActivePods(t *testing.T) {
 	for _, pod := range equalityTests {
 		podsWithDeletionCost := ActivePodsWithRanks{Pods: []*v1.Pod{pod, pod}}
 		if podsWithDeletionCost.Less(0, 1) || podsWithDeletionCost.Less(1, 0) {
-			t.Errorf("expected pod %q not to be less than than itself", pod.Name)
+			t.Errorf("expected pod %q not to be less than itself", pod.Name)
 		}
 	}
 	type podWithDeletionCost *v1.Pod

--- a/pkg/controller/daemonset/daemonset_event_handler.go
+++ b/pkg/controller/daemonset/daemonset_event_handler.go
@@ -119,7 +119,7 @@ func (e *podEventHandler) Update(ctx context.Context, evt event.TypedUpdateEvent
 	if curPod.DeletionTimestamp != nil {
 		// when a pod is deleted gracefully its deletion timestamp is first modified to reflect a grace period,
 		// and after such time has passed, the kubelet actually deletes it from the store. We receive an update
-		// for modification of the deletion timestamp and expect an ds to create more replicas asap, not wait
+		// for modification of the deletion timestamp and expect a ds to create more replicas asap, not wait
 		// until the kubelet actually deletes the pod.
 		e.deletePod(ctx, curPod, q, false)
 		return

--- a/pkg/controller/daemonset/daemonset_predownload_image.go
+++ b/pkg/controller/daemonset/daemonset_predownload_image.go
@@ -75,8 +75,8 @@ func (dsc *ReconcileDaemonSet) createImagePullJobsForInPlaceUpdate(ds *appsv1bet
 		Values:   []string{updateRevision.Name, updateRevision.Labels[history.ControllerRevisionHashLabel]},
 	})
 
-	// As deamonset is the job's owner, we have the convention that all resources owned by deamonset
-	// have to match the selector of deamonset, such as pod, pvc and controllerrevision.
+	// As daemonset is the job's owner, we have the convention that all resources owned by daemonset
+	// have to match the selector of daemonset, such as pod, pvc and controllerrevision.
 	// So we had better put the labels into jobs.
 	labelMap := make(map[string]string)
 	for k, v := range ds.Spec.Template.Labels {

--- a/pkg/controller/statefulset/stateful_set_control.go
+++ b/pkg/controller/statefulset/stateful_set_control.go
@@ -61,7 +61,7 @@ type StatefulSetControlInterface interface {
 	// Implementors should sink any errors that they do not wish to trigger a retry, and they may feel free to
 	// exit exceptionally at any point provided they wish the update to be re-run at a later point in time.
 	UpdateStatefulSet(ctx context.Context, set *appsv1beta1.StatefulSet, pods []*v1.Pod) error
-	// ListRevisions returns a array of the ControllerRevisions that represent the revisions of set. If the returned
+	// ListRevisions returns an array of the ControllerRevisions that represent the revisions of set. If the returned
 	// error is nil, the returns slice of ControllerRevisions is valid.
 	ListRevisions(set *appsv1beta1.StatefulSet) ([]*apps.ControllerRevision, error)
 	// AdoptOrphanRevisions adopts any orphaned ControllerRevisions that match set's Selector. If all adoptions are

--- a/pkg/controller/uniteddeployment/uniteddeployment_controller.go
+++ b/pkg/controller/uniteddeployment/uniteddeployment_controller.go
@@ -284,7 +284,7 @@ func (r *ReconcileUnitedDeployment) Reconcile(_ context.Context, request reconci
 }
 
 // getExistingSubsets fetches all subset workloads in cluster managed by this UnitedDeployment
-// if adaptive scheduling strategy is used, existing subset unscheduable status will be set true here (newly created subsets are default false)
+// if adaptive scheduling strategy is used, existing subset unschedulable status will be set true here (newly created subsets are default false)
 func (r *ReconcileUnitedDeployment) getExistingSubsets(instance *appsv1alpha1.UnitedDeployment, control ControlInterface, expectedRevision string) (existingSubsets map[string]*Subset, err error) {
 	subSets, err := control.GetAllSubsets(instance, expectedRevision)
 	if err != nil {
@@ -329,7 +329,7 @@ func setUpdatedCondition(status *appsv1alpha1.UnitedDeploymentStatus, currentRev
 	}
 }
 
-// calculateSubsetsStatusForDefaultAdaptiveStrategy manages subset unscheduable status and store them in the Subset.Status.UnschedulableStatus field.
+// calculateSubsetsStatusForDefaultAdaptiveStrategy manages subset unschedulable status and store them in the Subset.Status.UnschedulableStatus field.
 func calculateSubsetsStatusForDefaultAdaptiveStrategy(name string, subset *Subset, ud *appsv1alpha1.UnitedDeployment) {
 	now := time.Now()
 	unitedDeploymentKey := getUnitedDeploymentKey(ud)

--- a/pkg/controller/workloadspread/reschedule_test.go
+++ b/pkg/controller/workloadspread/reschedule_test.go
@@ -123,7 +123,7 @@ func TestRescheduleSubset(t *testing.T) {
 			},
 		},
 		{
-			name: "create no Pods, subset-a is scheduable",
+			name: "create no Pods, subset-a is schedulable",
 			getPods: func() []*corev1.Pod {
 				return []*corev1.Pod{}
 			},
@@ -151,7 +151,7 @@ func TestRescheduleSubset(t *testing.T) {
 			},
 		},
 		{
-			name: "create two Pods, two pending, subset-a is unscheduable",
+			name: "create two Pods, two pending, subset-a is unschedulable",
 			getPods: func() []*corev1.Pod {
 				pods := make([]*corev1.Pod, 2)
 				for i := range pods {
@@ -185,7 +185,7 @@ func TestRescheduleSubset(t *testing.T) {
 			},
 		},
 		{
-			name: "subset-a was unscheduable and not reach up 5 minutes",
+			name: "subset-a was unschedulable and not reach up 5 minutes",
 			getPods: func() []*corev1.Pod {
 				pods := make([]*corev1.Pod, 0)
 				return pods
@@ -220,7 +220,7 @@ func TestRescheduleSubset(t *testing.T) {
 			},
 		},
 		{
-			name: "subset-a was recovered from unscheduable to scheduable",
+			name: "subset-a was recovered from unschedulable to schedulable",
 			getPods: func() []*corev1.Pod {
 				pods := make([]*corev1.Pod, 0)
 				return pods

--- a/pkg/features/kruise_features.go
+++ b/pkg/features/kruise_features.go
@@ -98,7 +98,7 @@ const (
 	PreDownloadImageForDaemonSetUpdate featuregate.Feature = "PreDownloadImageForDaemonSetUpdate"
 
 	// CloneSetEventHandlerOptimization enable optimization for cloneset-controller to reduce the
-	// queuing frequency cased by pod update.
+	// queuing frequency caused by pod update.
 	CloneSetEventHandlerOptimization featuregate.Feature = "CloneSetEventHandlerOptimization"
 
 	// PreparingUpdateAsUpdate enable CloneSet/Advanced StatefulSet controller to regard preparing-update Pod
@@ -114,7 +114,7 @@ const (
 	// DeletionProtectionForCRDCascadingGate enable deletionProtection for crd Cascading
 	DeletionProtectionForCRDCascadingGate featuregate.Feature = "DeletionProtectionForCRDCascadingGate"
 
-	// Enables a enhanced livenessProbe solution
+	// Enables an enhanced livenessProbe solution
 	EnhancedLivenessProbeGate featuregate.Feature = "EnhancedLivenessProbe"
 
 	// RecreatePodWhenChangeVCTInCloneSetGate recreate the pod upon changing volume claim templates in a clone set to ensure PVC consistency.

--- a/pkg/util/history/controller_history.go
+++ b/pkg/util/history/controller_history.go
@@ -32,7 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// NewHistory returns an an instance of Interface that uses client to communicate with the API Server and lister to list ControllerRevisions.
+// NewHistory returns an instance of Interface that uses client to communicate with the API Server and lister to list ControllerRevisions.
 func NewHistory(c client.Client) history.Interface {
 	return &realHistory{Client: c}
 }

--- a/pkg/util/selector.go
+++ b/pkg/util/selector.go
@@ -184,7 +184,7 @@ func newRequirement(key string, op selection.Operator, vals []string) (*labels.R
 	return sel, nil
 }
 
-// IsSelectorLooseOverlap indicates whether selectors overlap (indicates that selector1, selector2 have same key, and there is an certain intersection）
+// IsSelectorLooseOverlap indicates whether selectors overlap (indicates that selector1, selector2 have same key, and there is a certain intersection）
 // 1. when selector1、selector2 don't have same key, it is considered non-overlap, e.g. selector1(a=b) and selector2(c=d)
 // 2. when selector1、selector2 have same key, and matchLabels & matchExps are intersection, it is considered overlap.
 // For examples:

--- a/pkg/util/updatesort/scatter_sort_test.go
+++ b/pkg/util/updatesort/scatter_sort_test.go
@@ -203,7 +203,7 @@ func TestSort(t *testing.T) {
 		expectedIndexes []int
 	}{
 		{
-			desc:            "a scattered pod + a ordinary pod",
+			desc:            "a scattered pod + an ordinary pod",
 			podLabels:       []map[string]string{{"labelA": "AAA", "labelB": "BBB"}},
 			scatterStrategy: appsv1beta1.UpdateScatterStrategy{{Key: "labelA", Value: "AAA"}},
 			expectedIndexes: []int{0},

--- a/test/e2e/framework/common/util.go
+++ b/test/e2e/framework/common/util.go
@@ -529,7 +529,7 @@ func dumpAllNodeInfo(c clientset.Interface) {
 	//DumpNodeDebugInfo(c, names, Logf)
 }
 
-// EventsLister defines a event listener
+// EventsLister defines an event listener
 type EventsLister func(opts metav1.ListOptions, ns string) (*v1.EventList, error)
 
 // DumpEventsInNamespace dump events in namespace

--- a/test/e2e/framework/v1alpha1/framework.go
+++ b/test/e2e/framework/v1alpha1/framework.go
@@ -86,7 +86,7 @@ type Framework struct {
 	AfterEachActions []func()
 }
 
-// TestDataSummary defines a interface to test data summary
+// TestDataSummary defines an interface to test data summary
 type TestDataSummary interface {
 	SummaryKind() string
 	PrintHumanReadable() string

--- a/test/e2e/framework/v1beta1/framework.go
+++ b/test/e2e/framework/v1beta1/framework.go
@@ -86,7 +86,7 @@ type Framework struct {
 	AfterEachActions []func()
 }
 
-// TestDataSummary defines a interface to test data summary
+// TestDataSummary defines an interface to test data summary
 type TestDataSummary interface {
 	SummaryKind() string
 	PrintHumanReadable() string

--- a/test/e2e/framework/v1beta1/statefulset_utils.go
+++ b/test/e2e/framework/v1beta1/statefulset_utils.go
@@ -112,7 +112,7 @@ func (s *StatefulSetTester) CheckMount(ss *appsv1beta1.StatefulSet, mountPath st
 	return nil
 }
 
-// ExecInStatefulPods executes cmd in all Pods in ss. If a error occurs it is returned and cmd is not execute in any subsequent Pods.
+// ExecInStatefulPods executes cmd in all Pods in ss. If an error occurs it is returned and cmd is not executed in any subsequent Pods.
 func (s *StatefulSetTester) ExecInStatefulPods(ss *appsv1beta1.StatefulSet, cmd string) error {
 	podList := s.GetPodList(ss)
 	for _, statefulPod := range podList.Items {

--- a/test/e2e/framework/v1beta1/util.go
+++ b/test/e2e/framework/v1beta1/util.go
@@ -531,7 +531,7 @@ func dumpAllNodeInfo(c clientset.Interface) {
 	//DumpNodeDebugInfo(c, names, Logf)
 }
 
-// EventsLister defines a event listener
+// EventsLister defines an event listener
 type EventsLister func(opts metav1.ListOptions, ns string) (*v1.EventList, error)
 
 // DumpEventsInNamespace dump events in namespace

--- a/tools/hack/csi-driver-host-path/csi_driver/destroy-hostpath.sh
+++ b/tools/hack/csi-driver-host-path/csi_driver/destroy-hostpath.sh
@@ -29,6 +29,6 @@ set -o pipefail
 # Using app.kubernetes.io/instance: hostpath.csi.k8s.io and app.kubernetes.io/part-of: csi-driver-host-path labels to identify the installation set
 #
 # kubectl maintains a few standard resources under "all" category which can be deleted by using just "kubectl delete all"
-# and other resources such as roles, clusterrole, serivceaccount etc needs to be deleted explicitly
+# and other resources such as roles, clusterrole, serviceaccount etc needs to be deleted explicitly
 kubectl delete all --all-namespaces -l app.kubernetes.io/instance=hostpath.csi.k8s.io,app.kubernetes.io/part-of=csi-driver-host-path --wait=true
 kubectl delete role,clusterrole,rolebinding,clusterrolebinding,serviceaccount,storageclass,csidriver --all-namespaces -l app.kubernetes.io/instance=hostpath.csi.k8s.io,app.kubernetes.io/part-of=csi-driver-host-path --wait=true


### PR DESCRIPTION

## What this PR does / why we need it
This PR fixes multiple spelling errors and typos found across the Kruise codebase. Clean documentation and comments improve code readability and maintainability.
## Which issue(s) this PR fixes
Fixes #2316 
## Changes Made
### Documentation
- **CHANGELOG.md**: Fixed "Chang log" → "Change log" (6 occurrences), "kruise-manger" → "kruise-manager", "filed" → "field", "unavilable" → "unavailable", "cased" → "caused"
- **docs/proposals/**: Fixed grammar and spelling in workloadspread and enhanced liveness probe proposals
### API Types & Comments
- Fixed "livnessprobe" → "livenessProbe" in `well_know_annotations.go` (v1alpha1 & v1beta1)
- Fixed "an workload" → "a workload" in multiple type definition files
- Fixed "a update" → "an update" in `uniteddeployment_types.go`
### Controllers & Utilities
- Fixed typos in comments across cloneset, daemonset, statefulset, and uniteddeployment controllers
- Fixed typos in test framework files
### Affected Files (30 files)
- CHANGELOG.md
- 6 API type definition files
- 2 proposal documents  
- 12 controller/pkg files
- 5 test framework files
- 2 misc files (Makefile, shell script)
## Special notes for reviewers
- All changes are cosmetic (typo/grammar fixes)
- No functional code changes
- No API changes
## Does this PR introduce a user-facing change?
```release-note
NONE