### PR TITLE
fix(daemon): resolve runtime panic by using existing container ID instead of hardcoded index

### DIFF
--- a/pkg/daemon/containermeta/container_meta_controller.go
+++ b/pkg/daemon/containermeta/container_meta_controller.go
@@ -425,10 +425,10 @@ func (c *Controller) getRuntimeForPod(pod *v1.Pod) (criapi.RuntimeService, kuber
 	}
 
 	containerID := kubeletcontainer.ContainerID{}
-	if err := containerID.ParseString(pod.Status.ContainerStatuses[0].ContainerID); err != nil {
-		return nil, nil, fmt.Errorf("failed to parse containerID %s: %v", pod.Status.ContainerStatuses[0].ContainerID, err)
+	if err := containerID.ParseString(existingID); err != nil {
+		return nil, nil, fmt.Errorf("failed to parse containerID %s: %v", existingID, err)
 	} else if containerID.Type == "" {
-		return nil, nil, fmt.Errorf("no runtime name in containerID %s", pod.Status.ContainerStatuses[0].ContainerID)
+		return nil, nil, fmt.Errorf("no runtime name in containerID %s", existingID)
 	}
 
 	runtimeName := containerID.Type

--- a/pkg/daemon/containermeta/container_meta_controller_test.go
+++ b/pkg/daemon/containermeta/container_meta_controller_test.go
@@ -1,0 +1,117 @@
+package containermeta
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	criapi "k8s.io/cri-api/pkg/apis"
+	"github.com/openkruise/kruise/pkg/daemon/criruntime/imageruntime"
+)
+
+type mockRuntimeService struct {
+	criapi.RuntimeService
+}
+
+type mockRuntimeFactory struct{}
+
+func (m *mockRuntimeFactory) GetRuntimeServiceByName(name string) criapi.RuntimeService {
+	if name == "docker" || name == "containerd" {
+		return &mockRuntimeService{}
+	}
+	return nil
+}
+
+func (m *mockRuntimeFactory) GetImageService() imageruntime.ImageService {
+	return nil
+}
+
+func (m *mockRuntimeFactory) GetRuntimeService() criapi.RuntimeService {
+	return nil
+}
+
+func TestGetRuntimeForPod(t *testing.T) {
+	c := &Controller{
+		runtimeFactory: &mockRuntimeFactory{},
+	}
+
+	testCases := []struct {
+		name            string
+		pod             *v1.Pod
+		expectedRuntime bool
+		expectedErr     string
+	}{
+		{
+			name:            "empty container statuses",
+			pod:             &v1.Pod{},
+			expectedRuntime: false,
+			expectedErr:     "empty containerStatuses in pod status",
+		},
+		{
+			name: "no existing ID",
+			pod: &v1.Pod{
+				Status: v1.PodStatus{
+					ContainerStatuses: []v1.ContainerStatus{
+						{ContainerID: ""},
+					},
+				},
+			},
+			expectedRuntime: false,
+			expectedErr:     "",
+		},
+		{
+			name: "valid docker runtime",
+			pod: &v1.Pod{
+				Status: v1.PodStatus{
+					ContainerStatuses: []v1.ContainerStatus{
+						{ContainerID: ""},
+						{ContainerID: "docker://12345678"},
+					},
+				},
+			},
+			expectedRuntime: true,
+			expectedErr:     "",
+		},
+		{
+			name: "invalid container ID format",
+			pod: &v1.Pod{
+				Status: v1.PodStatus{
+					ContainerStatuses: []v1.ContainerStatus{
+						{ContainerID: "invalid-format"},
+					},
+				},
+			},
+			expectedRuntime: false,
+			expectedErr:     "failed to parse containerID",
+		},
+		{
+			name: "unknown runtime",
+			pod: &v1.Pod{
+				Status: v1.PodStatus{
+					ContainerStatuses: []v1.ContainerStatus{
+						{ContainerID: "unknown://123"},
+					},
+				},
+			},
+			expectedRuntime: false,
+			expectedErr:     "not found runtime service for unknown in daemon",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, runtime, err := c.getRuntimeForPod(tc.pod)
+			if tc.expectedErr != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tc.expectedErr)
+			} else {
+				assert.NoError(t, err)
+				if tc.expectedRuntime {
+					assert.NotNil(t, runtime)
+				} else {
+					assert.Nil(t, runtime)
+				}
+			}
+		})
+	}
+}

--- a/pkg/daemon/containermeta/container_meta_controller_test.go
+++ b/pkg/daemon/containermeta/container_meta_controller_test.go
@@ -3,10 +3,10 @@ package containermeta
 import (
 	"testing"
 
+	"github.com/openkruise/kruise/pkg/daemon/criruntime/imageruntime"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	criapi "k8s.io/cri-api/pkg/apis"
-	"github.com/openkruise/kruise/pkg/daemon/criruntime/imageruntime"
 )
 
 type mockRuntimeService struct {
@@ -95,6 +95,18 @@ func TestGetRuntimeForPod(t *testing.T) {
 			},
 			expectedRuntime: false,
 			expectedErr:     "not found runtime service for unknown in daemon",
+		},
+		{
+			name: "empty runtime type",
+			pod: &v1.Pod{
+				Status: v1.PodStatus{
+					ContainerStatuses: []v1.ContainerStatus{
+						{ContainerID: "://123"},
+					},
+				},
+			},
+			expectedRuntime: false,
+			expectedErr:     "no runtime name in containerID",
 		},
 	}
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR resolves an array index and parsing bug in `pkg/daemon/containermeta/container_meta_controller.go`. 
Previously, the `getRuntimeForPod` function correctly iterated over `pod.Status.ContainerStatuses` to find the first initialized container ID and stored it in the `existingID` variable. However, it subsequently ignored `existingID` and attempted to parse `pod.Status.ContainerStatuses[0].ContainerID` instead. 
If the 0-th container (e.g., an `initContainer`) had not fully initialized and had an empty `ContainerID`, `containerID.ParseString("")` would fail and cause the entire container meta sync logic to prematurely abort for the Pod. This PR correctly replaces the hardcoded `[0]` index with the validated `existingID` variable.
### Why is this PR needed?
Without this fix, `kruise-daemon` will fail to extract metadata for pods where the first container in the status array is uninitialized (such as long-running init containers). This breaks the sync loop and delays necessary container operations (like in-place updates) until the 0-th container finally gets a runtime ID.
### How to test this PR?
- Deploy Kruise daemon.
- Schedule a Pod with multiple containers where the first container in the array experiences a startup delay.
- Ensure that `kruise-daemon` logs do not throw a `failed to parse containerID` error, and that it successfully parses the runtime for subsequent containers that have valid IDs.
### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No
### Checklist
- [X] I have read the [Contributing Guidelines](https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md).
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes (N/A).
- [X] All new and existing tests passed.
- [X] My commits are signed (DCO).