### PR TITLE
fix: prevent 409 conflicts after refresh

### DIFF
--- a/pkg/controller/cloneset/sync/cloneset_update.go
+++ b/pkg/controller/cloneset/sync/cloneset_update.go
@@ -171,6 +171,9 @@ func (c *realControl) refreshPodState(cs *appsv1beta1.CloneSet, coreControl clon
 			"cloneSet", klog.KObj(cs), "pod", klog.KObj(pod))
 		return false, 0, res.RefreshErr
 	}
+	if res.RefreshUpdated {
+		return true, res.DelayDuration, nil
+	}
 
 	var state appspub.LifecycleStateType
 	switch lifecycle.GetPodLifecycleState(pod) {


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
This PR fixes a race condition in the CloneSet controller that causes 409 Conflict errors during the first in-place image update of a Pod.

### Ⅱ. Does this pull request fix one issue?
Fixes [#2167](https://github.com/openkruise/kruise/issues/2167)
- Added RefreshUpdated boolean field to RefreshResult in pkg/util/inplaceupdate.
- Updated Refresh and finishGracePeriod to correctly report true whenever a write operation occurs.
- Updated cloneset_update.go to yield execution if Refresh modifies the Pod, ensuring the cache syncs before spec updates are attempted.

### Ⅲ. Describe how to verify it
1. Local Verification: Verified locally using a temporary reproduction test case that mocked Refresh to force an update. Confirmed that the controller yields execution immediately instead of proceeding to call Update with stale data.
2. Regression Testing:
Ran go test ./pkg/controller/cloneset/sync/... -> PASSED
Ran go test ./pkg/util/inplaceupdate/... ->PASSED

### Ⅳ. Special notes for reviews
None
