### PR TITLE
Fix durationstore race condition

### DIFF
--- a/pkg/util/requeueduration/duration.go
+++ b/pkg/util/requeueduration/duration.go
@@ -38,11 +38,10 @@ func (dm *DurationStore) Push(key string, newDuration time.Duration) {
 }
 
 func (dm *DurationStore) Pop(key string) time.Duration {
-	value, ok := dm.store.Load(key)
+	value, ok := dm.store.LoadAndDelete(key)
 	if !ok {
 		return 0
 	}
-	defer dm.store.Delete(key)
 	requeueDuration, ok := value.(*Duration)
 	if !ok {
 		return 0


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

This PR fixes a silent concurrency race condition in the `DurationStore` component (`pkg/util/requeueduration/duration.go`).

Previously, `DurationStore.Pop()` used a non-atomic `Load()` coupled with a `defer Delete()` pattern. If a concurrent goroutine (e.g. an event handler) invoked `Push()` for the same key right after the `Load()` but before the deferred `Delete()`, the new duration would be incorrectly deleted. This causes controllers to silently lose their requeue backoff durations, stalling reconciliations that should have retried.

This commit refactors `Pop()` to use Go's atomic `sync.Map.LoadAndDelete()` method, entirely eliminating the data race.

### Ⅱ. Does this pull request fix one issue?

fixes #2427 

### Ⅲ. Describe how to verify it

1. Ensure the project compiles cleanly:
   `go build main.go`

2. Run the `requeueduration` test suite with the Go race detector enabled:
   `go test -v -race ./pkg/util/requeueduration/...`

### Ⅳ. Special notes for reviews

- `sync.Map.LoadAndDelete()` was introduced in Go 1.15 and is fully supported in OpenKruise's minimum supported Go versions.
- The change is a single-line fix with no API surface changes, making it low risk.
- `DurationStore` is a shared utility used by multiple controllers (`DaemonSet`, `CloneSet`, etc.), so this fix improves stability across the entire controller framework.



