### PR TITLE
Fixing Sidecar Scatter Strategy

### DIFF
--- a/pkg/util/updatesort/scatter_sort.go
+++ b/pkg/util/updatesort/scatter_sort.go
@@ -185,7 +185,7 @@ func newScatterGroup(matched, unmatched int) scatterGroup {
 		sg.groupNum = unmatched
 	}
 
-	sg.matchedGroupSize = int(math.Round(float64(matched) / float64(sg.groupNum)))
+	sg.matchedGroupSize = matched / sg.groupNum
 	sg.unmatchedGroupSize = int(math.Round(float64(unmatched) / float64(sg.groupNum)))
 	return sg
 }

--- a/pkg/util/updatesort/scatter_sort_test.go
+++ b/pkg/util/updatesort/scatter_sort_test.go
@@ -137,7 +137,7 @@ func TestScatterPodsByRule(t *testing.T) {
 		{
 			desc:            "even scattered pods + even ordinary pods + scattered pods more than ordinary pods",
 			podLabels:       []string{"", "", "labelA=AAA", "labelA=AAA", "labelA=AAA", "labelA=AAA"},
-			expectedIndexes: []int{2, 3, 0, 4, 1, 5},
+			expectedIndexes: []int{2, 0, 3, 1, 4, 5},
 		},
 		{
 			desc:            "odd scattered pods + odd ordinary pods + scattered pods more than ordinary pods",
@@ -147,7 +147,7 @@ func TestScatterPodsByRule(t *testing.T) {
 		{
 			desc:            "even scattered pods + odd ordinary pods + scattered pods more than ordinary pods",
 			podLabels:       []string{"", "", "labelA=AAA", "", "labelA=AAA", "labelA=AAA", "labelA=AAA", "labelA=AAA", "labelA=AAA"},
-			expectedIndexes: []int{2, 4, 0, 5, 6, 1, 7, 3, 8},
+			expectedIndexes: []int{2, 0, 4, 1, 5, 3, 6, 7, 8},
 		},
 		{
 			desc:            "odd scattered pods + even ordinary pods + scattered pods more than ordinary pods",


### PR DESCRIPTION
Ⅰ. Describe what this PR does
This PR fixes a bug in the SidecarSet scatter strategy where pods matching the scatter key were being clumped together during updates, rather than being evenly distributed.
Previously, the matchedGroupSize was calculated using math.Round.This PR updates the logic to use integer division (floor) for the matched group size. This ensures that matched pods are distributed as sparsely as possible, preventing clumping and improving the safety of updates across failure domains.

Ⅱ. Does this pull request fix one issue?
fixes https://github.com/openkruise/kruise/issues/1226

Ⅲ. Describe how to verify it
1.Run logic verification tests: Execute go test -v ./pkg/util/updatesort/. =>The TestScatterPodsByRule has been updated to verify that pods are now strictly interleaved effectively preventing adjacent matched pods in the reported scenarios.
2.Run controller tests: Execute go test -v ./pkg/controller/sidecarset/. =>Ensures no regressions in the overall SidecarSet update logic

Ⅳ. Special notes for reviews
I updated the expected results in pkg/util/updatesort/scatter_sort_test.go (cases 7 and 9).Updated test cases 7 and 9 to expect evenly scattered pods instead of the previous clumped order.