### PR TITLE
fix(podprobemarker): avoid removing unrelated probes in finalizer

### DIFF
--- a/pkg/controller/podprobemarker/pod_probe_marker_controller.go
+++ b/pkg/controller/podprobemarker/pod_probe_marker_controller.go
@@ -488,6 +488,7 @@ func (r *ReconcilePodProbeMarker) removePodProbeFromNodePodProbe(ppmNamespace, p
 		return err
 	}
 
+	prefix := fmt.Sprintf("%s#", ppmName)
 	newSpec := appsv1alpha1.NodePodProbeSpec{}
 	for i := range npp.Spec.PodProbes {
 		podProbe := npp.Spec.PodProbes[i]
@@ -496,10 +497,10 @@ func (r *ReconcilePodProbeMarker) removePodProbeFromNodePodProbe(ppmNamespace, p
 			continue
 		}
 		newPodProbe := appsv1alpha1.PodProbe{Name: podProbe.Name, Namespace: podProbe.Namespace, UID: podProbe.UID, IP: podProbe.IP}
-		for i := range podProbe.Probes {
-			probe := podProbe.Probes[i]
+		for j := range podProbe.Probes {
+			probe := podProbe.Probes[j]
 			// probe.Name -> podProbeMarker.Name#probe.Name
-			if !strings.Contains(probe.Name, fmt.Sprintf("%s#", ppmName)) {
+			if !strings.HasPrefix(probe.Name, prefix) {
 				newPodProbe.Probes = append(newPodProbe.Probes, probe)
 			}
 		}


### PR DESCRIPTION
The PodProbeMarker finalizer cleanup previously used substring matching on probe name, which could remove unrelated probes when PodProbeMarker names overlap and/or exist in different namespaces.

Restrict cleanup to podProbes in the same namespace as the PodProbeMarker and match probes by prefix (ppmName + "#") to ensure only probes owned by the deleted PodProbeMarker are removed.

Fixes #2367

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
本 PR 修复 PodProbeMarker 删除流程（finalizer 清理）中对 NodePodProbe.spec 的误删除问题。
此前清理逻辑基于 probe.Name 的子串匹配（substring match）来判断 probe 是否属于某个 PPM，当存在 同名 PPM（跨 namespace） 或 PPM 名称包含关系（如 way/gateway）时，可能误删不属于当前 PPM 的 probe，导致 NodePodProbe.spec 被意外清空，进而影响探针执行与状态回写。

修复方式：

- 清理时先按 PPM 所在 namespace 限定范围（仅处理同 namespace 的 podProbes 条目）
- 再将匹配规则改为 前缀精确匹配：HasPrefix(probe.Name, ppmName+"#")，确保只删除当前 PPM 写入的 probe。

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #2367
### Ⅲ. Describe how to verify it
建议按以下步骤验证（可本地 Kind/测试集群复现）：

1. 在 devplus 和 test-devplus 两个 namespace 下分别创建同名 PodProbeMarker（例如都叫 gateway），并确保两边都能匹配到各自 namespace 的 Pod。
2. 等待控制器将探针配置写入对应节点的 NodePodProbe.spec，确认 NodePodProbe.spec.podProbes 中同时存在两个 namespace 的条目。
3. 删除 test-devplus/gateway（或删除 test-devplus namespace 触发 finalizer）。
4. 观察：
    - 删除后 NodePodProbe.spec 仅移除 test-devplus 的 gateway#* probes，devplus 的 probes 不受影响
    - NodePodProbe.spec 不会被错误清空
    - devplus 的探针功能仍能正常工作（daemon 执行 probe，NPP status/Pod condition 回写正常）

（可选）同 namespace 下验证名称包含关系场景：创建 PodProbeMarker gateway 与 way，删除 way 时不应影响 gateway#*。

### Ⅳ. Special notes for reviews

- 该改动仅影响 PPM finalizer 的清理匹配逻辑，属于 更严格的归属判断：namespace 限定 + ppmName+"#" 前缀匹配。
- 兼容性方面：probe.Name 本身即采用 ppmName#probeName 的命名约定，因此使用前缀匹配是对现有协议的加强，不改变正常情况下的行为。
