### PR TITLE
Remove deprecated rand.Seed() calls

### DIFF
--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -18,11 +18,9 @@ package main
 
 import (
 	"flag"
-	"math/rand"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
-	"time"
 
 	"github.com/spf13/pflag"
 	"k8s.io/klog/v2"
@@ -62,7 +60,6 @@ func main() {
 	klog.InitFlags(nil)
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.Parse()
-	rand.Seed(time.Now().UnixNano())
 	features.SetDefaultFeatureGates()
 	ctrl.SetLogger(klogr.New())
 

--- a/main.go
+++ b/main.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"flag"
-	"math/rand"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
@@ -139,7 +138,6 @@ func main() {
 	klog.InitFlags(nil)
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.Parse()
-	rand.Seed(time.Now().UnixNano())
 	ctrl.SetLogger(klogr.New())
 	if err := logsapi.ValidateAndApply(logOptions, nil); err != nil {
 		setupLog.Error(err, "logsapi ValidateAndApply failed")

--- a/pkg/controller/cloneset/cloneset_controller_test.go
+++ b/pkg/controller/cloneset/cloneset_controller_test.go
@@ -1325,7 +1325,6 @@ func newMockCloneSetReconciler() *ReconcileCloneSet {
 
 func randomString(n int) string {
 	const letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-	rand.Seed(time.Now().UnixNano()) // Go 1.20 之前需要这行；Go 1.20+ 可省略（但保留也无妨）
 	b := make([]byte, n)
 	for i := range b {
 		b[i] = letters[rand.Intn(len(letters))]

--- a/pkg/controller/uniteddeployment/subset_control_test.go
+++ b/pkg/controller/uniteddeployment/subset_control_test.go
@@ -5,7 +5,6 @@ import (
 	"math/rand"
 	"reflect"
 	"testing"
-	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -20,10 +19,6 @@ import (
 	appsv1beta1 "github.com/openkruise/kruise/apis/apps/v1beta1"
 	"github.com/openkruise/kruise/pkg/controller/uniteddeployment/adapter"
 )
-
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}
 
 func generateRandomId() string {
 	b := make([]byte, 32)


### PR DESCRIPTION
fixes #2374 
`rand.Seed()` is deprecated since Go 1.20 — the runtime now auto-seeds at startup.
Found 4 occurrences using `rand.Seed(time.Now().UnixNano())`:
- `main.go:142`
- `cmd/daemon/main.go:65`
- `pkg/controller/cloneset/cloneset_controller_test.go:1328`
- `pkg/controller/uniteddeployment/subset_control_test.go:25`
Since kruise uses Go 1.23, these are redundant and can be removed.
Ref: https://go.dev/doc/go1.20#math/rand