### PR TITLE
Security: Harden file and directory permissions for webhook certificates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ golangci-lint: ## Download golangci-lint locally if necessary.
 
 GINKGO = $(shell pwd)/bin/ginkgo
 ginkgo: ## Download ginkgo locally if necessary.
-	$(call go-get-tool,$(GINKGO),github.com/onsi/ginkgo/v2/ginkgo@latest)
+	$(call go-get-tool,$(GINKGO),github.com/onsi/ginkgo/v2/ginkgo@v2.27.5)
 
 # go-get-tool will 'go get' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))

--- a/pkg/webhook/util/writer/fs.go
+++ b/pkg/webhook/util/writer/fs.go
@@ -123,8 +123,8 @@ func prepareToWrite(dir string) error {
 	switch {
 	case os.IsNotExist(err):
 		klog.Info("cert directory doesn't exist, creating", "directory", dir)
-		// TODO: figure out if we can reduce the permission. (Now it's 0777)
-		err = os.MkdirAll(dir, 0777)
+		// Reduced directory permissions from 0777 to 0750 for better security.
+		err = os.MkdirAll(dir, 0750)
 		if err != nil {
 			return fmt.Errorf("can't create dir: %v", dir)
 		}
@@ -198,31 +198,31 @@ func ensureExist(dir string) error {
 }
 
 func certToProjectionMap(cert *generator.Artifacts) map[string]atomic.FileProjection {
-	// TODO: figure out if we can reduce the permission. (Now it's 0666)
+	// Reduced file permissions from 0666 for better security.
 	return map[string]atomic.FileProjection{
 		CAKeyName: {
 			Data: cert.CAKey,
-			Mode: 0666,
+			Mode: 0600,
 		},
 		CACertName: {
 			Data: cert.CACert,
-			Mode: 0666,
+			Mode: 0640,
 		},
 		ServerCertName: {
 			Data: cert.Cert,
-			Mode: 0666,
+			Mode: 0640,
 		},
 		ServerCertName2: {
 			Data: cert.Cert,
-			Mode: 0666,
+			Mode: 0640,
 		},
 		ServerKeyName: {
 			Data: cert.Key,
-			Mode: 0666,
+			Mode: 0600,
 		},
 		ServerKeyName2: {
 			Data: cert.Key,
-			Mode: 0666,
+			Mode: 0600,
 		},
 	}
 }

--- a/pkg/webhook/util/writer/fs_test.go
+++ b/pkg/webhook/util/writer/fs_test.go
@@ -87,6 +87,12 @@ func TestCertToProjectionMap(t *testing.T) {
 	g.Expect(projectionMap).To(gomega.HaveKey(ServerCertName))
 	g.Expect(projectionMap[ServerCertName].Mode).To(gomega.Equal(int32(0640)))
 	g.Expect(projectionMap[ServerCertName].Data).To(gomega.Equal([]byte("server-cert")))
+
+	g.Expect(projectionMap).To(gomega.HaveKey(ServerKeyName2))
+	g.Expect(projectionMap[ServerKeyName2].Mode).To(gomega.Equal(int32(0600)))
+
+	g.Expect(projectionMap).To(gomega.HaveKey(ServerCertName2))
+	g.Expect(projectionMap[ServerCertName2].Mode).To(gomega.Equal(int32(0640)))
 }
 
 func TestFSCertWriter(t *testing.T) {

--- a/pkg/webhook/util/writer/fs_test.go
+++ b/pkg/webhook/util/writer/fs_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2024 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package writer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/onsi/gomega"
+	"github.com/openkruise/kruise/pkg/webhook/util/generator"
+)
+
+func TestPrepareToWrite(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	tmpDir, err := os.MkdirTemp("", "webhook-certs-*")
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	defer os.RemoveAll(tmpDir)
+
+	// Test with a completely new directory that doesn't exist
+	newDir := filepath.Join(tmpDir, "new-certs")
+	err = prepareToWrite(newDir)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	// Verify directory was created with the correct permissions
+	info, err := os.Stat(newDir)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(info.IsDir()).To(gomega.BeTrue())
+	// Depending on umask, the permission might be 0750 or less, we just check it exists.
+	
+	// Test again with an existing directory
+	err = prepareToWrite(newDir)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	// Write dummy files and verify prepareToWrite cleans non-symlinks
+	dummyFile := filepath.Join(newDir, ServerCertName)
+	err = os.WriteFile(dummyFile, []byte("dummy cert"), 0640)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	
+	err = prepareToWrite(newDir)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	
+	// File should be deleted because it was not a symlink
+	_, err = os.Stat(dummyFile)
+	g.Expect(os.IsNotExist(err)).To(gomega.BeTrue())
+}
+
+func TestCertToProjectionMap(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	
+	artifacts := &generator.Artifacts{
+		CAKey:  []byte("ca-key"),
+		CACert: []byte("ca-cert"),
+		Key:    []byte("server-key"),
+		Cert:   []byte("server-cert"),
+	}
+	
+	projectionMap := certToProjectionMap(artifacts)
+	
+	// Check keys and their modes
+	g.Expect(projectionMap).To(gomega.HaveKey(CAKeyName))
+	g.Expect(projectionMap[CAKeyName].Mode).To(gomega.Equal(int32(0600)))
+	g.Expect(projectionMap[CAKeyName].Data).To(gomega.Equal([]byte("ca-key")))
+
+	g.Expect(projectionMap).To(gomega.HaveKey(CACertName))
+	g.Expect(projectionMap[CACertName].Mode).To(gomega.Equal(int32(0640)))
+	g.Expect(projectionMap[CACertName].Data).To(gomega.Equal([]byte("ca-cert")))
+
+	g.Expect(projectionMap).To(gomega.HaveKey(ServerKeyName))
+	g.Expect(projectionMap[ServerKeyName].Mode).To(gomega.Equal(int32(0600)))
+	g.Expect(projectionMap[ServerKeyName].Data).To(gomega.Equal([]byte("server-key")))
+
+	g.Expect(projectionMap).To(gomega.HaveKey(ServerCertName))
+	g.Expect(projectionMap[ServerCertName].Mode).To(gomega.Equal(int32(0640)))
+	g.Expect(projectionMap[ServerCertName].Data).To(gomega.Equal([]byte("server-cert")))
+}
+
+func TestFSCertWriter(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	tmpDir, err := os.MkdirTemp("", "webhook-certs-*")
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	defer os.RemoveAll(tmpDir)
+
+	writer, err := NewFSCertWriter(FSCertWriterOptions{
+		Path: tmpDir,
+	})
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	dnsName := "kruise-webhook-service.svc"
+	certs, changed, err := writer.EnsureCert(dnsName)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(changed).To(gomega.BeTrue())
+	g.Expect(certs).NotTo(gomega.BeNil())
+	
+	// Try reading the written certs
+	certs2, changed2, err := writer.EnsureCert(dnsName)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(changed2).To(gomega.BeFalse())
+	g.Expect(certs2.Cert).To(gomega.Equal(certs.Cert))
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

This PR hardens the security of the webhook certificate writer by reducing overly permissive file and directory permissions in `pkg/webhook/util/writer/fs.go`. It also addresses `TODO` comments left by developers regarding whether the permissions could be reduced.

Changes made:
- Reduced webhook certificate directory permissions from `0777` (world-writable) to `0750`.
- Reduced generated private key permissions (`CAKey`, `ServerKey`, `ServerKey2`) from `0666` (world-readable/writable) to `0600`.
- Reduced generated public certificate permissions (`CACert`, `ServerCert`, `ServerCert2`) from `0666` to `0640`.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

*(Note: If you ended up creating an issue with the previous template, replace `NONE` with `fixes #<YOUR_ISSUE_NUMBER>`)*

### Ⅲ. Describe how to verify it

1. Run the package unit tests to verify they are still successfully able to read/write the certs: 
   ```bash
   go test ./pkg/webhook/util/writer/...
