### PR TITLE
fix(client): Handle kube version minor suffixes safely

### DIFF
--- a/pkg/client/registry.go
+++ b/pkg/client/registry.go
@@ -17,6 +17,9 @@ var (
 	defaultGenericClient *GenericClientset
 
 	curVersion = &version.Info{Major: "1", Minor: "30"}
+
+	resizeSubresourceVersion = semver.New("1.32.0")
+	leadingDigitsRegexp     = regexp.MustCompile(`^(\d+)`)
 )
 
 // NewRegistry creates clientset by client-go
@@ -68,13 +71,7 @@ func ShouldUpdateResourceByResize() bool {
 		return false
 	}
 
-	targetSemver, err := semver.NewVersion("1.32.0")
-	if err != nil {
-		klog.ErrorS(err, "Failed to parse target k8s version")
-		return false
-	}
-
-	return currentSemver.Compare(*targetSemver) >= 0
+	return currentSemver.Compare(*resizeSubresourceVersion) >= 0
 }
 
 func sanitizeVersion(v string) string {
@@ -83,8 +80,7 @@ func sanitizeVersion(v string) string {
 		return "0"
 	}
 
-	re := regexp.MustCompile(`^(\d+)`)
-	matches := re.FindStringSubmatch(v)
+	matches := leadingDigitsRegexp.FindStringSubmatch(v)
 	if len(matches) > 1 {
 		return matches[1]
 	}

--- a/pkg/client/registry.go
+++ b/pkg/client/registry.go
@@ -2,10 +2,13 @@ package client
 
 import (
 	"fmt"
+	"regexp"
+	"strings"
 
 	"github.com/coreos/go-semver/semver"
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
 )
 
 var (
@@ -55,5 +58,36 @@ func GetCurrentServerVersion() *version.Info {
 // ShouldUpdateResourceByResize returns whether should update resource by resize
 // The resize sub-resource was introduced in version 1.32, https://github.com/kubernetes/kubernetes/pull/128266
 func ShouldUpdateResourceByResize() bool {
-	return semver.New(fmt.Sprintf("%s.%s.0", curVersion.Major, curVersion.Minor)).Compare(*semver.New("1.32.0")) >= 0
+	major := sanitizeVersion(curVersion.Major)
+	minor := sanitizeVersion(curVersion.Minor)
+
+	versionStr := fmt.Sprintf("%s.%s.0", major, minor)
+	currentSemver, err := semver.NewVersion(versionStr)
+	if err != nil {
+		klog.ErrorS(err, "Failed to parse current k8s version", "version", versionStr, "originalMajor", curVersion.Major, "originalMinor", curVersion.Minor)
+		return false
+	}
+
+	targetSemver, err := semver.NewVersion("1.32.0")
+	if err != nil {
+		klog.ErrorS(err, "Failed to parse target k8s version")
+		return false
+	}
+
+	return currentSemver.Compare(*targetSemver) >= 0
+}
+
+func sanitizeVersion(v string) string {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return "0"
+	}
+
+	re := regexp.MustCompile(`^(\d+)`)
+	matches := re.FindStringSubmatch(v)
+	if len(matches) > 1 {
+		return matches[1]
+	}
+
+	return "0"
 }

--- a/pkg/client/registry_test.go
+++ b/pkg/client/registry_test.go
@@ -1,0 +1,26 @@
+package client
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/version"
+)
+
+func TestShouldUpdateResourceByResizeWithKubectlVersionOutput(t *testing.T) {
+	originalVersion := curVersion
+	defer func() {
+		curVersion = originalVersion
+	}()
+
+	curVersion = &version.Info{
+		Major:      "1",
+		Minor:      "19+",
+		GitVersion: "v1.19.16-vke.2",
+		GitCommit:  "fd3942548f7530629133e9fd9e7e86e0276ae834",
+		Platform:   "linux/amd64",
+	}
+
+	if ShouldUpdateResourceByResize() {
+		t.Fatalf("expected resize subresource to be disabled for kubernetes %s.%s", curVersion.Major, curVersion.Minor)
+	}
+}

--- a/pkg/client/registry_test.go
+++ b/pkg/client/registry_test.go
@@ -15,12 +15,24 @@ func TestShouldUpdateResourceByResizeWithKubectlVersionOutput(t *testing.T) {
 	curVersion = &version.Info{
 		Major:      "1",
 		Minor:      "19+",
-		GitVersion: "v1.19.16-vke.2",
-		GitCommit:  "fd3942548f7530629133e9fd9e7e86e0276ae834",
+		GitVersion: "v1.19.16-xke.2",
+		GitCommit:  "fd3942548f7530629133e9fd9e7e86e0276ae666",
 		Platform:   "linux/amd64",
 	}
 
 	if ShouldUpdateResourceByResize() {
 		t.Fatalf("expected resize subresource to be disabled for kubernetes %s.%s", curVersion.Major, curVersion.Minor)
+	}
+
+	curVersion = &version.Info{
+		Major:      "1",
+		Minor:      "32+",
+		GitVersion: "v1.32.0-xke.1",
+		GitCommit:  "fd3942548f7530629133e9fd9e7e86e0276ae666",
+		Platform:   "linux/amd64",
+	}
+
+	if !ShouldUpdateResourceByResize() {
+		t.Fatalf("expected resize subresource to be enabled for kubernetes %s.%s", curVersion.Major, curVersion.Minor)
 	}
 }


### PR DESCRIPTION
    Sanitize Kubernetes major and minor version strings before semver comparison
    so clusters that report values like 1.19+ no longer panic in resize gating.

    Add a regression test covering the kubectl version output seen in the field.

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fix #2404 

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

