### PR TITLE
fix: resolve HTTP connection and FD leak in webhook health checker

### DIFF
--- a/pkg/webhook/util/health/checker.go
+++ b/pkg/webhook/util/health/checker.go
@@ -131,6 +131,9 @@ func Checker(_ *http.Request) error {
 
 	lock.Lock()
 	defer lock.Unlock()
-	_, err = client.Do(req)
+	resp, err := client.Do(req)
+	if err == nil && resp != nil {
+		defer resp.Body.Close()
+	}
 	return err
 }

--- a/pkg/webhook/util/health/checker_test.go
+++ b/pkg/webhook/util/health/checker_test.go
@@ -1,0 +1,66 @@
+package health
+
+import (
+	"encoding/pem"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestChecker(t *testing.T) {
+	// Start a dummy TLS test server
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	// Extract the port and set it as WEBHOOK_PORT
+	port := ts.Listener.Addr().(*net.TCPAddr).Port
+	os.Setenv("WEBHOOK_PORT", strconv.Itoa(port))
+	defer os.Unsetenv("WEBHOOK_PORT")
+
+	// create a temp dir for dummy cert
+	tempDir, err := os.MkdirTemp("", "kruise-cert")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	cert := ts.Certificate()
+	dummyCertPath := filepath.Join(tempDir, "ca-cert.pem")
+	certOut, err := os.Create(dummyCertPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}); err != nil {
+		t.Fatal(err)
+	}
+	certOut.Close()
+
+	// Override caCertFilePath
+	caCertFilePath = dummyCertPath
+
+	// First call to trigger onceWatch
+	Checker(nil)
+
+	// Now client is initialized. Override Transport to skip verify so localhost cert from httptest works
+	lock.Lock()
+	if client != nil && client.Transport != nil {
+		client.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify = true
+	}
+	lock.Unlock()
+
+	// Second call should succeed, hitting `defer resp.Body.Close()`
+	err = Checker(nil)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	
+	// Wait a bit to ensure background watcher doesn't cause issues on exit
+	time.Sleep(100 * time.Millisecond)
+}


### PR DESCRIPTION
### PR Description

**What this PR does / why we need it**:
This PR resolves a critical file descriptor and memory leak within the `kruise-manager`'s webhook readiness probe. 

In `pkg/webhook/util/health/checker.go`, the `Checker` function initiates an HTTP request (`client.Do(req)`) to the internal `/healthz` endpoint. Previously, this code ignored the HTTP response object and failed to close the response body (`resp.Body.Close()`). Because `webhook.Checker` is registered as the `/readyz` probe for the controller manager, Kubelet invokes this function periodically (e.g., every 10 seconds). 

Leaving the response body unclosed causes the underlying HTTP connection to leak on every single readiness ping, eventually accumulating in the connection pool or `CLOSE_WAIT` state. Over time, this exhausts the controller's file descriptors and memory, leading to an inevitable crash. 

This PR implements the standard Go `net/http` pattern to cleanly capture the response and defer its closure if the request is successful.

**Which issue(s) this PR fixes**:
Fixes #2448 

**Special notes for your reviewer**:
This is a standard connection leak cleanup and is completely safe to merge. It has been tested locally to ensure it properly handles `nil` responses and resolves the steady growth of open file descriptors under load.
