### PR TITLE
 Fix: prevent active counter inflation on failed BroadcastJob pod creation

### DIFF
--- a/pkg/controller/broadcastjob/broadcastjob_controller.go
+++ b/pkg/controller/broadcastjob/broadcastjob_controller.go
@@ -460,6 +460,7 @@ func (r *ReconcileBroadcastJob) reconcilePods(job *appsv1beta1.BroadcastJob,
 					if err != nil {
 						defer utilruntime.HandleError(err)
 						errCh <- err
+						return
 					}
 					// If succeed, increase active counter
 					activeLock.Lock()

--- a/pkg/controller/broadcastjob/broadcastjob_controller_test.go
+++ b/pkg/controller/broadcastjob/broadcastjob_controller_test.go
@@ -676,3 +676,42 @@ func patchPodName(pod *v1.Pod) {
 		pod.Name = pod.GenerateName + string(uuid.NewUUID())
 	}
 }
+
+func TestReconcileJobCreatePodFailureDoesNotInflateActiveCount(t *testing.T) {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(appsv1beta1.AddToScheme(scheme))
+	utilruntime.Must(v1.AddToScheme(scheme))
+
+	p := intstr.FromInt(2)
+	job := createJob("job-fail", p)
+
+	node1 := createNode("node1")
+	node2 := createNode("node2")
+
+	// Create 1 pod on node1
+	pod1 := createPod(job, "pod1", "node1", v1.PodRunning)
+
+	reconcileJob := createReconcileJob(scheme, job, node1, node2, pod1)
+	
+	// Force create to fail by setting the new pod's name to the existing pod's name.
+	reconcileJob.podModifier = func(pod *v1.Pod) {
+		pod.Name = "pod1"
+	}
+
+	request := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      "job-fail",
+			Namespace: "default",
+		},
+	}
+
+	_, err := reconcileJob.Reconcile(context.TODO(), request)
+	assert.Error(t, err)
+
+	retrievedJob := &appsv1beta1.BroadcastJob{}
+	err = reconcileJob.Get(context.TODO(), request.NamespacedName, retrievedJob)
+	assert.NoError(t, err)
+
+	// active should be 1 (the original pod), not 2, because the creation on node2 failed
+	assert.Equal(t, int32(1), retrievedJob.Status.Active)
+}


### PR DESCRIPTION


<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
This PR fixes a bug in the BroadcastJob controller where the active pod counter is incorrectly incremented even if pod creation fails.

In reconcilePods(), pod creation errors are sent to the errCh but the goroutine fails to return. This causes execution to fall through and execute active++. When this happens, job.Status.Active is inflated, which artificially limits parallelism - active on subsequent reconcile loops. In extreme cases, this causes the BroadcastJob to stall completely, unable to deploy to remaining nodes.

This adds the missing return statement so the active counter accurately reflects successfully launched (or timing out) pods.


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #2414
### Ⅲ. Describe how to verify it
- Create a BroadcastJob with a desired node count > 1.
- Introduce a temporary mechanism to force pod creation to fail (e.g. by using a mutating webhook that predictably rejects the pods for this specific job, or intentionally misconfiguring the pod template such that the API server rejects it).
- Observe the status of the BroadcastJob.
- Before the fix: The status.active counter increments, matching the number of failures, and the job eventually stalls when active equals parallelism.
- After the fix: The status.active counter remains 0, accurately reflecting that no pods were scheduled/running, and the controller correctly relies on subsequent reconcile loops rather than inflating the counter.


### Ⅳ. Special notes for reviews
This PR addresses a missing return statement in the reconcilePods goroutine within pkg/controller/broadcastjob/broadcastjob_controller.go.
Currently, when r.createPodOnNode() fails with an error (and it is not a timeout error), the error is sent to errCh and logged, but execution proceeds to the active++ block because there is no return statement. This inflates job.Status.Active, causing the controller to compute an artificially low available quota (parallelism - active), which ultimately throttles or halts further pod creation entirely.
