### PR TITLE
fix: correct annotation cache iteration in PersistentPodState controller

### DIFF
--- a/pkg/controller/persistentpodstate/persistent_pod_state_controller.go
+++ b/pkg/controller/persistentpodstate/persistent_pod_state_controller.go
@@ -231,7 +231,7 @@ func (r *ReconcilePersistentPodState) Reconcile(_ context.Context, req ctrl.Requ
 				currentKeys.Insert(key)
 			}
 			currentAns := sets.NewString()
-			for _, key := range podState.Annotations {
+			for key := range podState.Annotations {
 				currentAns.Insert(key)
 			}
 

--- a/pkg/controller/persistentpodstate/persistent_pod_state_controller_test.go
+++ b/pkg/controller/persistentpodstate/persistent_pod_state_controller_test.go
@@ -492,6 +492,83 @@ func TestReconcilePersistentPodState(t *testing.T) {
 				return staticIP
 			},
 		},
+		{
+			name: "kruise statefulset, 10 running pod with persistent annotations",
+			getSts: func() (*apps.StatefulSet, *appsv1beta1.StatefulSet) {
+				return nil, kruiseStsDemo.DeepCopy()
+			},
+			getPods: func() []*corev1.Pod {
+				pods := make([]*corev1.Pod, 0)
+				for i := 0; i < 10; i++ {
+					pod := podDemo.DeepCopy()
+					pod.Name = fmt.Sprintf("%s-%d", kruiseStsDemo.Name, i)
+					pod.OwnerReferences[0].UID = kruiseStsDemo.UID
+					pod.Status = corev1.PodStatus{
+						Phase: corev1.PodRunning,
+						Conditions: []corev1.PodCondition{
+							{
+								Type:   corev1.PodReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					}
+					pod.Annotations["test-annotation-key"] = fmt.Sprintf("test-annotation-value-%d", i)
+					pods = append(pods, pod)
+				}
+				return pods
+			},
+			getNodes: func() []*corev1.Node {
+				nodes := make([]*corev1.Node, 0)
+				for i := 0; i < 10; i++ {
+					node := nodeDemo.DeepCopy()
+					node.Name = fmt.Sprintf("node-%d", i)
+					node.Labels[podStateZoneTopologyLabel] = fmt.Sprintf("cn-beijing-%d", i)
+					node.Labels[podStateNodeTopologyLabel] = fmt.Sprintf("kube-resource011162007216-%d", i)
+					nodes = append(nodes, node)
+				}
+				return nodes
+			},
+			getPersistentPodState: func() *appsv1alpha1.PersistentPodState {
+				staticIP := staticIPDemo.DeepCopy()
+				staticIP.Spec.PersistentPodAnnotations = []appsv1alpha1.PersistentPodAnnotation{
+					{Key: "test-annotation-key"},
+				}
+				for i := 0; i < 5; i++ {
+					key := fmt.Sprintf("%s-%d", kruiseStsDemo.Name, i)
+					staticIP.Status.PodStates[key] = appsv1alpha1.PodState{
+						NodeName: fmt.Sprintf("node-%d", i),
+						NodeTopologyLabels: map[string]string{
+							podStateZoneTopologyLabel: fmt.Sprintf("cn-beijing-%d", i),
+							podStateNodeTopologyLabel: fmt.Sprintf("kube-resource011162007216-%d", i),
+						},
+						Annotations: map[string]string{
+							"test-annotation-key": fmt.Sprintf("test-annotation-value-%d", i),
+						},
+					}
+				}
+				return staticIP
+			},
+			exceptPersistentPodState: func() *appsv1alpha1.PersistentPodState {
+				staticIP := staticIPDemo.DeepCopy()
+				staticIP.Spec.PersistentPodAnnotations = []appsv1alpha1.PersistentPodAnnotation{
+					{Key: "test-annotation-key"},
+				}
+				for i := 0; i < 10; i++ {
+					key := fmt.Sprintf("%s-%d", kruiseStsDemo.Name, i)
+					staticIP.Status.PodStates[key] = appsv1alpha1.PodState{
+						NodeName: fmt.Sprintf("node-%d", i),
+						NodeTopologyLabels: map[string]string{
+							podStateZoneTopologyLabel: fmt.Sprintf("cn-beijing-%d", i),
+							podStateNodeTopologyLabel: fmt.Sprintf("kube-resource011162007216-%d", i),
+						},
+						Annotations: map[string]string{
+							"test-annotation-key": fmt.Sprintf("test-annotation-value-%d", i),
+						},
+					}
+				}
+				return staticIP
+			},
+		},
 	}
 
 	for _, cs := range cases {


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
This PR fixes a performance bug in the `PersistentPodState` controller where the cache-skip optimization never fired for pods using `PersistentPodAnnotations`. 
Previously, the controller mistakenly used a `for _, key := range podState.Annotations` loop, which inserted the annotation **values** (e.g., `10.244.0.5`) into the `currentAns` set instead of the **keys** (e.g., `cni.projectcalico.org/podIP`). When it later compared these values against the desired keys to check if the pod's state had already been recorded, the comparison always failed. This resulted in unnecessary Node API reads and status updates on *every single reconcile cycle* for any StatefulSet utilizing persistent annotations.
This PR correctly changes the iteration to `for key := range podState.Annotations`, bringing it in line with the correct pattern already used for `NodeTopologyLabels`. It also introduces test coverage for the `PersistentPodAnnotations` feature to prevent regressions.
### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #2439 
### Ⅲ. Describe how to verify it
1. Review the newly added unit test `kruise statefulset, 10 running pod with persistent annotations` in `persistent_pod_state_controller_test.go`, which explicitly verifies the caching behavior.
2. Run `make test` to ensure all tests pass.
3. Deploy a StatefulSet paired with a `PersistentPodState` defining `persistentPodAnnotations`. After pods become ready, observe controller logs/API server audit logs to ensure `r.getPodState()` (which fetches the Node) and `updatePersistentPodStateStatus()` are correctly skipped on subsequent reconciles.
### Ⅳ. Special notes for reviews
NONE