### PR TITLE
refactor: unify virtual-kubelet label constants and propagate to CRR

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,7 +65,7 @@ jobs:
           skip-pkg-cache: true
           mod: readonly
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@d2a392a13760cb64cb6bbd31d4bed2a7d9a5298d # master
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: 'fs'
           ignore-unfixed: true

--- a/pkg/controller/nodeimage/nodeimage_event_handler.go
+++ b/pkg/controller/nodeimage/nodeimage_event_handler.go
@@ -31,11 +31,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
+	"github.com/openkruise/kruise/pkg/util"
 	utilimagejob "github.com/openkruise/kruise/pkg/util/imagejob"
-)
-
-const (
-	VirtualKubelet = "virtual-kubelet"
 )
 
 type nodeHandler struct {
@@ -46,7 +43,7 @@ var _ handler.TypedEventHandler[*v1.Node] = &nodeHandler{}
 
 func (e *nodeHandler) Create(ctx context.Context, evt event.TypedCreateEvent[*v1.Node], q workqueue.RateLimitingInterface) {
 	node := evt.Object
-	if node.Labels["type"] == VirtualKubelet {
+	if node.Labels[util.VirtualKubeletLabelKey] == util.VirtualKubeletLabelValue {
 		return
 	}
 	if node.DeletionTimestamp != nil {
@@ -61,7 +58,7 @@ func (e *nodeHandler) Generic(ctx context.Context, evt event.TypedGenericEvent[*
 
 func (e *nodeHandler) Update(ctx context.Context, evt event.TypedUpdateEvent[*v1.Node], q workqueue.RateLimitingInterface) {
 	node := evt.ObjectNew
-	if node.Labels["type"] == VirtualKubelet {
+	if node.Labels[util.VirtualKubeletLabelKey] == util.VirtualKubeletLabelValue {
 		return
 	}
 	if node.DeletionTimestamp != nil {
@@ -73,7 +70,7 @@ func (e *nodeHandler) Update(ctx context.Context, evt event.TypedUpdateEvent[*v1
 
 func (e *nodeHandler) Delete(ctx context.Context, evt event.TypedDeleteEvent[*v1.Node], q workqueue.RateLimitingInterface) {
 	node := evt.Object
-	if node.Labels["type"] == VirtualKubelet {
+	if node.Labels[util.VirtualKubeletLabelKey] == util.VirtualKubeletLabelValue {
 		return
 	}
 	e.nodeDelete(node, q)

--- a/pkg/controller/nodepodprobe/nodepodprobe_event_handler.go
+++ b/pkg/controller/nodepodprobe/nodepodprobe_event_handler.go
@@ -33,6 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	appsalphav1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
+	"github.com/openkruise/kruise/pkg/util"
 )
 
 var _ handler.TypedEventHandler[*appsalphav1.NodePodProbe] = &enqueueRequestForNodePodProbe{}
@@ -121,10 +122,6 @@ func (p *enqueueRequestForPod) Update(ctx context.Context, evt event.TypedUpdate
 	}
 }
 
-const (
-	VirtualKubelet = "virtual-kubelet"
-)
-
 type enqueueRequestForNode struct {
 	client.Reader
 }
@@ -133,7 +130,7 @@ var _ handler.TypedEventHandler[*corev1.Node] = &enqueueRequestForNode{}
 
 func (e *enqueueRequestForNode) Create(ctx context.Context, evt event.TypedCreateEvent[*corev1.Node], q workqueue.RateLimitingInterface) {
 	node := evt.Object
-	if node.Labels["type"] == VirtualKubelet {
+	if node.Labels[util.VirtualKubeletLabelKey] == util.VirtualKubeletLabelValue {
 		return
 	}
 	if node.DeletionTimestamp != nil {
@@ -148,7 +145,7 @@ func (e *enqueueRequestForNode) Generic(ctx context.Context, evt event.TypedGene
 
 func (e *enqueueRequestForNode) Update(ctx context.Context, evt event.TypedUpdateEvent[*corev1.Node], q workqueue.RateLimitingInterface) {
 	node := evt.ObjectNew
-	if node.Labels["type"] == VirtualKubelet {
+	if node.Labels[util.VirtualKubeletLabelKey] == util.VirtualKubeletLabelValue {
 		return
 	}
 	if node.DeletionTimestamp != nil {
@@ -160,7 +157,7 @@ func (e *enqueueRequestForNode) Update(ctx context.Context, evt event.TypedUpdat
 
 func (e *enqueueRequestForNode) Delete(ctx context.Context, evt event.TypedDeleteEvent[*corev1.Node], q workqueue.RateLimitingInterface) {
 	node := evt.Object
-	if node.Labels["type"] == VirtualKubelet {
+	if node.Labels[util.VirtualKubeletLabelKey] == util.VirtualKubeletLabelValue {
 		return
 	}
 	e.nodeDelete(node, q)

--- a/pkg/controller/podprobemarker/pod_probe_marker_controller.go
+++ b/pkg/controller/podprobemarker/pod_probe_marker_controller.go
@@ -64,8 +64,6 @@ var (
 const (
 	// PodProbeMarkerFinalizer is on PodProbeMarker, and used to remove podProbe from NodePodProbe.Spec
 	PodProbeMarkerFinalizer = "kruise.io/node-pod-probe-cleanup"
-
-	VirtualKubelet = "virtual-kubelet"
 )
 
 /**
@@ -469,7 +467,7 @@ func (r *ReconcilePodProbeMarker) getMatchingPods(ppm *appsv1alpha1.PodProbeMark
 			nodes[node.Name] = node
 		}
 
-		if node.Labels["type"] == VirtualKubelet {
+		if node.Labels[util.VirtualKubeletLabelKey] == util.VirtualKubeletLabelValue {
 			serverlessPods = append(serverlessPods, pod)
 		} else {
 			normalPods = append(normalPods, pod)

--- a/pkg/controller/podprobemarker/podprobemarker_event_handler.go
+++ b/pkg/controller/podprobemarker/podprobemarker_event_handler.go
@@ -101,7 +101,7 @@ func (p *enqueueRequestForPod) Update(ctx context.Context, evt event.TypedUpdate
 		klog.ErrorS(err, "Failed to get Node", "nodeName", newObj.Spec.NodeName)
 		return
 	}
-	if node.Labels["type"] == VirtualKubelet {
+	if node.Labels[util.VirtualKubeletLabelKey] == util.VirtualKubeletLabelValue {
 		isServerlessPod = true
 	}
 

--- a/pkg/controller/podprobemarker/podprobemarker_event_handler_test.go
+++ b/pkg/controller/podprobemarker/podprobemarker_event_handler_test.go
@@ -507,7 +507,7 @@ func TestPodUpdateEventHandler_v2(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "test-node",
 						Labels: map[string]string{
-							"type": VirtualKubelet,
+							util.VirtualKubeletLabelKey: util.VirtualKubeletLabelValue,
 						},
 					},
 				}

--- a/pkg/controller/sidecarterminator/sidecar_terminator_controller_test.go
+++ b/pkg/controller/sidecarterminator/sidecar_terminator_controller_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
+	"github.com/openkruise/kruise/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -176,7 +177,7 @@ var (
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "vk-node",
 			Labels: map[string]string{
-				DefaultVKLabelKey: DefaultVKLabelValue,
+				util.VirtualKubeletLabelKey: util.VirtualKubeletLabelValue,
 			},
 		},
 		Spec: corev1.NodeSpec{

--- a/pkg/controller/sidecarterminator/virtual_kubelet_manager.go
+++ b/pkg/controller/sidecarterminator/virtual_kubelet_manager.go
@@ -19,12 +19,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openkruise/kruise/pkg/util"
 )
 
 const (
-	DefaultVKLabelKey   = "type"
-	DefaultVKLabelValue = "virtual-kubelet"
-	DefaultVKTaintKey   = "virtual-kubelet.io/provider"
+	DefaultVKTaintKey = "virtual-kubelet.io/provider"
 )
 
 func IsPodRunningOnVirtualKubelet(pod *corev1.Pod, reader client.Reader) (bool, error) {
@@ -41,5 +41,5 @@ func IsPodRunningOnVirtualKubelet(pod *corev1.Pod, reader client.Reader) (bool, 
 }
 
 func isVirtualKubelet(node *corev1.Node) bool {
-	return node.Labels[DefaultVKLabelKey] == DefaultVKLabelValue
+	return node.Labels[util.VirtualKubeletLabelKey] == util.VirtualKubeletLabelValue
 }

--- a/pkg/util/virtual_kubelet.go
+++ b/pkg/util/virtual_kubelet.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2026 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+const (
+	// VirtualKubeletLabelKey is the node label key used to identify a virtual-kubelet node.
+	VirtualKubeletLabelKey = "type"
+	// VirtualKubeletLabelValue is the node label value used to identify a virtual-kubelet node.
+	VirtualKubeletLabelValue = "virtual-kubelet"
+)

--- a/pkg/webhook/containerrecreaterequest/mutating/crr_mutating_handler.go
+++ b/pkg/webhook/containerrecreaterequest/mutating/crr_mutating_handler.go
@@ -132,8 +132,15 @@ func (h *ContainerRecreateRequestHandler) Handle(ctx context.Context, req admiss
 		return admission.Errored(http.StatusBadRequest, fmt.Errorf("not allowed to recreate containers in a pending Pod"))
 	}
 
-	err = injectPodIntoContainerRecreateRequest(obj, pod)
-	if err != nil {
+	node := &v1.Node{}
+	if err := h.Client.Get(ctx, types.NamespacedName{Name: pod.Spec.NodeName}, node); err != nil {
+		if errors.IsNotFound(err) {
+			return admission.Errored(http.StatusBadRequest, fmt.Errorf("failed to get Node %s: %v", pod.Spec.NodeName, err))
+		}
+		return admission.Errored(http.StatusInternalServerError, fmt.Errorf("failed to get Node %s: %v", pod.Spec.NodeName, err))
+	}
+
+	if err := injectPodIntoContainerRecreateRequest(obj, pod, node); err != nil {
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
@@ -156,9 +163,13 @@ func isTerminatedBySidecarTerminator(pod *v1.Pod) bool {
 	return false
 }
 
-func injectPodIntoContainerRecreateRequest(obj *appsv1alpha1.ContainerRecreateRequest, pod *v1.Pod) error {
+func injectPodIntoContainerRecreateRequest(obj *appsv1alpha1.ContainerRecreateRequest, pod *v1.Pod, node *v1.Node) error {
 	obj.Labels[appsv1alpha1.ContainerRecreateRequestNodeNameKey] = pod.Spec.NodeName
 	obj.Labels[appsv1alpha1.ContainerRecreateRequestPodUIDKey] = string(pod.UID)
+
+	if node != nil && node.Labels[util.VirtualKubeletLabelKey] == util.VirtualKubeletLabelValue {
+		obj.Labels[util.VirtualKubeletLabelKey] = util.VirtualKubeletLabelValue
+	}
 
 	if obj.Spec.Strategy.TerminationGracePeriodSeconds == nil {
 		obj.Spec.Strategy.TerminationGracePeriodSeconds = pod.Spec.TerminationGracePeriodSeconds

--- a/pkg/webhook/containerrecreaterequest/mutating/crr_mutating_handler_test.go
+++ b/pkg/webhook/containerrecreaterequest/mutating/crr_mutating_handler_test.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2026 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutating
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	appsv1alpha1 "github.com/openkruise/kruise/apis/apps/v1alpha1"
+	"github.com/openkruise/kruise/pkg/util"
+)
+
+func TestInjectPodIntoContainerRecreateRequest_VirtualKubeletLabel(t *testing.T) {
+	basePod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			UID:       types.UID("pod-uid-123"),
+		},
+		Spec: v1.PodSpec{
+			NodeName: "test-node",
+			Containers: []v1.Container{
+				{Name: "main"},
+			},
+		},
+		Status: v1.PodStatus{
+			ContainerStatuses: []v1.ContainerStatus{
+				{
+					Name:         "main",
+					ContainerID:  "docker://abc123",
+					RestartCount: 0,
+				},
+			},
+		},
+	}
+
+	baseCRR := func() *appsv1alpha1.ContainerRecreateRequest {
+		return &appsv1alpha1.ContainerRecreateRequest{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-crr",
+				Namespace: "default",
+				Labels:    map[string]string{},
+			},
+			Spec: appsv1alpha1.ContainerRecreateRequestSpec{
+				PodName: "test-pod",
+				Containers: []appsv1alpha1.ContainerRecreateRequestContainer{
+					{Name: "main"},
+				},
+				Strategy: &appsv1alpha1.ContainerRecreateRequestStrategy{},
+			},
+		}
+	}
+
+	tests := []struct {
+		name        string
+		node        *v1.Node
+		expectLabel bool
+		expectErr   bool
+	}{
+		{
+			name: "node has virtual-kubelet label, CRR should get the label",
+			node: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+					Labels: map[string]string{
+						util.VirtualKubeletLabelKey: util.VirtualKubeletLabelValue,
+					},
+				},
+			},
+			expectLabel: true,
+			expectErr:   false,
+		},
+		{
+			name: "node does not have virtual-kubelet label, CRR should not get the label",
+			node: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "test-node",
+					Labels: map[string]string{"foo": "bar"},
+				},
+			},
+			expectLabel: false,
+			expectErr:   false,
+		},
+		{
+			name:        "node not found, should not error and CRR should not get the label",
+			node:        nil,
+			expectLabel: false,
+			expectErr:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			crr := baseCRR()
+			err := injectPodIntoContainerRecreateRequest(crr, basePod, tt.node)
+
+			if tt.expectErr && err == nil {
+				t.Fatalf("expected error but got nil")
+			}
+			if !tt.expectErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			labelVal, hasLabel := crr.Labels[util.VirtualKubeletLabelKey]
+			if tt.expectLabel {
+				if !hasLabel || labelVal != util.VirtualKubeletLabelValue {
+					t.Errorf("expected CRR to have label %s=%s, got labels: %v",
+						util.VirtualKubeletLabelKey, util.VirtualKubeletLabelValue, crr.Labels)
+				}
+			} else {
+				if hasLabel {
+					t.Errorf("expected CRR not to have label %s, got labels: %v",
+						util.VirtualKubeletLabelKey, crr.Labels)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Extract virtual-kubelet label key/value into shared constants in pkg/util/virtual_kubelet.go, replacing hardcoded strings across nodeimage, nodepodprobe, podprobemarker, and sidecarterminator controllers. Also propagate the virtual-kubelet label from Node to ContainerRecreateRequest in the CRR mutating webhook.

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

