### PR TITLE
test: fix fuzzer logic for ImageListPullJob status generation

### DIFF
--- a/test/fuzz/imagelistpulljob.go
+++ b/test/fuzz/imagelistpulljob.go
@@ -97,10 +97,10 @@ func GenerateImageListPullJobV1Beta1(cf *fuzz.ConsumeFuzzer, bj *appsv1beta1.Ima
 
 	// Generate Status
 	bj.Status = appsv1beta1.ImageListPullJobStatus{
-		Active:    int32(r.Intn(1)),
-		Succeeded: int32(r.Intn(1)),
+		Active:    int32(r.Intn(2)),
+		Succeeded: int32(r.Intn(2)),
 		Desired:   int32(r.Intn(3)),
-		Completed: int32(r.Intn(1)),
+		Completed: int32(r.Intn(2)),
 	}
 
 	return nil


### PR DESCRIPTION
## What's changed?
This PR addresses a logical flaw in the fuzzer implementation for `ImageListPullJob` (`test/fuzz/imagelistpulljob.go`) that was restricting test coverage.

Previously, the random number generator used `r.Intn(1)` to generate the `Active`, `Succeeded`, and `Completed` status fields. According to the Go `math/rand` specification, `rand.Intn(n)` returns a value in the half-open interval `[0, n)`. Therefore, `r.Intn(1)` always returns `0`. This entirely prevented the fuzzer from generating test configurations where these status fields had a value of `1` or greater. 

This commit changes the bounds to `r.Intn(2)`, allowing the status variables to properly simulate both `0` and `1` states during fuzz testing, ultimately increasing the fuzzer's effectiveness at detecting latent bugs.

## How to test it?
1. Check out this branch.
2. Run `make test` to ensure all tests pass.
3. Run `staticcheck ./test/fuzz/...` to verify that the `SA4030` warning (which initially highlighted that `r.Intn(1)` always returns 0) has been cleared.

## Which issue(s) this PR fixes:
#2453 
