### PR TITLE
fix(cloneset): skip surge pods when in-place update is possible

### DIFF
--- a/pkg/controller/cloneset/cloneset_controller.go
+++ b/pkg/controller/cloneset/cloneset_controller.go
@@ -423,7 +423,7 @@ func (r *ReconcileCloneSet) syncCloneSet(
 	var podsScaleErr error
 	var podsUpdateErr error
 
-	scaling, podsScaleErr = r.syncControl.Scale(currentSet, updateSet, currentRevision.Name, updateRevision.Name, filteredPods, filteredPVCs)
+	scaling, podsScaleErr = r.syncControl.Scale(currentSet, updateSet, currentRevision, updateRevision, filteredPods, filteredPVCs)
 	if podsScaleErr != nil {
 		cond := appsv1beta1.CloneSetCondition{
 			Type:               appsv1beta1.CloneSetConditionFailedScale,

--- a/pkg/controller/cloneset/sync/api.go
+++ b/pkg/controller/cloneset/sync/api.go
@@ -33,7 +33,7 @@ import (
 type Interface interface {
 	Scale(
 		currentCS, updateCS *appsv1beta1.CloneSet,
-		currentRevision, updateRevision string,
+		currentRevision, updateRevision *apps.ControllerRevision,
 		pods []*v1.Pod, pvcs []*v1.PersistentVolumeClaim,
 	) (bool, error)
 

--- a/pkg/controller/cloneset/sync/cloneset_scale.go
+++ b/pkg/controller/cloneset/sync/cloneset_scale.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -48,7 +49,7 @@ const (
 
 func (r *realControl) Scale(
 	currentCS, updateCS *appsv1beta1.CloneSet,
-	currentRevision, updateRevision string,
+	currentRevision, updateRevision *apps.ControllerRevision,
 	pods []*v1.Pod, pvcs []*v1.PersistentVolumeClaim,
 ) (bool, error) {
 	if updateCS.Spec.Replicas == nil {
@@ -68,8 +69,15 @@ func (r *realControl) Scale(
 	}
 
 	// 2. calculate scale numbers
-	diffRes := calculateDiffsWithExpectation(updateCS, pods, currentRevision, updateRevision, revision.IsPodUpdate)
-	updatedPods, notUpdatedPods := clonesetutils.GroupUpdateAndNotUpdatePods(pods, updateRevision)
+	canInPlaceUpdate := false
+	if updateCS.Spec.UpdateStrategy.RollingUpdate != nil &&
+		(updateCS.Spec.UpdateStrategy.RollingUpdate.PodUpdatePolicy == appsv1beta1.InPlaceIfPossibleCloneSetPodUpdateStrategyType ||
+			updateCS.Spec.UpdateStrategy.RollingUpdate.PodUpdatePolicy == appsv1beta1.InPlaceOnlyCloneSetPodUpdateStrategyType) {
+		canInPlaceUpdate = r.inplaceControl.CanUpdateInPlace(currentRevision, updateRevision, coreControl.GetUpdateOptions())
+	}
+
+	diffRes := calculateDiffsWithExpectation(updateCS, pods, currentRevision.Name, updateRevision.Name, canInPlaceUpdate, revision.IsPodUpdate)
+	updatedPods, notUpdatedPods := clonesetutils.GroupUpdateAndNotUpdatePods(pods, updateRevision.Name)
 
 	if diffRes.scaleUpNum > diffRes.scaleUpLimit {
 		r.recorder.Event(updateCS, v1.EventTypeWarning, "ScaleUpLimited", fmt.Sprintf("scaleUp is limited because of scaleStrategy.maxUnavailable, limit: %d", diffRes.scaleUpLimit))
@@ -94,7 +102,7 @@ func (r *realControl) Scale(
 		}
 
 		return r.createPods(expectedCreations, expectedCurrentCreations,
-			currentCS, updateCS, currentRevision, updateRevision, availableIDs.List(), existingPVCNames)
+			currentCS, updateCS, currentRevision.Name, updateRevision.Name, availableIDs.List(), existingPVCNames)
 	}
 
 	// 4. try to delete pods already in pre-delete
@@ -107,7 +115,7 @@ func (r *realControl) Scale(
 
 	// 5. specified delete
 	if podsToDelete := util.DiffPods(podsSpecifiedToDelete, podsInPreDelete); len(podsToDelete) > 0 {
-		newPodsToDelete, oldPodsToDelete := clonesetutils.GroupUpdateAndNotUpdatePods(podsToDelete, updateRevision)
+		newPodsToDelete, oldPodsToDelete := clonesetutils.GroupUpdateAndNotUpdatePods(podsToDelete, updateRevision.Name)
 		klog.V(3).InfoS("CloneSet tried to delete pods specified", "cloneSet", klog.KObj(updateCS), "deleteReadyLimit", diffRes.deleteReadyLimit,
 			"newPods", util.GetPodNames(newPodsToDelete).List(), "oldPods", util.GetPodNames(oldPodsToDelete).List())
 

--- a/pkg/controller/cloneset/sync/cloneset_update_test.go
+++ b/pkg/controller/cloneset/sync/cloneset_update_test.go
@@ -1418,7 +1418,7 @@ func TestCalculateUpdateCount(t *testing.T) {
 
 		replicas := int32(tc.totalReplicas)
 		cs := &appsv1beta1.CloneSet{Spec: appsv1beta1.CloneSetSpec{Replicas: &replicas, UpdateStrategy: tc.strategy}}
-		diffRes := calculateDiffsWithExpectation(cs, tc.pods, currentRevision, updateRevision, nil)
+		diffRes := calculateDiffsWithExpectation(cs, tc.pods, currentRevision, updateRevision, false, nil)
 
 		var waitUpdateIndexes []int
 		var targetRevision string


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

When a CloneSet has `InPlaceIfPossible` (or `InPlaceOnly`) update strategy with `maxSurge > 0`, changing only in-place updatable fields (e.g. container images) caused `maxSurge` number of new pods to be created and then deleted unnecessarily. The root cause is that `calculateDiffsWithExpectation()` computes surge **before** checking whether in-place update is possible for the given revision change.

Surge exists to over-provision while old pods are being replaced by new ones. In-place update patches existing pods in place — no replacement happens, so surge is unnecessary.

**Fix:** Add a `canInPlaceUpdate bool` parameter to `calculateDiffsWithExpectation` and gate the surge calculation on `!canInPlaceUpdate`. Callers (`Scale` and `Update`) pre-compute this flag via `inplaceControl.CanUpdateInPlace()` at their call sites, keeping the diff calculation a pure function.

**Changes:**
- `calculateDiffsWithExpectation`: new `canInPlaceUpdate bool` param; surge block gated on `!canInPlaceUpdate`
- `Scale` interface/impl: accept `*apps.ControllerRevision` (instead of `string`) to support the `CanUpdateInPlace` call
- `Scale` and `Update` call sites: compute `canInPlaceUpdate` before calling `calculateDiffsWithExpectation`
- `cloneset_controller.go`: pass `*apps.ControllerRevision` to `Scale`

**Relation to #2370:** This PR addresses the same bug with a different design. PR #2370 passes `inplaceupdate.Interface` + `*apps.ControllerRevision` into `calculateDiffsWithExpectation`, coupling a pure calculation function with an interface dependency. This PR instead resolves the boolean at callers and passes a simple `bool`, keeping the function pure and tests trivial to write.

### Ⅱ. Does this pull request fix one issue?

fixes #2369

### Ⅲ. Describe how to verify it

**Unit tests (no cluster required):**

```bash
go test ./pkg/controller/cloneset/sync/... -count=1 -race -v
```

Three new test cases in `TestCalculateDiffsWithExpectation`:
- `in-place update with maxSurge should not create surge pods` — `canInPlaceUpdate=true`, maxSurge=3: expects `useSurge=0`, `scaleUpNum=0`
- `recreate update with maxSurge should still create surge pods` — `canInPlaceUpdate=false`, maxSurge=3: expects `useSurge=3`, `scaleUpNum=3`
- `in-place update without maxSurge should not change behavior` — `canInPlaceUpdate=true`, maxSurge=0: same result as before

All existing tests pass unchanged (the `canInPlaceUpdate=false` default preserves all prior behavior).

**E2E test (requires cluster with Kruise):**

```bash
ginkgo -v --focus="in-place update with maxSurge should not create surge pods" ./test/e2e/apps/v1beta1/
```

The E2E test creates a 3-replica CloneSet with `InPlaceIfPossible` + `maxSurge=2`, performs an image-only update, and asserts:
1. Pod count never exceeds 3 during the update (`Consistently`)
2. All pods are updated and ready
3. Pod UIDs are unchanged (confirming in-place update, not recreate)

**Manual reproduction:**

1. Create a CloneSet with `InPlaceIfPossible`, `maxSurge: 2`, `replicas: 3`
2. Update only the container image
3. Observe that pod count stays at 3 (no surge pods created)
4. Observe that pod UIDs are preserved (in-place update occurred)

### Ⅳ. Special notes for reviews

- `calculateDiffsWithExpectation` is described in the codebase as "the most important algorithm in cloneset-controller." This change adds one boolean parameter and one `if` guard — minimal surface area for the fix.
- All existing test cases pass without modification because `canInPlaceUpdate` defaults to `false`, which preserves the original surge behavior.
- The `Scale` interface change from `string` to `*apps.ControllerRevision` is necessary so the `Scale` implementation can call `CanUpdateInPlace()`. This is the only breaking interface change.
- The `canInPlaceUpdate` computation is duplicated at two call sites (Scale and Update). This is intentional — extracting a helper for 5 lines would add indirection without meaningful value.
