### PR TITLE
fix: validate v1beta1 CloneSet progress deadline

### DIFF
--- a/pkg/webhook/cloneset/validating/validation.go
+++ b/pkg/webhook/cloneset/validating/validation.go
@@ -303,6 +303,13 @@ func validateCloneSetV1beta1Spec(spec, oldSpec *v1beta1.CloneSetSpec, metadata *
 	allErrs = append(allErrs, validateScaleStrategyV1beta1(&spec.ScaleStrategy, oldScaleStrategy, metadata, fldPath.Child("scaleStrategy"))...)
 	allErrs = append(allErrs, validateUpdateStrategyV1beta1(&spec.UpdateStrategy, int(*spec.Replicas), fldPath.Child("updateStrategy"))...)
 
+	if spec.ProgressDeadlineSeconds != nil {
+		allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(*spec.ProgressDeadlineSeconds), fldPath.Child("progressDeadlineSeconds"))...)
+		if *spec.ProgressDeadlineSeconds != math.MaxInt32 && *spec.ProgressDeadlineSeconds <= spec.MinReadySeconds {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("progressDeadlineSeconds"), spec.ProgressDeadlineSeconds, "must be greater than minReadySeconds"))
+		}
+	}
+
 	return allErrs
 }
 

--- a/pkg/webhook/cloneset/validating/validation_test.go
+++ b/pkg/webhook/cloneset/validating/validation_test.go
@@ -772,3 +772,94 @@ func TestValidateImagePreDownloadParallelism(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateCloneSetV1beta1ProgressDeadlineSeconds(t *testing.T) {
+	validLabels := map[string]string{"a": "b"}
+	replicas := int32(1)
+	partition := intstr.FromInt(0)
+	maxUnavailable := intstr.FromInt(1)
+
+	tests := []struct {
+		name                    string
+		progressDeadlineSeconds *int32
+		minReadySeconds         int32
+		expectError             bool
+	}{
+		{
+			name:                    "valid greater than minReadySeconds",
+			progressDeadlineSeconds: ptr.To(int32(11)),
+			minReadySeconds:         10,
+			expectError:             false,
+		},
+		{
+			name:                    "valid max int32",
+			progressDeadlineSeconds: ptr.To(int32(math.MaxInt32)),
+			minReadySeconds:         math.MaxInt32,
+			expectError:             false,
+		},
+		{
+			name:                    "invalid negative",
+			progressDeadlineSeconds: ptr.To(int32(-1)),
+			expectError:             true,
+		},
+		{
+			name:                    "invalid equals minReadySeconds",
+			progressDeadlineSeconds: ptr.To(int32(10)),
+			minReadySeconds:         10,
+			expectError:             true,
+		},
+		{
+			name:                    "invalid less than minReadySeconds",
+			progressDeadlineSeconds: ptr.To(int32(9)),
+			minReadySeconds:         10,
+			expectError:             true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cloneSet := &v1beta1.CloneSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "cs-progress-deadline", Namespace: metav1.NamespaceDefault},
+				Spec: v1beta1.CloneSetSpec{
+					Replicas: &replicas,
+					Selector: &metav1.LabelSelector{MatchLabels: validLabels},
+					Template: v1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{Labels: validLabels},
+						Spec: v1.PodSpec{
+							RestartPolicy: v1.RestartPolicyAlways,
+							DNSPolicy:     v1.DNSClusterFirst,
+							Containers: []v1.Container{{
+								Name:                     "abc",
+								Image:                    "image",
+								ImagePullPolicy:          v1.PullIfNotPresent,
+								TerminationMessagePolicy: v1.TerminationMessageReadFile,
+							}},
+						},
+					},
+					UpdateStrategy: v1beta1.CloneSetUpdateStrategy{
+						Type: v1beta1.RollingUpdateCloneSetUpdateStrategyType,
+						RollingUpdate: &v1beta1.RollingUpdateCloneSetStrategy{
+							PodUpdatePolicy: v1beta1.InPlaceOnlyCloneSetPodUpdateStrategyType,
+							Partition:       &partition,
+							MaxUnavailable:  &maxUnavailable,
+						},
+					},
+					ProgressDeadlineSeconds: tt.progressDeadlineSeconds,
+					MinReadySeconds:         tt.minReadySeconds,
+				},
+			}
+
+			errs := ValidateCloneSetV1beta1(cloneSet, nil)
+			hasError := false
+			for _, err := range errs {
+				if err.Field == "spec.progressDeadlineSeconds" {
+					hasError = true
+					break
+				}
+			}
+			if hasError != tt.expectError {
+				t.Errorf("expected progressDeadlineSeconds error: %v, got errors: %v", tt.expectError, errs)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### I. Describe what this PR does

Adds the missing v1beta1 CloneSet validation for `spec.progressDeadlineSeconds`.

v1alpha1 already rejects negative values, and values <= `minReadySeconds` except `MaxInt32`. v1beta1 missed that check. Tiny parity fix, nothing fancy.

### II. Does this pull request fix one issue?

NONE

### III. Describe how to verify it

The added test reproduces the old bug: invalid v1beta1 values like `-1`, or `10` with `minReadySeconds: 10`, got no `spec.progressDeadlineSeconds` error. Pretty easy to miss tbh.

```bash
go test ./pkg/webhook/cloneset/validating -run TestValidateCloneSetV1beta1ProgressDeadlineSeconds -count=1
go test ./pkg/webhook/cloneset/... -count=1
git diff --check HEAD~1..HEAD
```

### IV. Special notes for reviews

No matching issue found. Closest context is #2225, which added the v1beta1 CloneSet path.
