### PR TITLE
fix(webhook): do not strictly validate leading/trailing whitespace for EphemeralJob image

### DIFF
--- a/pkg/webhook/ephemeraljob/validating/validation.go
+++ b/pkg/webhook/ephemeraljob/validating/validation.go
@@ -2,7 +2,6 @@ package validating
 
 import (
 	"reflect"
-	"strings"
 	"unicode"
 	"unicode/utf8"
 
@@ -137,9 +136,6 @@ func validateContainerCommon(ctr *core.Container, path *field.Path, opts validat
 // This is called by validateContainersOnlyForPod and validateEphemeralContainers directly.
 func validateContainerOnlyForPod(ctr *core.Container, path *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
-	if len(ctr.Image) != len(strings.TrimSpace(ctr.Image)) {
-		allErrs = append(allErrs, field.Invalid(path.Child("image"), ctr.Image, "must not have leading or trailing whitespace"))
-	}
 	return allErrs
 }
 

--- a/pkg/webhook/ephemeraljob/validating/validation_test.go
+++ b/pkg/webhook/ephemeraljob/validating/validation_test.go
@@ -92,6 +92,9 @@ func TestValidateEphemeralContainers(t *testing.T) {
 				TTY:       true,
 			},
 		}},
+		"Whitespace Padded Image Name": {
+			{EphemeralContainerCommon: core.EphemeralContainerCommon{Name: "debug", Image: " image", ImagePullPolicy: "IfNotPresent", TerminationMessagePolicy: "File"}},
+		},
 	} {
 		if errs := validateEphemeralContainers(ephemeralContainers, field.NewPath("ephemeralContainers"), validation.PodValidationOptions{}, true); len(errs) != 0 {
 			t.Errorf("expected success for '%s' but got errors: %v", title, errs)
@@ -130,13 +133,6 @@ func TestValidateEphemeralContainers(t *testing.T) {
 			{EphemeralContainerCommon: core.EphemeralContainerCommon{Name: "", Image: "image", ImagePullPolicy: "IfNotPresent", TerminationMessagePolicy: "File"}},
 		},
 		field.ErrorList{{Type: field.ErrorTypeRequired, Field: "ephemeralContainers[0].name"}},
-	}, {
-		"whitespace padded image name",
-		line(),
-		[]core.EphemeralContainer{
-			{EphemeralContainerCommon: core.EphemeralContainerCommon{Name: "debug", Image: " image", ImagePullPolicy: "IfNotPresent", TerminationMessagePolicy: "File"}},
-		},
-		field.ErrorList{{Type: field.ErrorTypeInvalid, Field: "ephemeralContainers[0].image"}},
 	}, {
 		"invalid image pull policy",
 		line(),


### PR DESCRIPTION

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
This PR updates the validation logic for EphemeralJob containers to no longer strictly fail validation when a container image has leading or trailing whitespace. This aligns the pod-only container validation with the intention of preserving backward compatibility. As noted in the codebase, padded image names (e.g., " ") might be used as special tokens in pod templates or by users with legacy configurations.

- Removed the strict strings.TrimSpace check in validateContainerOnlyForPod inside pkg/webhook/ephemeraljob/validating/validation.go.

- Removed the unused "strings" import to fix the build.

- Updated validation_test.go to move the "Whitespace Padded Image Name" test scenario from the Failure Cases block to the Success Cases block.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
This fixes the TODO in pkg/webhook/ephemeraljob/validating/validation.go at line 109
### Ⅲ. Describe how to verify it
```bash
go test ./pkg/webhook/ephemeraljob/validating
```

### Ⅳ. Special notes for reviews

