### PR TITLE
fix: mark incomplete containers as Failed when CRR activeDeadlineSeconds expires

### DIFF
--- a/pkg/controller/containerrecreaterequest/crr_controller.go
+++ b/pkg/controller/containerrecreaterequest/crr_controller.go
@@ -205,6 +205,24 @@ func (r *ReconcileContainerRecreateRequest) Reconcile(_ context.Context, request
 		leftTime := time.Duration(*crr.Spec.ActiveDeadlineSeconds)*time.Second - time.Since(crr.CreationTimestamp.Time)
 		if leftTime <= 0 {
 			klog.InfoS("Completed CRR as failure for recreating has exceeded the activeDeadlineSeconds", "containerRecreateRequest", klog.KObj(crr))
+			// Mark existing container states as Failed if not Succeeded
+			existingStates := map[string]*appsv1alpha1.ContainerRecreateRequestContainerRecreateState{}
+			for i := range crr.Status.ContainerRecreateStates {
+				state := &crr.Status.ContainerRecreateStates[i]
+				if state.Phase != appsv1alpha1.ContainerRecreateRequestSucceeded {
+					state.Phase = appsv1alpha1.ContainerRecreateRequestFailed
+				}
+				existingStates[state.Name] = state
+			}
+			// Add Failed state for containers not yet populated by daemon
+			for _, c := range crr.Spec.Containers {
+				if _, exists := existingStates[c.Name]; !exists {
+					crr.Status.ContainerRecreateStates = append(crr.Status.ContainerRecreateStates, appsv1alpha1.ContainerRecreateRequestContainerRecreateState{
+						Name:  c.Name,
+						Phase: appsv1alpha1.ContainerRecreateRequestFailed,
+					})
+				}
+			}
 			return reconcile.Result{}, r.completeCRR(crr, "recreating has exceeded the activeDeadlineSeconds")
 		}
 		duration.Update(leftTime)

--- a/pkg/controller/containerrecreaterequest/crr_controller_test.go
+++ b/pkg/controller/containerrecreaterequest/crr_controller_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2021 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package containerrecreaterequest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/clock"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
+)
+
+func TestCRRDeadlineMarksContainersFailed(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = appsv1alpha1.AddToScheme(scheme)
+	_ = v1.AddToScheme(scheme)
+
+	creationTime := metav1.NewTime(time.Now().Add(-30 * time.Second))
+	deadlineSeconds := int64(10)
+
+	crr := &appsv1alpha1.ContainerRecreateRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-crr",
+			Namespace:         "default",
+			CreationTimestamp: creationTime,
+			Labels: map[string]string{
+				appsv1alpha1.ContainerRecreateRequestPodUIDKey: "test-pod-uid",
+			},
+		},
+		Spec: appsv1alpha1.ContainerRecreateRequestSpec{
+			PodName:               "test-pod",
+			ActiveDeadlineSeconds: &deadlineSeconds,
+			Containers: []appsv1alpha1.ContainerRecreateRequestContainer{
+				{Name: "app"},
+				{Name: "sidecar"},
+			},
+		},
+		Status: appsv1alpha1.ContainerRecreateRequestStatus{
+			Phase: appsv1alpha1.ContainerRecreateRequestRecreating,
+			ContainerRecreateStates: []appsv1alpha1.ContainerRecreateRequestContainerRecreateState{
+				{Name: "app", Phase: appsv1alpha1.ContainerRecreateRequestRecreating},
+				{Name: "sidecar", Phase: appsv1alpha1.ContainerRecreateRequestPending},
+			},
+		},
+	}
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			UID:       "test-pod-uid",
+		},
+		Status: v1.PodStatus{Phase: v1.PodRunning},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(crr, pod).
+		WithStatusSubresource(crr).
+		Build()
+
+	r := &ReconcileContainerRecreateRequest{
+		Client: fakeClient,
+		clock:  clock.RealClock{},
+	}
+
+	_, err := r.Reconcile(context.TODO(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "test-crr", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile returned error: %v", err)
+	}
+
+	updatedCRR := &appsv1alpha1.ContainerRecreateRequest{}
+	_ = fakeClient.Get(context.TODO(), types.NamespacedName{Name: "test-crr", Namespace: "default"}, updatedCRR)
+
+	if updatedCRR.Status.Phase != appsv1alpha1.ContainerRecreateRequestCompleted {
+		t.Errorf("Expected CRR phase Completed, got %s", updatedCRR.Status.Phase)
+	}
+
+	for _, state := range updatedCRR.Status.ContainerRecreateStates {
+		if state.Phase != appsv1alpha1.ContainerRecreateRequestFailed {
+			t.Errorf("Expected container %s phase Failed, got %s", state.Name, state.Phase)
+		}
+	}
+
+	t.Log("All containers correctly marked as Failed on deadline expiry")
+}

--- a/test/e2e/apps/v1alpha1/containerrecreate.go
+++ b/test/e2e/apps/v1alpha1/containerrecreate.go
@@ -410,8 +410,8 @@ var _ = ginkgo.Describe("ContainerRecreateRequest", ginkgo.Label("ContainerRecre
 					return crr.Labels[appsv1alpha1.ContainerRecreateRequestActiveKey]
 				}, 5*time.Second, 1*time.Second).Should(gomega.Equal(""))
 				gomega.Expect(crr.Status.ContainerRecreateStates).Should(gomega.Equal([]appsv1alpha1.ContainerRecreateRequestContainerRecreateState{
-					{Name: "app", Phase: appsv1alpha1.ContainerRecreateRequestPending},
-					{Name: "sidecar", Phase: appsv1alpha1.ContainerRecreateRequestPending},
+					{Name: "app", Phase: appsv1alpha1.ContainerRecreateRequestFailed},
+					{Name: "sidecar", Phase: appsv1alpha1.ContainerRecreateRequestFailed},
 				}))
 
 				ginkgo.By("Check the app container should still be recreated")


### PR DESCRIPTION
## Problem
When a ContainerRecreateRequest (CRR) exceeds its `activeDeadlineSeconds`, 
the controller correctly marks the overall CRR phase as `Completed`, but 
individual container states are left as `Recreating` or `Pending` instead 
of being marked as `Failed`.

Fixes #2353

## Root Cause
In `crr_controller.go`, the deadline expiry code path called `completeCRR()` 
directly without first updating the per-container states.

## Fix
Iterate over all `ContainerRecreateStates` on deadline expiry and mark any 
non-Succeeded container as `Failed` before completing the CRR.

## Test
Added unit test `TestCRRDeadlineMarksContainersFailed` that verifies:
- CRR overall phase becomes `Completed`
- All non-succeeded containers are marked `Failed`

## Bug Evidence (from #2353)
When `activeDeadlineSeconds` expires, containers were left in wrong states:
- `app` → Phase: `Recreating` 
- `sidecar` → Phase: `Pending` 

## Fix Verified by Unit Test
After the fix, all incomplete containers are correctly marked as `Failed`:
<img width="980" height="241" alt="Screenshot 2026-05-17 173320" src="https://github.com/user-attachments/assets/89829a5f-3d32-4fa4-b4f8-62f2a18f851d" />
