### PR TITLE
feat(daemonset): add DaemonSetPruneIneligibleNodes feature gate to prune ineligible pods during rolling update

### DIFF
--- a/pkg/controller/daemonset/daemonset_node_filter.go
+++ b/pkg/controller/daemonset/daemonset_node_filter.go
@@ -1,0 +1,41 @@
+package daemonset
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	appsv1beta1 "github.com/openkruise/kruise/apis/apps/v1beta1"
+)
+
+func (dsc *ReconcileDaemonSet) pruneNodesAndOrphanedPods(ds *appsv1beta1.DaemonSet, nodeToDaemonPods map[string][]*corev1.Pod, nodeList []*corev1.Node) map[string][]*corev1.Pod {
+	nodeMap := make(map[string]*corev1.Node)
+	for _, node := range nodeList {
+		nodeMap[node.Name] = node
+	}
+
+	podsToDelete := sets.NewString()
+	nodeToDelete := sets.NewString()
+
+	for nodeName, pods := range nodeToDaemonPods {
+		node, exists := nodeMap[nodeName]
+		deleteNode := true
+		if exists {
+			wantToRun, _ := nodeShouldRunDaemonPod(node, ds)
+			if wantToRun {
+				deleteNode = false
+			}
+		}
+
+		if deleteNode {
+			nodeToDelete.Insert(nodeName)
+			for _, pod := range pods {
+				podsToDelete.Insert(pod.Name)
+			}
+		}
+	}
+	for _, nodeName := range nodeToDelete.List() {
+		delete(nodeToDaemonPods, nodeName)
+	}
+
+	return nodeToDaemonPods
+}

--- a/pkg/controller/daemonset/daemonset_node_filter_test.go
+++ b/pkg/controller/daemonset/daemonset_node_filter_test.go
@@ -1,0 +1,196 @@
+package daemonset
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/tools/cache"
+	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
+	"k8s.io/kubernetes/pkg/controller/daemon/util"
+
+	appsv1beta1 "github.com/openkruise/kruise/apis/apps/v1beta1"
+	"github.com/openkruise/kruise/pkg/features"
+	utilfeature "github.com/openkruise/kruise/pkg/util/feature"
+)
+
+func markAllPodsReady(store cache.Store, options []func(*corev1.Pod) bool) {
+	// mark pods as ready
+	for _, obj := range store.List() {
+		pod := obj.(*corev1.Pod)
+		handle := true
+		for _, option := range options {
+			handle = handle && option(pod)
+		}
+		if handle {
+			condition := corev1.PodCondition{Type: corev1.PodReady, Status: corev1.ConditionTrue}
+			podutil.UpdatePodCondition(&pod.Status, &condition)
+		}
+	}
+}
+
+// setNodesNotReady updates the given nodes in the store to have NodeReady=False.
+func setNodesNotReady(nodeStore cache.Store, nodeNames ...string) {
+	for _, name := range nodeNames {
+		obj, exists, _ := nodeStore.GetByKey(name)
+		if !exists {
+			continue
+		}
+		node := obj.(*corev1.Node).DeepCopy()
+		for i := range node.Status.Conditions {
+			if node.Status.Conditions[i].Type == corev1.NodeReady {
+				node.Status.Conditions[i].Status = corev1.ConditionFalse
+				break
+			}
+		}
+		_ = nodeStore.Update(node)
+	}
+}
+
+func TestManageDeletesPodsOnNotReadyNodesWhenIgnoreAnnotation(t *testing.T) {
+	defer utilfeature.SetFeatureGateDuringTest(t, utilfeature.DefaultMutableFeatureGate, features.DaemonSetPruneIneligibleNodes, true)()
+
+	ds := newDaemonSet("foo")
+
+	ds.Spec.UpdateStrategy = appsv1beta1.DaemonSetUpdateStrategy{
+		Type: appsv1beta1.RollingUpdateDaemonSetStrategyType,
+		RollingUpdate: &appsv1beta1.RollingUpdateDaemonSet{
+			MaxUnavailable: &intstr.IntOrString{Type: intstr.Int, IntVal: 1},
+		},
+	}
+	manager, podControl, _, err := newTestController(ds)
+	if err != nil {
+		t.Fatalf("error creating DaemonSets controller: %v", err)
+	}
+
+	// 5 nodes, initial sync creates one pod per node.
+	addNodes(manager.nodeStore, 0, 5, nil)
+	notReadyNodeSets := sets.NewString("node-0", "node-1")
+	setPodReady := func(all bool) {
+		markAllPodsReady(podControl.podStore, []func(*corev1.Pod) bool{func(pod *corev1.Pod) bool {
+			if all {
+				return true
+			}
+			nodeName, _ := util.GetTargetNodeName(pod)
+			if notReadyNodeSets.Has(nodeName) {
+				return false
+			}
+			return true
+		}})
+	}
+
+	clearExpectations(t, manager, ds, podControl)
+	manager.dsStore.Add(ds)
+	expectSyncDaemonSets(t, manager, ds, podControl, 5, 0, 0)
+	setPodReady(true)
+
+	// Mark two nodes NotReady and expect manage() NOT to delete pods on those nodes
+	// because IgnoreNotReadyNodes annotation is set.
+	clearExpectations(t, manager, ds, podControl)
+	setNodesNotReady(manager.nodeStore, notReadyNodeSets.List()...)
+	expectSyncDaemonSets(t, manager, ds, podControl, 0, 0, 0)
+
+	ds.Spec.Template.Spec.Affinity = &corev1.Affinity{
+		NodeAffinity: &corev1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{
+					{
+						MatchExpressions: []corev1.NodeSelectorRequirement{
+							{
+								Key:      "kubernetes.io/hostname",
+								Operator: corev1.NodeSelectorOpNotIn,
+								Values:   notReadyNodeSets.List(),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ds.Spec.Template.Spec.Containers[0].Image = "bar2"
+	ds.Generation++
+	manager.dsStore.Update(ds)
+	// manage 2  update 1
+	clearExpectations(t, manager, ds, podControl)
+	expectSyncDaemonSets(t, manager, ds, podControl, 0, 3, 0)
+
+	clearExpectations(t, manager, ds, podControl)
+	expectSyncDaemonSets(t, manager, ds, podControl, 1, 0, 0)
+
+	clearExpectations(t, manager, ds, podControl)
+	setPodReady(false)
+	expectSyncDaemonSets(t, manager, ds, podControl, 0, 1, 0)
+
+	clearExpectations(t, manager, ds, podControl)
+	setPodReady(false)
+	expectSyncDaemonSets(t, manager, ds, podControl, 1, 0, 0)
+
+	clearExpectations(t, manager, ds, podControl)
+	setPodReady(false)
+	expectSyncDaemonSets(t, manager, ds, podControl, 0, 1, 0)
+
+	clearExpectations(t, manager, ds, podControl)
+	setPodReady(false)
+	expectSyncDaemonSets(t, manager, ds, podControl, 1, 0, 0)
+
+	nodeSeen := make(map[string]bool)
+
+	for _, _pod := range podControl.podStore.List() {
+		pod := _pod.(*corev1.Pod)
+		nodeName, _ := util.GetTargetNodeName(pod)
+		if notReadyNodeSets.Has(nodeName) {
+			t.Fatalf("pod %s should not exists", nodeName)
+		}
+		nodeSeen[nodeName] = true
+	}
+	if len(nodeSeen) != 3 {
+		t.Fatalf("expect 3 nodes to be seen %v", nodeSeen)
+	}
+
+}
+
+// TestDaemonSetIgnoreNotReadyNodesWhenUpdating verifies that when the ignore-notready-nodes
+// annotation is set, pods on NotReady nodes are not counted in numUnavailable and are deleted,
+// so rollout can proceed on ready nodes even when NotReady count > maxUnavailable.
+func TestDaemonSetIgnoreNotReadyNodesWhenUpdating(t *testing.T) {
+	defer utilfeature.SetFeatureGateDuringTest(t, utilfeature.DefaultMutableFeatureGate, features.DaemonSetPruneIneligibleNodes, true)()
+
+	ds := newDaemonSet("foo")
+	if ds.Annotations == nil {
+		ds.Annotations = make(map[string]string)
+	}
+
+	manager, podControl, _, err := newTestController(ds)
+	if err != nil {
+		t.Fatalf("error creating DaemonSets controller: %v", err)
+	}
+	addNodes(manager.nodeStore, 0, 5, nil)
+	manager.dsStore.Add(ds)
+	expectSyncDaemonSets(t, manager, ds, podControl, 5, 0, 0)
+	markAllPodsReady(podControl.podStore, nil)
+
+	// Make 3 nodes NotReady. Without the annotation, numUnavailable would be 3 >= maxUnavailable(2)
+	// and rollout would be blocked. With the annotation, pods on NotReady nodes are not counted
+	// and are deleted; we can also delete 2 more from ready nodes (maxUnavailable).
+	clearExpectations(t, manager, ds, podControl)
+	setNodesNotReady(manager.nodeStore, "node-0", "node-1", "node-2")
+
+	// First sync after update:
+	// - manage: deletes 3 pods on NotReady nodes (node-0, node-1, node-2)
+	// - rollingUpdate: deletes 2 pods on ready nodes (node-3, node-4) per maxUnavailable
+	// Total: 0 creates, 5 deletes
+
+	// Update image and set rolling update with maxUnavailable=2 and enable ignore-notready-nodes.
+	ds.Spec.Template.Spec.Containers[0].Image = "foo2/bar2"
+	ds.Spec.UpdateStrategy.Type = appsv1beta1.RollingUpdateDaemonSetStrategyType
+	intStr := intstr.FromInt(2)
+	ds.Spec.UpdateStrategy.RollingUpdate = &appsv1beta1.RollingUpdateDaemonSet{MaxUnavailable: &intStr}
+	clearExpectations(t, manager, ds, podControl)
+	manager.dsStore.Update(ds)
+	expectSyncDaemonSets(t, manager, ds, podControl, 0, 2, 0)
+
+	clearExpectations(t, manager, ds, podControl)
+	expectSyncDaemonSets(t, manager, ds, podControl, 2, 0, 0)
+}

--- a/pkg/controller/daemonset/daemonset_update.go
+++ b/pkg/controller/daemonset/daemonset_update.go
@@ -35,7 +35,9 @@ import (
 
 	appsv1beta1 "github.com/openkruise/kruise/apis/apps/v1beta1"
 	clonesetutils "github.com/openkruise/kruise/pkg/controller/cloneset/utils"
+	"github.com/openkruise/kruise/pkg/features"
 	"github.com/openkruise/kruise/pkg/util"
+	utilfeature "github.com/openkruise/kruise/pkg/util/feature"
 	"github.com/openkruise/kruise/pkg/util/inplaceupdate"
 )
 
@@ -47,12 +49,29 @@ func (dsc *ReconcileDaemonSet) rollingUpdate(ctx context.Context, ds *appsv1beta
 	if err != nil {
 		return fmt.Errorf("couldn't get node to daemon pod mapping for daemon set %q: %v", ds.Name, err)
 	}
+
+	// Handle pods on nodes that no longer match the DaemonSet's nodeSelector/nodeAffinity/taints.
+	// When the selector is narrowed, some nodes become ineligible and their existing pods should be removed.
+	// - DaemonSetPruneIneligibleNodes enabled: pods on newly-ineligible nodes are deleted immediately during
+	//   the rolling update, keeping nodeToDaemonPods consistent with the current selector.
+	// - DaemonSetPruneIneligibleNodes disabled (default): ineligible nodes are left in nodeToDaemonPods as-is,
+	//   so the rolling update budget still counts their pods. This prevents the update from consuming
+	//   extra unavailability slots just because the selector changed — the manage loop will handle
+	//   deleting those pods separately via its normal reconcile path.
+	//   WARNING: this can block the rollout in two situations:
+	//   1. The number of NotReady pods across all nodes already reaches or exceeds maxUnavailable,
+	//      leaving no budget for the rolling update to proceed.
+	//   2. The selector is narrowed and the excluded pods (which cannot be deleted by the rolling
+	//      update itself) occupy all maxUnavailable slots, so no eligible node can be updated.
+	if utilfeature.DefaultFeatureGate.Enabled(features.DaemonSetPruneIneligibleNodes) {
+		nodeToDaemonPods = dsc.pruneNodesAndOrphanedPods(ds, nodeToDaemonPods, nodeList)
+	}
+
 	maxSurge, maxUnavailable, err := dsc.updatedDesiredNodeCounts(ds, nodeList, nodeToDaemonPods)
 	if err != nil {
 		return fmt.Errorf("couldn't get unavailable numbers: %v", err)
 	}
 
-	// Advanced: filter the pods updated, updating and can update, according to partition and selector
 	nodeToDaemonPods, err = dsc.filterDaemonPodsToUpdate(ds, nodeList, hash, nodeToDaemonPods)
 	if err != nil {
 		return fmt.Errorf("failed to filterDaemonPodsToUpdate: %v", err)

--- a/pkg/controller/daemonset/daemonset_util_test.go
+++ b/pkg/controller/daemonset/daemonset_util_test.go
@@ -273,6 +273,11 @@ func TestGetPodRevision(t *testing.T) {
 }
 
 func newNode(name string, label map[string]string) *corev1.Node {
+	if label == nil {
+		label = make(map[string]string)
+	}
+	label["kubernetes.io/hostname"] = name
+
 	return &corev1.Node{
 		TypeMeta: metav1.TypeMeta{APIVersion: "v1"},
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/features/kruise_features.go
+++ b/pkg/features/kruise_features.go
@@ -156,6 +156,11 @@ const (
 	// Enabling this means a default will be assigned even to embeddedPodSpecs
 	// (e.g. in a CloneSet,Advanced DaemonSet), which is the historical default.
 	DefaultHostNetworkHostPortsInPodTemplates featuregate.Feature = "DefaultHostNetworkHostPortsInPodTemplates"
+
+	// DaemonSetPruneIneligibleNodes Enabling this feature means if the reduction in the node set such as
+	// node affinity, then the pods on the nodes that have undergone
+	// this reduction will not be counted in the maxUnavailable.
+	DaemonSetPruneIneligibleNodes featuregate.Feature = "DaemonSetPruneIneligibleNodes"
 )
 
 var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
@@ -197,6 +202,8 @@ var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	EnableSortSidecarContainerByName:          {Default: false, PreRelease: featuregate.Alpha},
 	InPlacePodVerticalScaling:                 {Default: false, PreRelease: featuregate.Alpha},
 	DefaultHostNetworkHostPortsInPodTemplates: {Default: false, PreRelease: featuregate.Alpha},
+
+	DaemonSetPruneIneligibleNodes: {Default: false, PreRelease: featuregate.Alpha},
 }
 
 func init() {

--- a/test/e2e/apps/v1beta1/daemonset_filter_nodes.go
+++ b/test/e2e/apps/v1beta1/daemonset_filter_nodes.go
@@ -1,0 +1,260 @@
+package v1beta1
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientset "k8s.io/client-go/kubernetes"
+	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
+	"k8s.io/utils/pointer"
+
+	appsv1beta1 "github.com/openkruise/kruise/apis/apps/v1beta1"
+	kruiseclientset "github.com/openkruise/kruise/pkg/client/clientset/versioned"
+	"github.com/openkruise/kruise/pkg/util"
+	"github.com/openkruise/kruise/test/e2e/framework/common"
+	"github.com/openkruise/kruise/test/e2e/framework/v1beta1"
+)
+
+var _ = ginkgo.Describe("DaemonSet", ginkgo.Label("DaemonSet", "workload"), func() {
+	f := v1beta1.NewDefaultFramework("daemonset")
+	var ns string
+	var c clientset.Interface
+	var kc kruiseclientset.Interface
+	var tester *v1beta1.DaemonSetTester
+
+	ginkgo.BeforeEach(func() {
+		c = f.ClientSet
+		kc = f.KruiseClientSet
+		ns = f.Namespace.Name
+		tester = v1beta1.NewDaemonSetTester(c, kc, ns)
+	})
+
+	ginkgo.Context("Basic DaemonSet functionality [DaemonSetBasic]", func() {
+		dsName := "e2e-ds"
+
+		ginkgo.AfterEach(func() {
+			if ginkgo.CurrentSpecReport().Failed() {
+				common.DumpDebugInfo(c, ns)
+			}
+			common.Logf("Deleting DaemonSet %s/%s in cluster", ns, dsName)
+			tester.DeleteDaemonSet(ns, dsName)
+		})
+
+		ginkgo.It("should ignore not ready nodes during rolling update when annotation is set", ginkgo.Serial, func() {
+			// This test performs destructive cluster-level operations (docker rm nodes)
+			// It must run serially to avoid interfering with other tests
+			label := map[string]string{v1beta1.DaemonSetNameLabel: dsName}
+
+			ginkgo.By(fmt.Sprintf("Creating DaemonSet %s with ignore-notready-nodes annotation", dsName))
+			maxUnavailable := intstr.IntOrString{IntVal: int32(2)}
+			ds := tester.NewDaemonSet(dsName, label, common.WebserverImage, appsv1beta1.DaemonSetUpdateStrategy{
+				Type: appsv1beta1.RollingUpdateDaemonSetStrategyType,
+				RollingUpdate: &appsv1beta1.RollingUpdateDaemonSet{
+					MaxUnavailable: &maxUnavailable,
+				},
+			})
+
+			ds.Spec.Template.Spec.TerminationGracePeriodSeconds = pointer.Int64Ptr(5)
+			ds, err := tester.CreateDaemonSet(ds)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("Check that daemon pods launch on every node of the cluster.")
+			err = wait.PollImmediate(v1beta1.DaemonSetRetryPeriod, v1beta1.DaemonSetRetryTimeout, tester.CheckRunningOnAllNodes(ds))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "error waiting for daemon pod to start")
+			filterWorkerNode := func(nodes *v1.NodeList) *v1.NodeList {
+				tmp := v1.NodeList{}
+				for i, node := range nodes.Items {
+					if strings.Contains(node.Name, "-worker") {
+						tmp.Items = append(tmp.Items, nodes.Items[i])
+					}
+				}
+				return &tmp
+			}
+
+			nodeList := common.GetReadySchedulableNodesOrDie(f.ClientSet)
+			nodeList = filterWorkerNode(nodeList)
+			// We need at least 2 nodes to meaningfully test ignoring one NotReady node.
+			notReadyNodeCount := 2
+			if len(nodeList.Items) < notReadyNodeCount {
+				ginkgo.Skip("Need at least 2 schedulable nodes for ignore-notready-nodes e2e")
+			}
+			nodeNotReadySet := sets.NewString()
+			for i := 0; i < notReadyNodeCount; i++ {
+				node := nodeList.Items[len(nodeList.Items)-1-i]
+				nodeNotReadySet.Insert(node.Name)
+				ginkgo.By(fmt.Sprintf("Mark node %s NotReady", node.Name))
+				err = exec.Command("docker", "stop", node.Name).Run()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+
+			ginkgo.By("wait node to not ready")
+			err = wait.PollImmediate(v1beta1.DaemonSetRetryPeriod, v1beta1.DaemonSetRetryTimeout*2, func() (bool, error) {
+				notStatus := map[string]bool{}
+				nodeList := common.GetReadySchedulableNodesOrDie(f.ClientSet)
+				for _, p := range nodeList.Items {
+					if nodeNotReadySet.Has(p.Name) {
+						notStatus[p.Name] = true
+					}
+				}
+				if len(notStatus) == 0 {
+					return true, nil
+				}
+				return false, nil
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "error node not unready")
+
+			ginkgo.By("Migrate the kruise-system pod")
+			err = wait.PollImmediate(v1beta1.DaemonSetRetryPeriod, v1beta1.DaemonSetRetryTimeout*2, func() (bool, error) {
+				podList, err := c.CoreV1().Pods(util.GetKruiseNamespace()).List(context.TODO(), metav1.ListOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				for _, pod := range podList.Items {
+					if nodeNotReadySet.Has(pod.Spec.NodeName) && pod.Labels["control-plane"] == "controller-manager" {
+						err := c.CoreV1().Pods(pod.Namespace).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{GracePeriodSeconds: pointer.Int64Ptr(0)})
+						gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					}
+				}
+				return true, nil
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("wait kruise pod ready")
+			err = wait.PollImmediate(v1beta1.DaemonSetRetryPeriod*5, v1beta1.DaemonSetRetryTimeout, func() (bool, error) {
+				podList, err := c.CoreV1().Pods(util.GetKruiseNamespace()).List(context.Background(), metav1.ListOptions{
+					LabelSelector: labels.SelectorFromSet(map[string]string{
+						"control-plane": "controller-manager",
+					}).String(),
+				})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				if len(podList.Items) == 0 {
+					common.Logf("Waiting for the kruise controller pod to become ready")
+					return false, nil
+				}
+				for _, pod := range podList.Items {
+					if !podutil.IsPodReady(&pod) {
+						return false, nil
+					}
+				}
+				return true, nil
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "kruise controller ok")
+
+			ginkgo.By("Update DaemonSet image to trigger rolling update")
+			err = tester.UpdateDaemonSet(ds.Name, func(ds *appsv1beta1.DaemonSet) { // Bottleneck point
+				ds.Spec.Template.Spec.Containers[0].Image = common.NewWebserverImage
+				ds.Spec.Template.Spec.Affinity = &v1.Affinity{
+					NodeAffinity: &v1.NodeAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+							NodeSelectorTerms: []v1.NodeSelectorTerm{
+								{
+									MatchExpressions: []v1.NodeSelectorRequirement{
+										{
+											Key:      "kubernetes.io/hostname",
+											Operator: v1.NodeSelectorOpNotIn,
+											Values:   nodeNotReadySet.List(),
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "error updating daemonset image")
+
+			ginkgo.By("Ensure daemon pods on the NotReady node are eventually deleted")
+			err = wait.PollImmediate(v1beta1.DaemonSetRetryPeriod, v1beta1.DaemonSetRetryTimeout, func() (bool, error) {
+				podList, err := tester.ListDaemonPods(label)
+				if err != nil {
+					return false, err
+				}
+				for _, p := range podList.Items {
+					if nodeNotReadySet.Has(p.Name) && p.DeletionTimestamp == nil {
+						common.Logf("Pod %s is still running", p.Name)
+						return false, nil
+					}
+				}
+				return true, nil
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "daemon pods on NotReady node were not deleted")
+
+			ginkgo.By("Check that daemon pods images")
+			err = wait.PollImmediate(v1beta1.DaemonSetRetryPeriod, v1beta1.DaemonSetRetryTimeout, func() (bool, error) {
+
+				podList, err := tester.ListDaemonPods(label)
+				if err != nil {
+					return false, err
+				}
+				for _, p := range podList.Items {
+					if !nodeNotReadySet.Has(p.Spec.NodeName) {
+						if p.Spec.Containers[0].Image != common.NewWebserverImage {
+							common.Logf("Pod %s is not running on node %s", p.Name, p.Spec.NodeName)
+							return false, nil
+						}
+					}
+				}
+				return true, nil
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "daemonset did not update all pods")
+
+			ginkgo.By("clean unready pods")
+			err = wait.PollImmediate(v1beta1.DaemonSetRetryPeriod, v1beta1.DaemonSetRetryTimeout, func() (bool, error) {
+				podList, err := c.CoreV1().Pods("").List(context.Background(), metav1.ListOptions{})
+				if err != nil {
+					common.Logf("Error listing pods: %v", err)
+					return false, err
+				}
+				for _, pod := range podList.Items {
+					if nodeNotReadySet.Has(pod.Spec.NodeName) {
+						err := c.CoreV1().Pods(pod.Namespace).Delete(context.Background(), pod.Name, metav1.DeleteOptions{GracePeriodSeconds: pointer.Int64(0)})
+						if err != nil && errors.IsNotFound(err) {
+							common.Logf("Pod %s is still running", pod.Name)
+							return false, err
+						}
+					}
+				}
+				return true, nil
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "daemonset delete unready node")
+
+			ginkgo.By("recover node")
+			for _, node := range nodeNotReadySet.List() {
+				err = exec.Command("docker", "start", node).Run()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+
+			ginkgo.By("wait all node and pod ready")
+			err = wait.PollImmediate(v1beta1.DaemonSetRetryPeriod*5, v1beta1.DaemonSetRetryTimeout, func() (bool, error) {
+				nodeList, err := c.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				for _, node := range nodeList.Items {
+					if !v1beta1.IsNodeReady(&node) {
+						return false, nil
+					}
+				}
+
+				podList, err := c.CoreV1().Pods("").List(context.Background(), metav1.ListOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				for _, pod := range podList.Items {
+					if !podutil.IsPodReady(&pod) {
+						return false, nil
+					}
+				}
+				return true, nil
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "cluster ok")
+
+		})
+	})
+})

--- a/test/e2e/framework/v1alpha1/daemonset_util.go
+++ b/test/e2e/framework/v1alpha1/daemonset_util.go
@@ -206,6 +206,7 @@ func (t *DaemonSetTester) SetDaemonSetNodeLabels(nodeName string, labels map[str
 		daemonSetLabels, otherLabels := t.SeparateDaemonSetNodeLabels(node.Labels)
 		if reflect.DeepEqual(daemonSetLabels, labels) {
 			newNode = node
+			newLabels = daemonSetLabels
 			return true, nil
 		}
 		node.Labels = otherLabels

--- a/test/e2e/framework/v1beta1/daemonset_util.go
+++ b/test/e2e/framework/v1beta1/daemonset_util.go
@@ -205,6 +205,7 @@ func (t *DaemonSetTester) SetDaemonSetNodeLabels(nodeName string, labels map[str
 		daemonSetLabels, otherLabels := t.SeparateDaemonSetNodeLabels(node.Labels)
 		if reflect.DeepEqual(daemonSetLabels, labels) {
 			newNode = node
+			newLabels = daemonSetLabels
 			return true, nil
 		}
 		node.Labels = otherLabels


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
```
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: busybox
spec:
  selector:
    matchLabels:
      app: busybox
  template:
    metadata:
      labels:
        app: busybox
    spec:
      containers:
        - name: busybox
          image: busybox
          args:
            - /bin/sh
            - -c
            - 'while true; do ping -c 4 8.8.8.8; sleep 60; done'
      affinity:
        nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:
              - matchExpressions:
                  - key: "kubernetes.io/hostname"
                    operator: "NotIn"
                    values:
                      - "koord-worker1"
                      - "koord-worker2"
                      - "koord-worker3"
  updateStrategy:
    type: RollingUpdate
    rollingUpdate: 
      maxUnavailable: 2
      
```
When koord-worker1, koord-worker2, and koord-worker3 fail to function properly and no affinity settings are made, there will be issues with the re-deployment. because during DaemonSet rolling updates, `maxUnavailable` controls how many pods can be unavailable simultaneously. When nodes become unexcepted by nodeSelector, pods on those nodes can **block rollouts on healthy nodes**.

**Solution:** `Adding "affinity" means that these nodes are excluded from the expected nodes. Not taking into account the situations of these nodes when releasing . And before applying the actual logic, clean up the nodeToPods and actively delete the unexpected nodes and their pods.`

This allows updates to proceed on healthy nodes by dynamically adjusting the unavailability budget.


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

