### PR TITLE
Improve error context for controller startup failures

### DIFF
--- a/pkg/controller/cloneset/cloneset_controller.go
+++ b/pkg/controller/cloneset/cloneset_controller.go
@@ -20,6 +20,7 @@ package cloneset
 import (
 	"context"
 	"flag"
+	"fmt"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -133,7 +134,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		Reconciler: r, MaxConcurrentReconciles: concurrentReconciles, CacheSyncTimeout: util.GetControllerCacheSyncTimeout(),
 		RateLimiter: ratelimiter.DefaultControllerRateLimiter[reconcile.Request]()})
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create cloneset controller: %w", err)
 	}
 
 	// Watch for changes to CloneSet
@@ -150,19 +151,19 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 			},
 		}))
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to watch CloneSet resources: %w", err)
 	}
 
 	// Watch for changes to Pod
 	err = c.Watch(source.Kind(mgr.GetCache(), &v1.Pod{}, &podEventHandler{Reader: mgr.GetCache()}))
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to watch Pod resources for CloneSet controller: %w", err)
 	}
 
 	// Watch for changes to PVC, just ensure cache updated
 	err = c.Watch(source.Kind(mgr.GetCache(), &v1.PersistentVolumeClaim{}, &pvcEventHandler{}))
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to watch PersistentVolumeClaim resources for CloneSet controller: %w", err)
 	}
 
 	return nil

--- a/pkg/controller/resourcedistribution/resourcedistribution_controller.go
+++ b/pkg/controller/resourcedistribution/resourcedistribution_controller.go
@@ -84,7 +84,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		Reconciler: r, MaxConcurrentReconciles: concurrentReconciles, CacheSyncTimeout: util.GetControllerCacheSyncTimeout(),
 		RateLimiter: ratelimiter.DefaultControllerRateLimiter[reconcile.Request]()})
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create resourcedistribution controller: %w", err)
 	}
 
 	// Watch for changes to ResourceDistribution
@@ -125,7 +125,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 			},
 		}))
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to watch Secret resources for ResourceDistribution: %w", err)
 	}
 
 	// Watch for changes to ConfigMap
@@ -142,7 +142,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 			},
 		}))
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to watch ConfigMap resources for ResourceDistribution: %w", err)
 	}
 
 	return nil

--- a/pkg/controller/resourcedistribution/resourcedistribution_controller.go
+++ b/pkg/controller/resourcedistribution/resourcedistribution_controller.go
@@ -102,13 +102,13 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 			},
 		}))
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to watch ResourceDistribution resources: %w", err)
 	}
 
 	// Watch for changes to all namespaces
 	err = c.Watch(source.Kind(mgr.GetCache(), &corev1.Namespace{}, &enqueueRequestForNamespace{reader: mgr.GetCache()}))
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to watch Namespace resources for ResourceDistribution: %w", err)
 	}
 
 	// Watch for changes to Secrets

--- a/pkg/webhook/server.go
+++ b/pkg/webhook/server.go
@@ -107,7 +107,7 @@ func SetupWithManager(mgr manager.Manager) error {
 func Initialize(ctx context.Context, cfg *rest.Config, webhookInitializeTime time.Duration) error {
 	c, err := webhookcontroller.New(cfg, HandlerMap)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create webhook controller: %w", err)
 	}
 	go func() {
 		c.Start(ctx)


### PR DESCRIPTION
***Fixes #2340***
Add error wrapping with context to controller initialization errors to improve debugging of startup failures. This helps operators quickly identify which controller failed during initialization without grepping through code.

Changes:
- Add error context to controller.New() failures
- Add error context to Watch() setup failures for all resource types
- Add error context to webhook controller initialization