### PR TITLE
fix: replace os.Exit in goroutine with context cancellation for graceful shutdown

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"flag"
 	"net/http"
 	_ "net/http/pprof"
@@ -164,7 +165,9 @@ func main() {
 		})
 	}
 
-	ctx := ctrl.SetupSignalHandler()
+	signalCtx := ctrl.SetupSignalHandler()
+	ctx, cancel := context.WithCancel(signalCtx)
+	defer cancel()
 	cfg := ctrl.GetConfigOrDie()
 	setRestConfig(cfg)
 	cfg.UserAgent = "kruise-manager"
@@ -256,15 +259,17 @@ func main() {
 
 	go func() {
 		setupLog.Info("wait webhook ready")
-		if err = webhook.WaitReady(); err != nil {
+		if err := webhook.WaitReady(ctx); err != nil {
 			setupLog.Error(err, "unable to wait webhook ready")
-			os.Exit(1)
+			cancel()
+			return
 		}
 
 		setupLog.Info("setup controllers")
-		if err = controller.SetupWithManager(mgr); err != nil {
+		if err := controller.SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to setup controllers")
-			os.Exit(1)
+			cancel()
+			return
 		}
 	}()
 

--- a/pkg/webhook/server.go
+++ b/pkg/webhook/server.go
@@ -133,10 +133,16 @@ func Checker(req *http.Request) error {
 	return health.Checker(req)
 }
 
-func WaitReady() error {
+func WaitReady(ctx context.Context) error {
 	startTS := time.Now()
 	var err error
 	for {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("context canceled while waiting for webhook ready: %w", ctx.Err())
+		default:
+		}
+
 		duration := time.Since(startTS)
 		if err = Checker(nil); err == nil {
 			return nil
@@ -147,5 +153,4 @@ func WaitReady() error {
 		}
 		time.Sleep(time.Second * 2)
 	}
-
 }

--- a/pkg/webhook/server_test.go
+++ b/pkg/webhook/server_test.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2024 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestWaitReadyCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // instantly cancel the context
+
+	err := WaitReady(ctx)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected error to wrap context.Canceled, got: %v", err)
+	}
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Two related problems in the startup path:

**1. `os.Exit(1)` in goroutine leaks the leader election lease**

The goroutine at `main.go:257` that waits for webhook readiness and sets up controllers calls `os.Exit(1)` on failure. This kills the process immediately — deferred cleanup never runs, the manager's graceful shutdown is skipped, and the leader election lease is never released. With the default `leaseDuration` of 15s, no other replica can take over until the lease expires on its own.

**2. `WaitReady()` is an infinite loop with no exit condition**

`WaitReady` in `pkg/webhook/server.go` loops forever polling `Checker()` with a 2-second sleep. If the health check never passes (e.g. bad TLS cert, webhook server failed to bind), this goroutine spins indefinitely. Controllers never get set up, but the manager keeps running and renewing the leader lease — so you get a leader that holds the lock but does nothing useful.

**What this PR changes:**

- Wraps the signal handler context with `context.WithCancel` to get a `cancel` function
- Replaces `os.Exit(1)` in the goroutine with `cancel()` + `return`, which triggers the manager's graceful shutdown path (releasing the leader lease, draining queues, etc.)
- Updates `WaitReady` to accept a `context.Context` so it can exit cleanly when the context is cancelled

### Ⅱ. Does this pull request fix one issue?

fixes #2401 

### Ⅲ. Describe how to verify it

1. Review the diff — the changes are straightforward and localized to `main.go` and `pkg/webhook/server.go`.
2. Verify the `os.Exit(1)` calls in the goroutine are replaced with `cancel()` + `return`, while `os.Exit(1)` calls in the main goroutine (pre-manager startup) are intentionally left unchanged since those run before leader election.
3. Verify `WaitReady` now checks `ctx.Done()` at the top of each loop iteration.
4. To test the graceful shutdown path: cause `controller.SetupWithManager` to fail and confirm the manager exits cleanly and the leader lease is released immediately (rather than held for the full TTL).

### Ⅳ. Special notes for reviews

- The `os.Exit(1)` calls **outside** the goroutine (lines 179–247) are intentionally left as-is. Those run in the main goroutine before `mgr.Start()`, so leader election hasn't started yet and there's no lease to leak.
- `WaitReady`'s signature changed from `WaitReady()` to `WaitReady(ctx context.Context)` — the only caller is in `main.go`, which is updated in the same commit.
