### PR TITLE
fix: read InPlaceUpdateState from fresh clone instead of stale pod in updateNextBatch

### DIFF
--- a/pkg/util/inplaceupdate/inplace_update.go
+++ b/pkg/util/inplaceupdate/inplace_update.go
@@ -264,7 +264,7 @@ func (c *realControl) updateNextBatch(pod *v1.Pod, opts *UpdateOptions) (bool, e
 		}
 
 		state := appspub.InPlaceUpdateState{}
-		if stateStr, ok := appspub.GetInPlaceUpdateState(pod); !ok {
+		if stateStr, ok := appspub.GetInPlaceUpdateState(clone); !ok {
 			return nil
 		} else if err := json.Unmarshal([]byte(stateStr), &state); err != nil {
 			return err

--- a/pkg/util/inplaceupdate/inplace_update_test.go
+++ b/pkg/util/inplaceupdate/inplace_update_test.go
@@ -648,3 +648,60 @@ func TestRefresh(t *testing.T) {
 		}
 	}
 }
+
+func TestUpdateNextBatchReadsFromClone(t *testing.T) {
+	aHourAgo := metav1.NewTime(time.Unix(time.Now().Add(-time.Hour).Unix(), 0))
+	Clock = testingclock.NewFakeClock(aHourAgo.Time)
+
+	// storedPod is the pod in the fake client (what GetPod returns as "clone").
+	// It does NOT have the InPlaceUpdateState annotation.
+	storedPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pod-stale-test",
+			Labels: map[string]string{
+				apps.StatefulSetRevisionLabel: "new-revision",
+			},
+		},
+		Spec: v1.PodSpec{
+			Containers:     []v1.Container{{Name: "c1", Image: "c1-img2"}, {Name: "c2", Image: "c2-img1"}},
+			ReadinessGates: []v1.PodReadinessGate{{ConditionType: appspub.InPlaceUpdateReady}},
+		},
+		Status: v1.PodStatus{
+			ContainerStatuses: []v1.ContainerStatus{
+				{Name: "c1", ImageID: "c1-img2-ID"},
+				{Name: "c2", ImageID: "c2-img1-ID"},
+			},
+		},
+	}
+
+	// stalePod is what gets passed to Refresh — it's a stale snapshot that still
+	// has the InPlaceUpdateState annotation with NextContainerImages.
+	// Before the fix, updateNextBatch would read from this stale pod.
+	// After the fix, it reads from the clone (storedPod) which has no annotation.
+	stalePod := storedPod.DeepCopy()
+	stalePod.Annotations = map[string]string{
+		appspub.InPlaceUpdateStateKey: util.DumpJSON(appspub.InPlaceUpdateState{
+			Revision:            "new-revision",
+			UpdateTimestamp:     aHourAgo,
+			NextContainerImages: map[string]string{"c2": "c2-img2"},
+		}),
+	}
+
+	cli := fake.NewClientBuilder().WithObjects(storedPod).Build()
+	ctrl := New(cli, revisionadapter.NewDefaultImpl())
+
+	res := ctrl.Refresh(stalePod, nil)
+	if res.RefreshErr != nil {
+		t.Fatalf("Refresh should not fail, got: %v", res.RefreshErr)
+	}
+
+	// Verify the stored pod was NOT modified — updateNextBatch should have
+	// returned early because the clone has no InPlaceUpdateState annotation.
+	got := &v1.Pod{}
+	if err := cli.Get(context.TODO(), types.NamespacedName{Name: storedPod.Name}, got); err != nil {
+		t.Fatalf("failed to get pod: %v", err)
+	}
+	if got.Spec.Containers[1].Image != "c2-img1" {
+		t.Fatalf("expected c2 image to remain c2-img1 (unchanged), got %s", got.Spec.Containers[1].Image)
+	}
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Fixes a bug in `updateNextBatch` (`pkg/util/inplaceupdate/inplace_update.go`) where `InPlaceUpdateState` is read from the original stale `pod` argument instead of the freshly-fetched `clone` inside the `retry.RetryOnConflict` loop.

The function correctly fetches a fresh pod via `GetPod` at the top of each retry, but then reads the state annotation from the original `pod`:

```go
clone, err := c.podAdapter.GetPod(pod.Namespace, pod.Name)  // fresh ✓
// ...
if stateStr, ok := appspub.GetInPlaceUpdateState(pod); !ok { // stale ✗
```
On conflict retries, the NextContainerImages, NextContainerRefMetadata, and NextContainerResources are never refreshed, so the retry patches the pod using outdated batch info. This can apply wrong container images or leave pods stuck in Updating state during multi-batch in-place updates.

The fix changes pod → clone on that line, matching the correct pattern already used in finishGracePeriod (lines 203, 213 in the same file).

**Ⅱ. Does this pull request fix one issue?**
fixes #2399

**Ⅲ. Describe how to verify it**
Look at the one-line diff — GetInPlaceUpdateState(pod) → GetInPlaceUpdateState(clone).
Compare with finishGracePeriod in the same file (line 203, 213), which already reads from clone correctly.
Existing unit tests in inplace_update_test.go continue to pass since the non-retry path behavior is unchanged.
To test the retry path specifically: trigger a multi-batch in-place update where a conflict occurs on the first UpdatePod call inside updateNextBatch, and verify the retried attempt reads the latest state from the freshly-fetched pod.

**Ⅳ. Special notes for reviews**
This is a single-character fix (pod → clone). The bug only manifests on conflict retries during multi-batch in-place updates, which makes it hard to catch in normal testing. The sibling function finishGracePeriod already follows the correct pattern, so this was likely just an oversight from when updateNextBatch was originally written.

**Note:** While this bug primarily manifested during conflict retries, the added test validates the broader behavior ensuring updateNextBatch always reads from the freshly-fetched clone rather than any stale pod snapshot.

