### PR TITLE
docs/dev: add dev overlay with IfNotPresent imagePullPolicy for local KIND development

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,6 +105,12 @@ make build
 
 # Run the unit tests
 make test
+
+### Local development with KIND
+
+For local development using KIND and locally built images,
+use manifests under `config/dev`, which set imagePullPolicy
+to `IfNotPresent`.
 ```
 
 **There are some guide documents for contributors in [./docs/contributing/](./docs/contributing), such as a debug guide to help you test your own branch in a Kubernetes cluster.**

--- a/config/dev/kustomization.yaml
+++ b/config/dev/kustomization.yaml
@@ -1,0 +1,11 @@
+# Adds namespace to all resources.
+namespace: kruise-system
+
+resources:
+- manager.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: controller
+  newName: openkruise/kruise-manager
+  newTag: test

--- a/config/dev/manager.yaml
+++ b/config/dev/manager.yaml
@@ -1,0 +1,154 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: manager
+  namespace: system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+  labels:
+    control-plane: controller-manager
+spec:
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        control-plane: controller-manager
+    spec:
+      containers:
+      - command:
+        - /manager
+        args:
+        - --enable-leader-election
+        - --logtostderr=true
+        - --v=5
+        - --feature-gates=AllAlpha=true,AllBeta=true,EnableExternalCerts=false,TemplateNoDefaults=false
+        image: controller:latest
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          capabilities:
+            drop:
+              - all
+            add: [ 'NET_BIND_SERVICE' ]
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 65534
+        name: manager
+        env:
+          - name: KUBE_CACHE_MUTATION_DETECTOR
+            value: "true"
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+        readinessProbe:
+          httpGet:
+            path: readyz
+            port: 8000
+        resources:
+          limits:
+            cpu: 2
+            memory: 2Gi
+          requests:
+            cpu: 100m
+            memory: 200Mi
+      terminationGracePeriodSeconds: 10
+      serviceAccountName: kruise-manager
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: webhook-certs
+  namespace: system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: daemon
+  namespace: system
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: daemon
+  namespace: system
+  labels:
+    control-plane: daemon
+spec:
+  selector:
+    matchLabels:
+      control-plane: daemon
+  template:
+    metadata:
+      labels:
+        control-plane: daemon
+    spec:
+      containers:
+      - command:
+        - /kruise-daemon
+        args:
+        - --logtostderr=true
+        - -v=5
+        - --feature-gates=AllAlpha=true,AllBeta=true
+        - --max-workers-for-pull-image=2
+        image: controller:latest
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          capabilities:
+            drop:
+              - all
+            add: [ 'NET_BIND_SERVICE' ]
+          allowPrivilegeEscalation: false
+        name: daemon
+        env:
+        - name: KUBE_CACHE_MUTATION_DETECTOR
+          value: "true"
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 10221
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+          requests:
+            cpu: "0"
+            memory: "0"
+        volumeMounts:
+        - mountPath: /hostvarrun
+          name: runtime-socket
+          readOnly: true
+      tolerations:
+      - operator: Exists
+      hostNetwork: true
+      terminationGracePeriodSeconds: 10
+      serviceAccountName: kruise-daemon
+      volumes:
+      - hostPath:
+          path: /var/run
+          type: ""
+        name: runtime-socket


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines.
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

This PR improves the local development workflow for contributors using KIND by adding a dedicated dev overlay (`config/dev`) that sets `imagePullPolicy: IfNotPresent` for Kruise manager and daemon images.

Currently, the default manifests use `imagePullPolicy: Always`. When developers build images locally (e.g. `openkruise/kruise-manager:test`) and load them into a KIND cluster using `kind load docker-image`, Kubernetes still tries to pull images from the remote registry, which leads to `ImagePullBackOff` errors.

To avoid changing production behavior, this PR does NOT modify `config/manager`. Instead, it adds a separate `config/dev` manifest set intended only for local development. This keeps production/CI behavior unchanged while making local contributor setup smoother.

Changes included:
- Added `config/dev` overlay based on `config/manager`
- Updated imagePullPolicy from `Always` → `IfNotPresent` in dev manifests only
- Added documentation for local KIND-based development workflow

This is focused purely on developer experience and does not change runtime logic.


### Ⅱ. Does this pull request fix one issue?

fixes #2325

### Ⅲ. Describe how to verify it

Verify locally with KIND:

```bash
make docker-build
kind create cluster --name kind
kind load docker-image openkruise/kruise-manager:test --name kind
kubectl apply -f config/dev
kubectl get pods -n kruise-system

Expected result:
* Pods start successfully
* No ImagePullBackOff errors
* Manager and daemon pods reach Running state
```
### Ⅳ. Special notes for reviews

* This PR intentionally does NOT modify `config/manager` to avoid impacting production or CI behavior.
* The change is isolated to a new dev-only manifest set.
* The goal is to improve contributor onboarding and local testing with KIND.
* If maintainers prefer a kustomize patch overlay instead of a copied dev config, I can refactor this PR accordingly.
