### PR TITLE
Add scale subresource check in controller_finder

### DIFF
--- a/pkg/util/controllerfinder/controller_finder.go
+++ b/pkg/util/controllerfinder/controller_finder.go
@@ -482,7 +482,7 @@ func (r *ControllerFinder) getScaleController(ref ControllerReference, namespace
 		if errors.IsNotFound(err) {
 			gvk := schema.GroupVersionKind{Group: gv.Group, Version: gv.Version, Kind: ref.Kind}
 			if !r.implementsScale(gvk) {
-				// This resource type doesn't support scale (e.g., ConfigMap, DaemonSet)
+				// This resource type doesn't support scale (e.g., ConfigMap)
 				return nil, nil
 			}
 			// Resource supports scale but this instance wasn't found
@@ -565,7 +565,7 @@ func isValidGroupVersionKind(apiVersion, kind string) bool {
 
 // implementsScale checks if a resource type supports the scale subresource.
 // Some resources like Deployment, StatefulSet have "/scale" subresource for HPA.
-// Others like ConfigMap, DaemonSet don't support scaling.
+// Whether a resource supports scale is determined dynamically via the discovery API.
 func (r *ControllerFinder) implementsScale(gvk schema.GroupVersionKind) bool {
 	if r.discoveryClient == nil {
 		return true


### PR DESCRIPTION
**FIXES #2329**

**Changes:**
- Add [implementsScale(gvk)](cci:1://file:///home/kunal/Desktop/kruise/pkg/util/controllerfinder/controller_finder.go:565:0-596:1) function that queries discovery API
- Check if resource supports scale before returning nil on NotFound
**Approach:**
The function queries [ServerResourcesForGroupVersion()](cci:1://file:///home/kunal/go/pkg/mod/k8s.io/client-go@v0.32.10/discovery/fake/discovery.go:42:0-64:1) to get all resources for an API group. Resources that support scale have a `{resource}/scale` entry (e.g., `deployments/scale`). We check if this entry exists for the given Kind.
**Assumption:**
Interpreted the TODO as checking scale subresource support via discovery API. Please correct if a different approach was intended.
**Reference:** Resolves TODO at `pkg/util/controllerfinder/controller_finder.go:483`
**Testing:**
- Existing tests pass