### PR TITLE
test: add comprehensive unit tests for controller packages

### DIFF
--- a/pkg/controller/containerrecreaterequest/crr_event_handler_test.go
+++ b/pkg/controller/containerrecreaterequest/crr_event_handler_test.go
@@ -1,0 +1,473 @@
+/*
+Copyright 2025 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package containerrecreaterequest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
+	appsv1beta1 "github.com/openkruise/kruise/apis/apps/v1beta1"
+	policyv1alpha1 "github.com/openkruise/kruise/apis/policy/v1alpha1"
+)
+
+func TestPodEventHandler_Create(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = appsv1alpha1.AddToScheme(scheme)
+	_ = appsv1beta1.AddToScheme(scheme)
+	_ = policyv1alpha1.AddToScheme(scheme)
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			UID:       "test-pod-uid",
+		},
+	}
+
+	crr := &appsv1alpha1.ContainerRecreateRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-crr",
+			Namespace: "default",
+			Labels: map[string]string{
+				appsv1alpha1.ContainerRecreateRequestPodUIDKey: "test-pod-uid",
+			},
+		},
+		Spec: appsv1alpha1.ContainerRecreateRequestSpec{
+			PodName: "test-pod",
+		},
+	}
+
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(crr).Build()
+	handler := &podEventHandler{Reader: client}
+	queue := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]())
+
+	evt := event.TypedCreateEvent[*v1.Pod]{
+		Object: pod,
+	}
+
+	handler.Create(context.Background(), evt, queue)
+
+	// Verify that the CRR was queued
+	assert.Equal(t, 1, queue.Len())
+	item, _ := queue.Get()
+	req := item
+	assert.Equal(t, "test-crr", req.Name)
+	assert.Equal(t, "default", req.Namespace)
+}
+
+func TestPodEventHandler_Update(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = appsv1alpha1.AddToScheme(scheme)
+	_ = appsv1beta1.AddToScheme(scheme)
+	_ = policyv1alpha1.AddToScheme(scheme)
+
+	tests := []struct {
+		name          string
+		oldPod        *v1.Pod
+		newPod        *v1.Pod
+		shouldEnqueue bool
+	}{
+		{
+			name: "pod deletion timestamp changed",
+			oldPod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+					UID:       "test-pod-uid",
+				},
+			},
+			newPod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-pod",
+					Namespace:         "default",
+					UID:               "test-pod-uid",
+					DeletionTimestamp: &metav1.Time{Time: metav1.Now().Time},
+				},
+			},
+			shouldEnqueue: true,
+		},
+		{
+			name: "container statuses changed",
+			oldPod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+					UID:       "test-pod-uid",
+				},
+				Status: v1.PodStatus{
+					ContainerStatuses: []v1.ContainerStatus{
+						{
+							Name:  "container1",
+							Ready: false,
+						},
+					},
+				},
+			},
+			newPod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+					UID:       "test-pod-uid",
+				},
+				Status: v1.PodStatus{
+					ContainerStatuses: []v1.ContainerStatus{
+						{
+							Name:  "container1",
+							Ready: true,
+						},
+					},
+				},
+			},
+			shouldEnqueue: true,
+		},
+		{
+			name: "no relevant changes",
+			oldPod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+					UID:       "test-pod-uid",
+					Labels: map[string]string{
+						"app": "test",
+					},
+				},
+				Status: v1.PodStatus{
+					ContainerStatuses: []v1.ContainerStatus{
+						{
+							Name:  "container1",
+							Ready: true,
+						},
+					},
+				},
+			},
+			newPod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+					UID:       "test-pod-uid",
+					Labels: map[string]string{
+						"app": "test-updated",
+					},
+				},
+				Status: v1.PodStatus{
+					ContainerStatuses: []v1.ContainerStatus{
+						{
+							Name:  "container1",
+							Ready: true,
+						},
+					},
+				},
+			},
+			shouldEnqueue: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			crr := &appsv1alpha1.ContainerRecreateRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-crr",
+					Namespace: "default",
+					Labels: map[string]string{
+						appsv1alpha1.ContainerRecreateRequestPodUIDKey: "test-pod-uid",
+					},
+				},
+				Spec: appsv1alpha1.ContainerRecreateRequestSpec{
+					PodName: "test-pod",
+				},
+			}
+
+			client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(crr).Build()
+			handler := &podEventHandler{Reader: client}
+			queue := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]())
+
+			evt := event.TypedUpdateEvent[*v1.Pod]{
+				ObjectOld: tt.oldPod,
+				ObjectNew: tt.newPod,
+			}
+
+			handler.Update(context.Background(), evt, queue)
+
+			if tt.shouldEnqueue {
+				assert.Equal(t, 1, queue.Len())
+			} else {
+				assert.Equal(t, 0, queue.Len())
+			}
+		})
+	}
+}
+
+func TestPodEventHandler_Delete(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = appsv1alpha1.AddToScheme(scheme)
+	_ = appsv1beta1.AddToScheme(scheme)
+	_ = policyv1alpha1.AddToScheme(scheme)
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			UID:       "test-pod-uid",
+		},
+	}
+
+	crr := &appsv1alpha1.ContainerRecreateRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-crr",
+			Namespace: "default",
+			Labels: map[string]string{
+				appsv1alpha1.ContainerRecreateRequestPodUIDKey: "test-pod-uid",
+			},
+		},
+		Spec: appsv1alpha1.ContainerRecreateRequestSpec{
+			PodName: "test-pod",
+		},
+	}
+
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(crr).Build()
+	handler := &podEventHandler{Reader: client}
+	queue := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]())
+
+	evt := event.TypedDeleteEvent[*v1.Pod]{
+		Object: pod,
+	}
+
+	handler.Delete(context.Background(), evt, queue)
+
+	assert.Equal(t, 1, queue.Len())
+	item, _ := queue.Get()
+	req := item
+	assert.Equal(t, "test-crr", req.Name)
+	assert.Equal(t, "default", req.Namespace)
+}
+
+func TestPodEventHandler_Handle(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = appsv1alpha1.AddToScheme(scheme)
+	_ = appsv1beta1.AddToScheme(scheme)
+	_ = policyv1alpha1.AddToScheme(scheme)
+
+	tests := []struct {
+		name          string
+		pod           *v1.Pod
+		crrs          []appsv1alpha1.ContainerRecreateRequest
+		expectedQueue int
+	}{
+		{
+			name: "single active CRR",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+					UID:       "test-pod-uid",
+				},
+			},
+			crrs: []appsv1alpha1.ContainerRecreateRequest{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "crr-1",
+						Namespace: "default",
+						Labels: map[string]string{
+							appsv1alpha1.ContainerRecreateRequestPodUIDKey: "test-pod-uid",
+						},
+					},
+					Spec: appsv1alpha1.ContainerRecreateRequestSpec{
+						PodName: "test-pod",
+					},
+				},
+			},
+			expectedQueue: 1,
+		},
+		{
+			name: "multiple active CRRs",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+					UID:       "test-pod-uid",
+				},
+			},
+			crrs: []appsv1alpha1.ContainerRecreateRequest{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "crr-1",
+						Namespace: "default",
+						Labels: map[string]string{
+							appsv1alpha1.ContainerRecreateRequestPodUIDKey: "test-pod-uid",
+						},
+					},
+					Spec: appsv1alpha1.ContainerRecreateRequestSpec{
+						PodName: "test-pod",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "crr-2",
+						Namespace: "default",
+						Labels: map[string]string{
+							appsv1alpha1.ContainerRecreateRequestPodUIDKey: "test-pod-uid",
+						},
+					},
+					Spec: appsv1alpha1.ContainerRecreateRequestSpec{
+						PodName: "test-pod",
+					},
+				},
+			},
+			expectedQueue: 2,
+		},
+		{
+			name: "CRR with deletion timestamp should be ignored",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+					UID:       "test-pod-uid",
+				},
+			},
+			crrs: []appsv1alpha1.ContainerRecreateRequest{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "crr-1",
+						Namespace: "default",
+						Labels: map[string]string{
+							appsv1alpha1.ContainerRecreateRequestPodUIDKey: "test-pod-uid",
+						},
+						Finalizers:        []string{"test-finalizer"},
+						DeletionTimestamp: &metav1.Time{Time: metav1.Now().Time},
+					},
+					Spec: appsv1alpha1.ContainerRecreateRequestSpec{
+						PodName: "test-pod",
+					},
+				},
+			},
+			expectedQueue: 0,
+		},
+		{
+			name: "completed CRR should be ignored",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+					UID:       "test-pod-uid",
+				},
+			},
+			crrs: []appsv1alpha1.ContainerRecreateRequest{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "crr-1",
+						Namespace: "default",
+						Labels: map[string]string{
+							appsv1alpha1.ContainerRecreateRequestPodUIDKey: "test-pod-uid",
+						},
+					},
+					Spec: appsv1alpha1.ContainerRecreateRequestSpec{
+						PodName: "test-pod",
+					},
+					Status: appsv1alpha1.ContainerRecreateRequestStatus{
+						CompletionTime: &metav1.Time{Time: metav1.Now().Time},
+					},
+				},
+			},
+			expectedQueue: 0,
+		},
+		{
+			name: "no matching CRRs",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+					UID:       "test-pod-uid",
+				},
+			},
+			crrs:          []appsv1alpha1.ContainerRecreateRequest{},
+			expectedQueue: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			objects := make([]client.Object, len(tt.crrs))
+			for i := range tt.crrs {
+				objects[i] = &tt.crrs[i]
+			}
+
+			client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+			handler := &podEventHandler{Reader: client}
+			queue := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]())
+
+			handler.handle(tt.pod, queue)
+
+			assert.Equal(t, tt.expectedQueue, queue.Len())
+		})
+	}
+}
+
+func TestPodEventHandler_Generic(t *testing.T) {
+	// Generic events should not enqueue anything
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = appsv1alpha1.AddToScheme(scheme)
+	_ = appsv1beta1.AddToScheme(scheme)
+	_ = policyv1alpha1.AddToScheme(scheme)
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			UID:       "test-pod-uid",
+		},
+	}
+
+	client := fake.NewClientBuilder().WithScheme(scheme).Build()
+	handler := &podEventHandler{Reader: client}
+	queue := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]())
+
+	evt := event.TypedGenericEvent[*v1.Pod]{
+		Object: pod,
+	}
+
+	handler.Generic(context.Background(), evt, queue)
+
+	assert.Equal(t, 0, queue.Len())
+}
+
+func TestGetReadinessMessage(t *testing.T) {
+	crr := &appsv1alpha1.ContainerRecreateRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-crr",
+			Namespace: "default",
+		},
+	}
+
+	msg := getReadinessMessage(crr)
+
+	assert.Equal(t, "ContainerRecreateRequest", msg.UserAgent)
+	assert.Equal(t, "default/test-crr", msg.Key)
+}

--- a/pkg/controller/ephemeraljob/ephemeraljob_utils_test.go
+++ b/pkg/controller/ephemeraljob/ephemeraljob_utils_test.go
@@ -1,0 +1,625 @@
+/*
+Copyright 2025 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ephemeraljob
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
+)
+
+func TestPastActiveDeadline(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name     string
+		job      *appsv1alpha1.EphemeralJob
+		expected bool
+	}{
+		{
+			name: "no active deadline set",
+			job: &appsv1alpha1.EphemeralJob{
+				Spec: appsv1alpha1.EphemeralJobSpec{},
+			},
+			expected: false,
+		},
+		{
+			name: "no start time",
+			job: &appsv1alpha1.EphemeralJob{
+				Spec: appsv1alpha1.EphemeralJobSpec{
+					ActiveDeadlineSeconds: ptr(int64(300)),
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "within deadline",
+			job: &appsv1alpha1.EphemeralJob{
+				Spec: appsv1alpha1.EphemeralJobSpec{
+					ActiveDeadlineSeconds: ptr(int64(600)), // 10 minutes
+				},
+				Status: appsv1alpha1.EphemeralJobStatus{
+					StartTime: &metav1.Time{Time: now.Add(-5 * time.Minute)},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "past deadline",
+			job: &appsv1alpha1.EphemeralJob{
+				Spec: appsv1alpha1.EphemeralJobSpec{
+					ActiveDeadlineSeconds: ptr(int64(300)), // 5 minutes
+				},
+				Status: appsv1alpha1.EphemeralJobStatus{
+					StartTime: &metav1.Time{Time: now.Add(-10 * time.Minute)},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "exactly at deadline",
+			job: &appsv1alpha1.EphemeralJob{
+				Spec: appsv1alpha1.EphemeralJobSpec{
+					ActiveDeadlineSeconds: ptr(int64(300)),
+				},
+				Status: appsv1alpha1.EphemeralJobStatus{
+					StartTime: &metav1.Time{Time: now.Add(-300 * time.Second)},
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := pastActiveDeadline(tt.job)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestPodMatchedEphemeralJob(t *testing.T) {
+	tests := []struct {
+		name        string
+		pod         *v1.Pod
+		ejob        *appsv1alpha1.EphemeralJob
+		expected    bool
+		expectError bool
+	}{
+		{
+			name: "namespace mismatch",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+			},
+			ejob: &appsv1alpha1.EphemeralJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "kube-system",
+				},
+			},
+			expected:    false,
+			expectError: false,
+		},
+		{
+			name: "selector matches",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+					Labels: map[string]string{
+						"app": "test",
+					},
+				},
+			},
+			ejob: &appsv1alpha1.EphemeralJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: appsv1alpha1.EphemeralJobSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "test",
+						},
+					},
+				},
+			},
+			expected:    true,
+			expectError: false,
+		},
+		{
+			name: "selector does not match",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+					Labels: map[string]string{
+						"app": "other",
+					},
+				},
+			},
+			ejob: &appsv1alpha1.EphemeralJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: appsv1alpha1.EphemeralJobSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "test",
+						},
+					},
+				},
+			},
+			expected:    false,
+			expectError: false,
+		},
+		{
+			name: "empty selector",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+			},
+			ejob: &appsv1alpha1.EphemeralJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: appsv1alpha1.EphemeralJobSpec{
+					Selector: &metav1.LabelSelector{},
+				},
+			},
+			expected:    false,
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := podMatchedEphemeralJob(tt.pod, tt.ejob)
+
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestAddConditions(t *testing.T) {
+	tests := []struct {
+		name          string
+		conditions    []appsv1alpha1.EphemeralJobCondition
+		conditionType appsv1alpha1.EphemeralJobConditionType
+		reason        string
+		message       string
+		expectedLen   int
+	}{
+		{
+			name:          "add to empty conditions",
+			conditions:    []appsv1alpha1.EphemeralJobCondition{},
+			conditionType: appsv1alpha1.EJobSucceeded,
+			reason:        "JobCompleted",
+			message:       "All containers succeeded",
+			expectedLen:   1,
+		},
+		{
+			name: "update existing condition",
+			conditions: []appsv1alpha1.EphemeralJobCondition{
+				{
+					Type:    appsv1alpha1.EJobSucceeded,
+					Status:  v1.ConditionFalse,
+					Reason:  "OldReason",
+					Message: "Old message",
+				},
+			},
+			conditionType: appsv1alpha1.EJobSucceeded,
+			reason:        "NewReason",
+			message:       "New message",
+			expectedLen:   1,
+		},
+		{
+			name: "add new condition type",
+			conditions: []appsv1alpha1.EphemeralJobCondition{
+				{
+					Type:    appsv1alpha1.EJobSucceeded,
+					Status:  v1.ConditionTrue,
+					Reason:  "Completed",
+					Message: "Done",
+				},
+			},
+			conditionType: appsv1alpha1.EJobFailed,
+			reason:        "Failed",
+			message:       "Job failed",
+			expectedLen:   2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := addConditions(tt.conditions, tt.conditionType, tt.reason, tt.message)
+
+			assert.Equal(t, tt.expectedLen, len(result))
+
+			// Find the condition we added/updated
+			var found bool
+			for _, cond := range result {
+				if cond.Type == tt.conditionType {
+					found = true
+					assert.Equal(t, v1.ConditionTrue, cond.Status)
+					assert.Equal(t, tt.reason, cond.Reason)
+					assert.Equal(t, tt.message, cond.Message)
+					break
+				}
+			}
+			assert.True(t, found, "condition should be present")
+		})
+	}
+}
+
+func TestNewCondition(t *testing.T) {
+	conditionType := appsv1alpha1.EJobSucceeded
+	reason := "JobCompleted"
+	message := "All tasks finished"
+
+	cond := newCondition(conditionType, reason, message)
+
+	assert.Equal(t, conditionType, cond.Type)
+	assert.Equal(t, v1.ConditionTrue, cond.Status)
+	assert.Equal(t, reason, cond.Reason)
+	assert.Equal(t, message, cond.Message)
+	assert.False(t, cond.LastProbeTime.IsZero())
+	assert.False(t, cond.LastTransitionTime.IsZero())
+}
+
+func TestGetEphemeralContainersMaps(t *testing.T) {
+	tests := []struct {
+		name          string
+		containers    []v1.EphemeralContainer
+		expectedLen   int
+		expectedEmpty bool
+		expectedNames []string
+	}{
+		{
+			name:          "empty containers",
+			containers:    []v1.EphemeralContainer{},
+			expectedLen:   0,
+			expectedEmpty: true,
+		},
+		{
+			name: "single container",
+			containers: []v1.EphemeralContainer{
+				{
+					EphemeralContainerCommon: v1.EphemeralContainerCommon{
+						Name: "debug-1",
+					},
+				},
+			},
+			expectedLen:   1,
+			expectedEmpty: false,
+			expectedNames: []string{"debug-1"},
+		},
+		{
+			name: "multiple containers",
+			containers: []v1.EphemeralContainer{
+				{
+					EphemeralContainerCommon: v1.EphemeralContainerCommon{
+						Name: "debug-1",
+					},
+				},
+				{
+					EphemeralContainerCommon: v1.EphemeralContainerCommon{
+						Name: "debug-2",
+					},
+				},
+			},
+			expectedLen:   2,
+			expectedEmpty: false,
+			expectedNames: []string{"debug-1", "debug-2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, isEmpty := getEphemeralContainersMaps(tt.containers)
+
+			assert.Equal(t, tt.expectedLen, len(result))
+			assert.Equal(t, tt.expectedEmpty, isEmpty)
+
+			for _, name := range tt.expectedNames {
+				_, exists := result[name]
+				assert.True(t, exists, "container %s should exist in map", name)
+			}
+		})
+	}
+}
+
+func TestGetPodEphemeralContainers(t *testing.T) {
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-pod",
+		},
+	}
+
+	ejob := &appsv1alpha1.EphemeralJob{
+		Spec: appsv1alpha1.EphemeralJobSpec{
+			Template: appsv1alpha1.EphemeralContainerTemplateSpec{
+				EphemeralContainers: []v1.EphemeralContainer{
+					{
+						EphemeralContainerCommon: v1.EphemeralContainerCommon{
+							Name: "debug",
+						},
+					},
+					{
+						EphemeralContainerCommon: v1.EphemeralContainerCommon{
+							Name: "trace",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result := getPodEphemeralContainers(pod, ejob)
+
+	assert.Equal(t, 2, len(result))
+	assert.Contains(t, result, "test-pod-debug")
+	assert.Contains(t, result, "test-pod-trace")
+}
+
+func TestIsCreatedByEJob(t *testing.T) {
+	jobUID := "test-job-uid"
+
+	tests := []struct {
+		name      string
+		container v1.EphemeralContainer
+		expected  bool
+	}{
+		{
+			name: "container created by ejob",
+			container: v1.EphemeralContainer{
+				EphemeralContainerCommon: v1.EphemeralContainerCommon{
+					Env: []v1.EnvVar{
+						{
+							Name:  appsv1alpha1.EphemeralContainerEnvKey,
+							Value: jobUID,
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "container not created by ejob",
+			container: v1.EphemeralContainer{
+				EphemeralContainerCommon: v1.EphemeralContainerCommon{
+					Env: []v1.EnvVar{
+						{
+							Name:  "OTHER_ENV",
+							Value: "value",
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "container with different job uid",
+			container: v1.EphemeralContainer{
+				EphemeralContainerCommon: v1.EphemeralContainerCommon{
+					Env: []v1.EnvVar{
+						{
+							Name:  appsv1alpha1.EphemeralContainerEnvKey,
+							Value: "different-uid",
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "container with no env vars",
+			container: v1.EphemeralContainer{
+				EphemeralContainerCommon: v1.EphemeralContainerCommon{},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isCreatedByEJob(jobUID, tt.container)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestParseEphemeralContainerStatus(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   *v1.ContainerStatus
+		expected ephemeralContainerStatusState
+	}{
+		{
+			name: "succeeded container",
+			status: &v1.ContainerStatus{
+				State: v1.ContainerState{
+					Terminated: &v1.ContainerStateTerminated{
+						ExitCode:   0,
+						FinishedAt: metav1.Now(),
+					},
+				},
+			},
+			expected: SucceededStatus,
+		},
+		{
+			name: "failed container with non-zero exit code",
+			status: &v1.ContainerStatus{
+				State: v1.ContainerState{
+					Terminated: &v1.ContainerStateTerminated{
+						ExitCode: 1,
+					},
+				},
+			},
+			expected: FailedStatus,
+		},
+		{
+			name: "running container",
+			status: &v1.ContainerStatus{
+				State: v1.ContainerState{
+					Running: &v1.ContainerStateRunning{
+						StartedAt: metav1.Now(),
+					},
+				},
+			},
+			expected: RunningStatus,
+		},
+		{
+			name: "waiting container",
+			status: &v1.ContainerStatus{
+				State: v1.ContainerState{
+					Waiting: &v1.ContainerStateWaiting{
+						Reason: "ContainerCreating",
+					},
+				},
+			},
+			expected: WaitingStatus,
+		},
+		{
+			name: "container with RunContainerError",
+			status: &v1.ContainerStatus{
+				State: v1.ContainerState{
+					Waiting: &v1.ContainerStateWaiting{
+						Reason: "RunContainerError",
+					},
+				},
+			},
+			expected: FailedStatus,
+		},
+		{
+			name:     "unknown state",
+			status:   &v1.ContainerStatus{},
+			expected: UnknownStatus,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseEphemeralContainerStatus(tt.status)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestHasEphemeralContainerFinalizer(t *testing.T) {
+	tests := []struct {
+		name       string
+		finalizers []string
+		expected   bool
+	}{
+		{
+			name:       "empty finalizers",
+			finalizers: []string{},
+			expected:   false,
+		},
+		{
+			name:       "has ephemeral container finalizer",
+			finalizers: []string{EphemeralContainerFinalizer},
+			expected:   true,
+		},
+		{
+			name:       "has multiple finalizers including target",
+			finalizers: []string{"other.finalizer", EphemeralContainerFinalizer, "another.finalizer"},
+			expected:   true,
+		},
+		{
+			name:       "does not have ephemeral container finalizer",
+			finalizers: []string{"other.finalizer", "another.finalizer"},
+			expected:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := hasEphemeralContainerFinalizer(tt.finalizers)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestDeleteEphemeralContainerFinalizer(t *testing.T) {
+	tests := []struct {
+		name       string
+		finalizers []string
+		finalizer  string
+		expected   []string
+	}{
+		{
+			name:       "empty finalizers",
+			finalizers: []string{},
+			finalizer:  EphemeralContainerFinalizer,
+			expected:   []string{},
+		},
+		{
+			name:       "remove existing finalizer",
+			finalizers: []string{EphemeralContainerFinalizer},
+			finalizer:  EphemeralContainerFinalizer,
+			expected:   []string{},
+		},
+		{
+			name:       "remove from multiple finalizers",
+			finalizers: []string{"other.finalizer", EphemeralContainerFinalizer, "another.finalizer"},
+			finalizer:  EphemeralContainerFinalizer,
+			expected:   []string{"other.finalizer", "another.finalizer"},
+		},
+		{
+			name:       "finalizer not present",
+			finalizers: []string{"other.finalizer", "another.finalizer"},
+			finalizer:  EphemeralContainerFinalizer,
+			expected:   []string{"other.finalizer", "another.finalizer"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := deleteEphemeralContainerFinalizer(tt.finalizers, tt.finalizer)
+			assert.ElementsMatch(t, tt.expected, result)
+		})
+	}
+}
+
+func TestTimeNow(t *testing.T) {
+	before := time.Now()
+	result := timeNow()
+	after := time.Now()
+
+	assert.NotNil(t, result)
+	assert.True(t, !result.Time.Before(before) && !result.Time.After(after))
+}
+
+// Helper function
+func ptr[T any](v T) *T {
+	return &v
+}

--- a/pkg/controller/ephemeraljob/ephemeraljob_utils_test.go
+++ b/pkg/controller/ephemeraljob/ephemeraljob_utils_test.go
@@ -76,7 +76,7 @@ func TestPastActiveDeadline(t *testing.T) {
 			expected: true,
 		},
 		{
-			name: "exactly at deadline",
+			name: "at or past deadline (exactly at deadline)",
 			job: &appsv1alpha1.EphemeralJob{
 				Spec: appsv1alpha1.EphemeralJobSpec{
 					ActiveDeadlineSeconds: ptr(int64(300)),
@@ -174,7 +174,7 @@ func TestPodMatchedEphemeralJob(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "empty selector",
+			name: "empty selector does not match",
 			pod: &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-pod",


### PR DESCRIPTION
## Description
This PR adds comprehensive unit tests for the `containerrecreaterequest` and `ephemeraljob` controller packages, addressing testing gaps in critical workload management features.

## Tests Added

### 1. crr_event_handler_test.go (473 lines - 6 test functions)
- `TestPodEventHandler_Create`: Pod creation event handling and CRR queuing
- `TestPodEventHandler_Update`: Pod update detection and status change handling
- `TestPodEventHandler_Delete`: Pod deletion and cleanup validation
- `TestPodEventHandler_Handle`: Multi-scenario CRR filtering (active, completed, deletion timestamps)
- `TestPodEventHandler_Generic`: Generic event handler for unrecognized event types
- `TestGetReadinessMessage`: Readiness status message extraction and formatting

### 2. ephemeraljob_utils_test.go (625 lines - 11 test functions)
- `TestPastActiveDeadline`: Deadline expiration validation with time calculations
- `TestPodMatchedEphemeralJob`: Pod selector matching logic and label validation
- `TestAddConditions`: Condition updates with timestamp and reason tracking
- `TestNewCondition`: New condition creation and validation
- `TestGetEphemeralContainersMaps`: Ephemeral container mapping and organization
- `TestGetPodEphemeralContainers`: Pod ephemeral container retrieval and filtering
- `TestIsCreatedByEJob`: Owner reference validation for ephemeral job relationships
- `TestParseEphemeralContainerStatus`: Container status parsing and phase detection
- `TestHasEphemeralContainerFinalizer`: Finalizer presence checking
- `TestDeleteEphemeralContainerFinalizer`: Finalizer removal with edge cases (empty, multiple)
- `TestTimeNow`: Time utility function validation

## Issue Fix
Improves test coverage for containerrecreaterequest and ephemeraljob controllers, ensuring robustness of pod recreation and ephemeral container management workflows.
