### PR TITLE
Fix: Prevent SidecarSet from updating zero-value Pod on Get() failures

### DIFF
--- a/pkg/controller/sidecarset/sidecarset_processor.go
+++ b/pkg/controller/sidecarset/sidecarset_processor.go
@@ -205,6 +205,7 @@ func (p *Processor) updatePodSidecarAndHash(control sidecarcontrol.SidecarContro
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		if err := p.Client.Get(context.TODO(), types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}, podClone); err != nil {
 			klog.ErrorS(err, "SidecarSet got updated pod from client failed", "sidecarSet", klog.KObj(sidecarSet), "pod", klog.KObj(pod))
+			return err
 		}
 		// update pod sidecar container
 		updatePodSidecarContainer(control, podClone)

--- a/pkg/controller/sidecarset/sidecarset_processor_test.go
+++ b/pkg/controller/sidecarset/sidecarset_processor_test.go
@@ -538,3 +538,22 @@ func TestTruncateHistory(t *testing.T) {
 		t.Fatalf("expected name %s, actual : %s", getName(15), rvs[9].Name)
 	}
 }
+
+func TestUpdatePodSidecarAndHashGetError(t *testing.T) {
+	sidecarSetInput := sidecarSetDemo.DeepCopy()
+	podInput := podDemo.DeepCopy()
+
+	// Build a fake client that contains the sidecarSet but NOT the pod.
+	// This forces p.Client.Get() inside updatePodSidecarAndHash to fail
+	// with a "not found" error, exercising the early-return error path.
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(sidecarSetInput).
+		WithStatusSubresource(&appsv1beta1.SidecarSet{}).Build()
+	processor := NewSidecarSetProcessor(fakeClient, record.NewFakeRecorder(10))
+
+	control := sidecarcontrol.New(sidecarSetInput)
+	err := processor.updatePodSidecarAndHash(control, podInput)
+	if err == nil {
+		t.Fatal("expected error from updatePodSidecarAndHash when pod Get() fails, but got nil")
+	}
+}


### PR DESCRIPTION
This prevents invalid update requests under API server lag by adding an early return on p.Client.Get errors. Fixes #2416

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
This PR stops the SidecarSet controller from proceeding to manipulate and update a partially uninitialized corev1.Pod object when the client retrieval (Get()) fails.

Prior to this fix, if p.Client.Get failed during updatePodSidecarAndHash (e.g. transient API blip), the error was logged but swallowed. The code would then mutate the zero-valued podClone and pass it to p.Client.Update(), resulting in guaranteed-to-fail API calls and confusing validation errors. Adding return err ensures that we fail-fast so the established backoff retry mechanisms can take over gracefully.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #2416
### Ⅲ. Describe how to verify it
I- ntroduce transient faults (e.g., fault injection returning synthetic errors intermittently) to p.Client.Get during a SidecarSet reconciliation.
- Monitor controller logs.
- Before fix: You will see the SidecarSet got updated pod from client failed log message immediately followed by API server validation objections about missing required Pod fields during Update().
- After fix: You will only see the read-related failure appropriately surfaced and the retry-delay will trigger. The subsequent confusing Update calls vanish.

### Ⅳ. Special notes for reviews
This is a straightforward one-line addition (return err) in pkg/controller/sidecarset/sidecarset_processor.go inside the RetryOnConflict block within updatePodSidecarAndHash(). All unit tests for the sidecarset package remain passing.

