### PR TITLE
fix logical error in the imagepulljob sync secrets

### DIFF
--- a/pkg/controller/imagepulljob/imagepulljob_controller.go
+++ b/pkg/controller/imagepulljob/imagepulljob_controller.go
@@ -30,6 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
@@ -447,21 +448,29 @@ func (r *ReconcileImagePullJob) classifyPullSecretsForJob(job *appsv1beta1.Image
 		return nil, nil, err
 	}
 
+	// In versions prior to 1.9, multiple syncedSecrets could correspond to a single source secret.
+	// To ensure the same synced secret is selected across multiple reconcile iterations, sort syncedSecrets by name.
+	syncedSecrets := make([]v1.Secret, len(secretList.Items))
+	copy(syncedSecrets, secretList.Items)
+	sort.Slice(syncedSecrets, func(i, j int) bool {
+		return syncedSecrets[i].Name < syncedSecrets[j].Name
+	})
+
 	// jobKey is imagePullJob namespace/name
 	jobKey := jobAsReferenceObject(job)
 	// pull secret name -> v1.secret
-	pullSecrets := map[appsv1beta1.ReferenceObject]*v1.Secret{}
+	desiredSecrets := map[appsv1beta1.ReferenceObject]*v1.Secret{}
 
 	// Only sync pullSecrets when the job is in running state
 	if job.DeletionTimestamp.IsZero() && job.Status.CompletionTime == nil {
 		for _, name := range job.Spec.PullSecrets {
-			pullSecrets[appsv1beta1.ReferenceObject{Namespace: job.Namespace, Name: name}] = nil
+			desiredSecrets[appsv1beta1.ReferenceObject{Namespace: job.Namespace, Name: name}] = nil
 		}
 	}
 	// imagePullJob previously configured pullSecret, but later removed it during updates, so it needs to be released
 	var releasedSecrets []*v1.Secret
-	for i := range secretList.Items {
-		secret := &secretList.Items[i]
+	for i := range syncedSecrets {
+		secret := &syncedSecrets[i]
 		if secret.DeletionTimestamp != nil {
 			continue
 		}
@@ -476,19 +485,29 @@ func (r *ReconcileImagePullJob) classifyPullSecretsForJob(job *appsv1beta1.Image
 		}
 
 		sourceSecretRef := getSourceSecret(secret)
+		// There are three scenarios for kruise-daemon-config secrets:
+		// 1. No kruise-daemon-config secrets match pullSecrets, thus requiring creation of a new kruise-daemon-config secret
+		// 2. A kruise-daemon-config secret exists that matches pullSecrets and has matching referJobs. This has the highest priority and should be used preferentially
+		// 3. A kruise-daemon-config secret exists that matches pullSecrets but has non-matching referJobs. No new kruise-daemon-config secret needs to be created,
+		//    but the secret annotations referJobs need to be updated
+
 		// If the source secret matches the pullSecrets, it indicates that the imagePullJob can also use the secret to pull images
-		// Therefore, there is no need to duplicate the creation of a new kruise-daemon-config secret
-		if _, ok := pullSecrets[sourceSecretRef]; ok {
-			pullSecrets[sourceSecretRef] = secret
+		// Therefore, there is no need to duplicate the creation of a new kruise-daemon-config secret.
+		if obj, ok := desiredSecrets[sourceSecretRef]; ok {
+			if obj == nil {
+				desiredSecrets[sourceSecretRef] = secret
+			} else if referJobs.Has(jobKey) {
+				desiredSecrets[sourceSecretRef] = secret
+			}
 			continue
 		}
-		// Code execution reaches here indicates: secret does not match pullSecrets, but secret referenceJobs includes this imagePullJob
+		// Code execution reaches here indicates: secret does not match desiredSecrets, but secret referenceJobs includes this imagePullJob
 		// This usually occurs when updating imagePullJob to remove the pullSecret configuration, so it needs to be released
 		if referJobs.Has(jobKey) {
 			releasedSecrets = append(releasedSecrets, secret)
 		}
 	}
-	return pullSecrets, releasedSecrets, nil
+	return desiredSecrets, releasedSecrets, nil
 }
 
 func (r *ReconcileImagePullJob) releaseImagePullJobSecrets(secrets []*v1.Secret, job *appsv1beta1.ImagePullJob) error {
@@ -618,7 +637,8 @@ func (r *ReconcileImagePullJob) calculateStatus(job *appsv1beta1.ImagePullJob, n
 		return nil, nil, fmt.Errorf("invalid image %s: %v", job.Spec.Image, err)
 	}
 
-	var notSynced, pulling, succeeded, failed []string
+	var pulling, succeeded, failed []string
+	notSynced := sets.NewString()
 	for _, nodeImage := range nodeImages {
 		var tagVersion int64 = -1
 		var secretSynced bool = true
@@ -629,10 +649,8 @@ func (r *ReconcileImagePullJob) calculateStatus(job *appsv1beta1.ImagePullJob, n
 					break
 				}
 			}
-
 			if !secretSynced {
-				notSynced = append(notSynced, nodeImage.Name)
-				continue
+				notSynced.Insert(nodeImage.Name)
 			}
 
 			for _, tagSpec := range imageSpec.Tags {
@@ -654,7 +672,7 @@ func (r *ReconcileImagePullJob) calculateStatus(job *appsv1beta1.ImagePullJob, n
 		}
 
 		if tagVersion < 0 {
-			notSynced = append(notSynced, nodeImage.Name)
+			notSynced.Insert(nodeImage.Name)
 			continue
 		}
 
@@ -688,7 +706,7 @@ func (r *ReconcileImagePullJob) calculateStatus(job *appsv1beta1.ImagePullJob, n
 			newStatus.CompletionTime = &now
 			newStatus.Succeeded = int32(len(succeeded))
 			failed = append(failed, pulling...)
-			failed = append(failed, notSynced...)
+			failed = append(failed, notSynced.List()...)
 			newStatus.Failed = int32(len(failed))
 			newStatus.FailedNodes = failed
 			newStatus.Message = "job exceeds activeDeadlineSeconds"
@@ -706,7 +724,7 @@ func (r *ReconcileImagePullJob) calculateStatus(job *appsv1beta1.ImagePullJob, n
 
 	newStatus.Message = formatStatusMessage(&newStatus)
 	sort.Strings(newStatus.FailedNodes)
-	return &newStatus, notSynced, nil
+	return &newStatus, notSynced.List(), nil
 }
 
 func (r *ReconcileImagePullJob) namespaceIsActive(name string) error {

--- a/pkg/controller/imagepulljob/imagepulljob_controller_test.go
+++ b/pkg/controller/imagepulljob/imagepulljob_controller_test.go
@@ -2,6 +2,7 @@ package imagepulljob
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -10,10 +11,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	k8stesting "k8s.io/utils/clock/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	appsv1beta1 "github.com/openkruise/kruise/apis/apps/v1beta1"
 	"github.com/openkruise/kruise/pkg/util"
@@ -437,7 +440,7 @@ func TestReconcileImagePullJob_calculateStatus(t *testing.T) {
 			expectedStatus: &appsv1beta1.ImagePullJobStatus{
 				Desired:     1,
 				Succeeded:   0,
-				Active:      0,
+				Active:      1, // Even when secret not synced, if tag is synced, node is counted as pulling/active
 				Failed:      0,
 				FailedNodes: []string{},
 				Message:     "job is running, progress 0.0%",
@@ -724,12 +727,12 @@ func TestGetTargetSecretMap(t *testing.T) {
 
 	// Define test cases
 	tests := []struct {
-		name              string
-		job               *appsv1beta1.ImagePullJob
-		existingSecrets   []v1.Secret
-		expectedTargetLen int
-		expectedDeleteLen int
-		expectError       bool
+		name                  string
+		job                   *appsv1beta1.ImagePullJob
+		existingSecrets       []v1.Secret
+		expectedTargetSecrets []string
+		expectedDeleteSecrets []string
+		expectError           bool
 	}{
 		{
 			name: "Normal case - successfully categorize secrets",
@@ -769,9 +772,9 @@ func TestGetTargetSecretMap(t *testing.T) {
 					},
 				},
 			},
-			expectedTargetLen: 1,
-			expectedDeleteLen: 1,
-			expectError:       false,
+			expectedTargetSecrets: []string{"target-secret-1"},
+			expectedDeleteSecrets: []string{"delete-secret-1"},
+			expectError:           false,
 		},
 		{
 			name: "Empty secrets list",
@@ -782,10 +785,10 @@ func TestGetTargetSecretMap(t *testing.T) {
 					UID:       types.UID("job-uid-1"),
 				},
 			},
-			existingSecrets:   []v1.Secret{},
-			expectedTargetLen: 0,
-			expectedDeleteLen: 0,
-			expectError:       false,
+			existingSecrets:       []v1.Secret{},
+			expectedTargetSecrets: []string{},
+			expectedDeleteSecrets: []string{},
+			expectError:           false,
 		},
 		{
 			name: "All secrets being deleted should be ignored",
@@ -810,9 +813,9 @@ func TestGetTargetSecretMap(t *testing.T) {
 					},
 				},
 			},
-			expectedTargetLen: 0,
-			expectedDeleteLen: 0,
-			expectError:       false,
+			expectedTargetSecrets: []string{},
+			expectedDeleteSecrets: []string{},
+			expectError:           false,
 		},
 		{
 			name: "Secrets not associated with job should be ignored",
@@ -835,9 +838,9 @@ func TestGetTargetSecretMap(t *testing.T) {
 					},
 				},
 			},
-			expectedTargetLen: 0,
-			expectedDeleteLen: 0,
-			expectError:       false,
+			expectedTargetSecrets: []string{},
+			expectedDeleteSecrets: []string{},
+			expectError:           false,
 		},
 		{
 			name: "Secrets with invalid annotation should be ignored",
@@ -860,9 +863,139 @@ func TestGetTargetSecretMap(t *testing.T) {
 					},
 				},
 			},
-			expectedTargetLen: 0,
-			expectedDeleteLen: 0,
-			expectError:       false,
+			expectedTargetSecrets: []string{},
+			expectedDeleteSecrets: []string{},
+			expectError:           false,
+		},
+		{
+			name: "multiple matched source secrets",
+			job: &appsv1beta1.ImagePullJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-job",
+					Namespace: "default",
+					UID:       types.UID("job-uid-1"),
+				},
+				Spec: appsv1beta1.ImagePullJobSpec{
+					ImagePullJobTemplate: appsv1beta1.ImagePullJobTemplate{
+						PullSecrets: []string{"source-secret-1"},
+					},
+				},
+			},
+			existingSecrets: []v1.Secret{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "target-secret-3",
+						Namespace: "kruise-daemon-config",
+						Annotations: map[string]string{
+							SecretAnnotationSourceSecretKey: "default/source-secret-1",
+							SecretAnnotationReferenceJobs:   "default/other-job",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "target-secret-2",
+						Namespace: "kruise-daemon-config",
+						Annotations: map[string]string{
+							SecretAnnotationSourceSecretKey: "default/source-secret-1",
+							SecretAnnotationReferenceJobs:   "default/other-job",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "target-secret-1",
+						Namespace: "kruise-daemon-config",
+						Annotations: map[string]string{
+							SecretAnnotationSourceSecretKey: "default/source-secret-1",
+							SecretAnnotationReferenceJobs:   "default/other-job",
+						},
+					},
+				},
+			},
+			expectedTargetSecrets: []string{"target-secret-1"},
+			expectedDeleteSecrets: []string{},
+			expectError:           false,
+		},
+		{
+			name: "multiple matched source secrets, and multiple matched refer secrets",
+			job: &appsv1beta1.ImagePullJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-job",
+					Namespace: "default",
+					UID:       types.UID("job-uid-1"),
+				},
+				Spec: appsv1beta1.ImagePullJobSpec{
+					ImagePullJobTemplate: appsv1beta1.ImagePullJobTemplate{
+						PullSecrets: []string{"source-secret-1"},
+					},
+				},
+			},
+			existingSecrets: []v1.Secret{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "target-secret-3",
+						Namespace: "kruise-daemon-config",
+						Annotations: map[string]string{
+							SecretAnnotationSourceSecretKey: "default/source-secret-1",
+							SecretAnnotationReferenceJobs:   "default/other-job",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "target-secret-2",
+						Namespace: "kruise-daemon-config",
+						Annotations: map[string]string{
+							SecretAnnotationSourceSecretKey: "default/source-secret-1",
+							SecretAnnotationReferenceJobs:   "default/other-job",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "target-secret-1",
+						Namespace: "kruise-daemon-config",
+						Annotations: map[string]string{
+							SecretAnnotationSourceSecretKey: "default/source-secret-1",
+							SecretAnnotationReferenceJobs:   "default/other-job",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "target-secret-6",
+						Namespace: "kruise-daemon-config",
+						Annotations: map[string]string{
+							SecretAnnotationSourceSecretKey: "default/source-secret-1",
+							SecretAnnotationReferenceJobs:   "default/other-job,default/test-job",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "target-secret-4",
+						Namespace: "kruise-daemon-config",
+						Annotations: map[string]string{
+							SecretAnnotationSourceSecretKey: "default/source-secret-1",
+							SecretAnnotationReferenceJobs:   "default/other-job,default/test-job",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "target-secret-5",
+						Namespace: "kruise-daemon-config",
+						Annotations: map[string]string{
+							SecretAnnotationSourceSecretKey: "default/source-secret-1",
+							SecretAnnotationReferenceJobs:   "default/other-job,default/test-job",
+						},
+					},
+				},
+			},
+			expectedTargetSecrets: []string{"target-secret-6"},
+			expectedDeleteSecrets: []string{},
+			expectError:           false,
 		},
 	}
 
@@ -893,8 +1026,20 @@ func TestGetTargetSecretMap(t *testing.T) {
 				assert.Nil(t, deleteMap)
 			} else {
 				assert.NoError(t, err)
-				assert.Len(t, targetMap, tt.expectedTargetLen)
-				assert.Len(t, deleteMap, tt.expectedDeleteLen)
+				assert.Len(t, targetMap, len(tt.expectedTargetSecrets))
+				assert.Len(t, deleteMap, len(tt.expectedDeleteSecrets))
+				targetSecrets := sets.NewString(tt.expectedTargetSecrets...)
+				for _, obj := range targetMap {
+					if !targetSecrets.Has(obj.Name) {
+						t.Fatalf("expect(%v), but get(%s)", targetSecrets.List(), obj.Name)
+					}
+				}
+				deleteSecrets := sets.NewString(tt.expectedDeleteSecrets...)
+				for _, obj := range deleteMap {
+					if !deleteSecrets.Has(obj.Name) {
+						t.Fatalf("expect(%v), but get(%s)", deleteSecrets.List(), obj.Name)
+					}
+				}
 			}
 		})
 	}
@@ -1995,4 +2140,500 @@ func TestClaimImagePullJobSecrets_UpdateExistingSecret(t *testing.T) {
 
 	assert.Contains(t, updatedSecret.Annotations[SecretAnnotationReferenceJobs], "default/test-job")
 	assert.Contains(t, updatedSecret.Annotations[SecretAnnotationReferenceJobs], "default/other-job")
+}
+
+func TestSyncJobPullSecrets_ClassifyError(t *testing.T) {
+	job := &appsv1beta1.ImagePullJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "test-job",
+		},
+		Spec: appsv1beta1.ImagePullJobSpec{
+			ImagePullJobTemplate: appsv1beta1.ImagePullJobTemplate{
+				PullSecrets: []string{"secret1"},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithRuntimeObjects(
+			&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: util.GetKruiseDaemonConfigNamespace()}},
+		).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				if _, ok := list.(*v1.SecretList); ok {
+					return fmt.Errorf("list secrets failed")
+				}
+				return c.List(ctx, list, opts...)
+			},
+		}).Build()
+
+	r := &ReconcileImagePullJob{Client: fakeClient, scheme: scheme}
+	_, err := r.syncJobPullSecrets(job)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "list secrets failed")
+}
+
+func TestSyncJobPullSecrets_ReleaseError(t *testing.T) {
+	kruiseDaemonConfigNs := util.GetKruiseDaemonConfigNamespace()
+	job := &appsv1beta1.ImagePullJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "test-job",
+		},
+		Status: appsv1beta1.ImagePullJobStatus{
+			CompletionTime: func() *metav1.Time { t := metav1.Now(); return &t }(),
+		},
+	}
+
+	// This secret will need to be released, and we inject a delete error
+	secretToRelease := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "synced-secret",
+			Namespace: kruiseDaemonConfigNs,
+			Annotations: map[string]string{
+				SecretAnnotationSourceSecretKey: "default/source-secret",
+				SecretAnnotationReferenceJobs:   "default/test-job",
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithRuntimeObjects(
+			&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: kruiseDaemonConfigNs}},
+			secretToRelease,
+		).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+				return fmt.Errorf("delete failed")
+			},
+		}).Build()
+
+	r := &ReconcileImagePullJob{Client: fakeClient, scheme: scheme}
+	_, err := r.syncJobPullSecrets(job)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "delete failed")
+}
+
+func TestSyncJobPullSecrets_NamespaceNotActive(t *testing.T) {
+	job := &appsv1beta1.ImagePullJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "test-job",
+		},
+		Spec: appsv1beta1.ImagePullJobSpec{
+			ImagePullJobTemplate: appsv1beta1.ImagePullJobTemplate{
+				PullSecrets: []string{"secret1"},
+			},
+		},
+	}
+
+	// No namespace object → namespaceIsActive will fail
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &ReconcileImagePullJob{Client: fakeClient, scheme: scheme}
+	_, err := r.syncJobPullSecrets(job)
+	assert.Error(t, err)
+}
+
+func TestSyncJobPullSecrets_NamespaceDeleting(t *testing.T) {
+	now := metav1.Now()
+	job := &appsv1beta1.ImagePullJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "test-job",
+		},
+		Spec: appsv1beta1.ImagePullJobSpec{
+			ImagePullJobTemplate: appsv1beta1.ImagePullJobTemplate{
+				PullSecrets: []string{"secret1"},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithRuntimeObjects(
+			&v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              util.GetKruiseDaemonConfigNamespace(),
+					DeletionTimestamp: &now,
+					Finalizers:        []string{"test"},
+				},
+			},
+		).Build()
+	r := &ReconcileImagePullJob{Client: fakeClient, scheme: scheme}
+	_, err := r.syncJobPullSecrets(job)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "is being deleted")
+}
+
+func TestSyncJobPullSecrets_NoPullSecrets(t *testing.T) {
+	job := &appsv1beta1.ImagePullJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: util.GetKruiseDaemonConfigNamespace(),
+			Name:      "test-job",
+		},
+		Spec: appsv1beta1.ImagePullJobSpec{},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &ReconcileImagePullJob{Client: fakeClient, scheme: scheme}
+	result, err := r.syncJobPullSecrets(job)
+	assert.NoError(t, err)
+	assert.Nil(t, result)
+}
+
+func TestClassifyPullSecretsForJob_ListError(t *testing.T) {
+	job := &appsv1beta1.ImagePullJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-job",
+			Namespace: "default",
+		},
+		Spec: appsv1beta1.ImagePullJobSpec{
+			ImagePullJobTemplate: appsv1beta1.ImagePullJobTemplate{
+				PullSecrets: []string{"secret1"},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				return fmt.Errorf("list error")
+			},
+		}).Build()
+
+	r := &ReconcileImagePullJob{Client: fakeClient, scheme: scheme}
+	pullSecrets, releasedSecrets, err := r.classifyPullSecretsForJob(job)
+	assert.Error(t, err)
+	assert.Nil(t, pullSecrets)
+	assert.Nil(t, releasedSecrets)
+}
+
+func TestClassifyPullSecretsForJob_SecretPriorityWithJobRef(t *testing.T) {
+	kruiseDaemonConfigNs := util.GetKruiseDaemonConfigNamespace()
+	job := &appsv1beta1.ImagePullJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-job",
+			Namespace: "default",
+		},
+		Spec: appsv1beta1.ImagePullJobSpec{
+			ImagePullJobTemplate: appsv1beta1.ImagePullJobTemplate{
+				PullSecrets: []string{"source-secret"},
+			},
+		},
+	}
+
+	// Two secrets with the same source, both mapping to the same pullSecret
+	// First secret (alphabetically) will be picked first (obj == nil → assigned)
+	// Second secret has jobKey in referJobs → triggers else if branch
+	existingSecrets := []client.Object{
+		&v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "aaa-secret",
+				Namespace: kruiseDaemonConfigNs,
+				Annotations: map[string]string{
+					SecretAnnotationSourceSecretKey: "default/source-secret",
+					SecretAnnotationReferenceJobs:   "default/other-job",
+				},
+			},
+		},
+		&v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bbb-secret",
+				Namespace: kruiseDaemonConfigNs,
+				Annotations: map[string]string{
+					SecretAnnotationSourceSecretKey: "default/source-secret",
+					SecretAnnotationReferenceJobs:   "default/test-job",
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existingSecrets...).Build()
+	r := &ReconcileImagePullJob{Client: fakeClient, scheme: scheme}
+
+	pullSecrets, releasedSecrets, err := r.classifyPullSecretsForJob(job)
+	assert.NoError(t, err)
+	assert.Len(t, pullSecrets, 1)
+	assert.Empty(t, releasedSecrets)
+
+	// The secret with jobKey (bbb-secret) should be preferred
+	ref := appsv1beta1.ReferenceObject{Namespace: "default", Name: "source-secret"}
+	assert.Equal(t, "bbb-secret", pullSecrets[ref].Name)
+}
+
+func TestClassifyPullSecretsForJob_JobBeingDeleted(t *testing.T) {
+	kruiseDaemonConfigNs := util.GetKruiseDaemonConfigNamespace()
+	now := metav1.Now()
+	job := &appsv1beta1.ImagePullJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-job",
+			Namespace:         "default",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{"test"},
+		},
+		Spec: appsv1beta1.ImagePullJobSpec{
+			ImagePullJobTemplate: appsv1beta1.ImagePullJobTemplate{
+				PullSecrets: []string{"source-secret"},
+			},
+		},
+	}
+
+	existingSecrets := []client.Object{
+		&v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "synced-secret",
+				Namespace: kruiseDaemonConfigNs,
+				Annotations: map[string]string{
+					SecretAnnotationSourceSecretKey: "default/source-secret",
+					SecretAnnotationReferenceJobs:   "default/test-job",
+				},
+			},
+		},
+		// Secret not referenced by this job
+		&v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "other-secret",
+				Namespace: kruiseDaemonConfigNs,
+				Annotations: map[string]string{
+					SecretAnnotationSourceSecretKey: "default/other-source",
+					SecretAnnotationReferenceJobs:   "default/other-job",
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existingSecrets...).Build()
+	r := &ReconcileImagePullJob{Client: fakeClient, scheme: scheme}
+
+	pullSecrets, releasedSecrets, err := r.classifyPullSecretsForJob(job)
+	assert.NoError(t, err)
+	assert.Empty(t, pullSecrets)
+	assert.Len(t, releasedSecrets, 1)
+	assert.Equal(t, "synced-secret", releasedSecrets[0].Name)
+}
+
+func TestReleaseImagePullJobSecrets_SecretBeingDeleted(t *testing.T) {
+	now := metav1.Now()
+	job := &appsv1beta1.ImagePullJob{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-job", Namespace: "default"},
+	}
+
+	secrets := []*v1.Secret{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "deleting-secret",
+				Namespace:         "kruise-daemon-config",
+				DeletionTimestamp: &now,
+				Finalizers:        []string{"test"},
+				Annotations: map[string]string{
+					SecretAnnotationReferenceJobs: "default/test-job",
+				},
+			},
+		},
+	}
+
+	r := &ReconcileImagePullJob{Client: fake.NewClientBuilder().WithScheme(scheme).Build()}
+	err := r.releaseImagePullJobSecrets(secrets, job)
+	assert.NoError(t, err)
+}
+
+func TestReleaseImagePullJobSecrets_NilSecret(t *testing.T) {
+	job := &appsv1beta1.ImagePullJob{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-job", Namespace: "default"},
+	}
+
+	secrets := []*v1.Secret{nil}
+
+	r := &ReconcileImagePullJob{Client: fake.NewClientBuilder().WithScheme(scheme).Build()}
+	err := r.releaseImagePullJobSecrets(secrets, job)
+	assert.NoError(t, err)
+}
+
+func TestReleaseImagePullJobSecrets_DeleteError(t *testing.T) {
+	job := &appsv1beta1.ImagePullJob{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-job", Namespace: "default"},
+	}
+
+	secret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "secret-1",
+			Namespace: "kruise-daemon-config",
+			Annotations: map[string]string{
+				SecretAnnotationReferenceJobs: "default/test-job",
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithRuntimeObjects(secret).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+				return fmt.Errorf("delete error")
+			},
+		}).Build()
+
+	r := &ReconcileImagePullJob{Client: fakeClient, scheme: scheme}
+	err := r.releaseImagePullJobSecrets([]*v1.Secret{secret}, job)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "delete error")
+}
+
+func TestReleaseImagePullJobSecrets_NilAnnotations(t *testing.T) {
+	job := &appsv1beta1.ImagePullJob{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-job", Namespace: "default"},
+	}
+
+	// Secret with nil annotations but referencing multiple jobs via annotations set on the raw map
+	secret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "secret-1",
+			Namespace: "kruise-daemon-config",
+		},
+	}
+
+	// Let's just verify the Delete path (referJobs empty) with nil annotations
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithRuntimeObjects(secret.DeepCopy()).Build()
+	r := &ReconcileImagePullJob{Client: fakeClient, scheme: scheme}
+	err := r.releaseImagePullJobSecrets([]*v1.Secret{secret}, job)
+	assert.NoError(t, err)
+}
+
+func TestReleaseImagePullJobSecrets_UpdateError(t *testing.T) {
+	job := &appsv1beta1.ImagePullJob{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-job", Namespace: "default"},
+	}
+
+	secret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "secret-1",
+			Namespace: "kruise-daemon-config",
+			Annotations: map[string]string{
+				SecretAnnotationReferenceJobs: "default/test-job,default/other-job",
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithRuntimeObjects(secret.DeepCopy()).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+				return fmt.Errorf("update error")
+			},
+		}).Build()
+
+	r := &ReconcileImagePullJob{Client: fakeClient, scheme: scheme}
+	err := r.releaseImagePullJobSecrets([]*v1.Secret{secret}, job)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "update error")
+}
+
+func TestClaimImagePullJobSecrets_GetError(t *testing.T) {
+	job := &appsv1beta1.ImagePullJob{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-job", Namespace: "default"},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if _, ok := obj.(*v1.Secret); ok {
+					return fmt.Errorf("internal server error")
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}).Build()
+
+	pullSecrets := map[appsv1beta1.ReferenceObject]*v1.Secret{
+		{Namespace: "default", Name: "my-secret"}: nil,
+	}
+
+	r := &ReconcileImagePullJob{Client: fakeClient, scheme: scheme, generateRandomStringFunc: defaultGenerateRandomString}
+	_, err := r.claimImagePullJobSecrets(job, pullSecrets)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "internal server error")
+}
+
+func TestClaimImagePullJobSecrets_CreateError(t *testing.T) {
+	job := &appsv1beta1.ImagePullJob{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-job", Namespace: "default"},
+	}
+
+	sourceSecret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-secret",
+			Namespace: "default",
+		},
+		Data: map[string][]byte{"key": []byte("value")},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithRuntimeObjects(sourceSecret).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				if secret, ok := obj.(*v1.Secret); ok && secret.Namespace == util.GetKruiseDaemonConfigNamespace() {
+					return fmt.Errorf("create error")
+				}
+				return c.Create(ctx, obj, opts...)
+			},
+		}).Build()
+
+	pullSecrets := map[appsv1beta1.ReferenceObject]*v1.Secret{
+		{Namespace: "default", Name: "my-secret"}: nil,
+	}
+
+	r := &ReconcileImagePullJob{
+		Client:                   fakeClient,
+		scheme:                   scheme,
+		generateRandomStringFunc: func() string { return "test" },
+	}
+	_, err := r.claimImagePullJobSecrets(job, pullSecrets)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "create error")
+}
+
+func TestClaimImagePullJobSecrets_UpdateError(t *testing.T) {
+	kruiseDaemonConfigNs := util.GetKruiseDaemonConfigNamespace()
+	job := &appsv1beta1.ImagePullJob{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-job", Namespace: "default"},
+	}
+
+	sourceSecret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-secret",
+			Namespace: "default",
+		},
+		Data: map[string][]byte{"key": []byte("new-value")},
+	}
+
+	existingSecret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "synced-secret",
+			Namespace: kruiseDaemonConfigNs,
+			Annotations: map[string]string{
+				SecretAnnotationReferenceJobs: "default/other-job",
+			},
+		},
+		Data: map[string][]byte{"key": []byte("old-value")},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithRuntimeObjects(sourceSecret, existingSecret).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+				return fmt.Errorf("update error")
+			},
+		}).Build()
+
+	pullSecrets := map[appsv1beta1.ReferenceObject]*v1.Secret{
+		{Namespace: "default", Name: "my-secret"}: existingSecret,
+	}
+
+	r := &ReconcileImagePullJob{
+		Client:                   fakeClient,
+		scheme:                   scheme,
+		generateRandomStringFunc: defaultGenerateRandomString,
+	}
+	_, err := r.claimImagePullJobSecrets(job, pullSecrets)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "update error")
 }


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
In previous Kruise versions, if multiple imagepulljobs existed and referenced the same secret, each imagepulljob would generate its own kruise-daemon-config secret.

Starting from Kruise 1.9, this scenario will generate only one kruise-daemon-config secret.

However, the secret synchronization logic in kruise 1.9's imagepulljob controller has some issues with existing kruise-daemon-config secrets. It consistently selects different secrets each time, causing mismatches with nodeImage pullSecrets. This subsequently triggers nodeImage secret synchronization.

From the user's perspective, the imagepulljob task appears 100% complete. Yet due to the aforementioned reason, the imagepulljob controller's statistics become inaccurate, causing the imagepulljob task to remain unfinished indefinitely.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

