### PR TITLE
fix(podprobe): pin probes to pod IP and reject Host header to prevent SSRF

### DIFF
--- a/pkg/daemon/podprobe/prober.go
+++ b/pkg/daemon/podprobe/prober.go
@@ -99,11 +99,14 @@ func (pb *prober) runProbe(p *appsv1alpha1.ContainerProbeSpec, probeKey probeKey
 		}
 		return pb.http.Probe(req, timeout)
 	case p.TCPSocket != nil:
-		port := p.TCPSocket.Port.IntValue()
-		host := p.TCPSocket.Host
-		if host == "" {
-			host = probeKey.podIP
+		// FIX(SSRF): never honor a caller-supplied Host. NodePodProbe has no admission
+		// webhook of its own and the daemon runs with hostNetwork=true, so a Host smuggled
+		// in via a direct NodePodProbe write would dial node-local/metadata endpoints.
+		host, err := resolveProbeHost(p.TCPSocket.Host, probeKey.podIP)
+		if err != nil {
+			return probe.Unknown, "", err
 		}
+		port := p.TCPSocket.Port.IntValue()
 		klog.InfoS("TCP-Probe Host", "host", host, "port", port, "timeout", timeout)
 		return pb.tcp.Probe(host, port, timeout)
 	}
@@ -112,15 +115,33 @@ func (pb *prober) runProbe(p *appsv1alpha1.ContainerProbeSpec, probeKey probeKey
 	return probe.Unknown, "", fmt.Errorf("missing probe handler for %s", containerRuntimeStatus.Metadata.Name)
 }
 
+// resolveProbeHost returns the only address a probe is permitted to dial: the target
+// Pod IP. A non-empty Host that differs from the Pod IP is rejected loudly rather than
+// silently dropped so a direct NodePodProbe injection (e.g. Host=169.254.169.254) is
+// both blocked and observable in the daemon logs. An empty Pod IP is rejected too, which
+// also closes the latent net.JoinHostPort("", port) -> ":port" loopback dial.
+func resolveProbeHost(specHost, podIP string) (string, error) {
+	if specHost != "" && specHost != podIP {
+		return "", fmt.Errorf("probe host %q is not allowed: probes may only target the pod IP", specHost)
+	}
+	if podIP == "" {
+		return "", fmt.Errorf("probe target pod IP is empty")
+	}
+	return podIP, nil
+}
+
 func newRequestForHTTPGetAction(httpGet *v1.HTTPGetAction, podIP string, userAgentFragment string) (*http.Request, error) {
 	scheme := string(httpGet.Scheme)
 	if scheme == "" {
 		scheme = "http"
 	}
 
-	host := httpGet.Host
-	if host == "" {
-		host = podIP
+	// FIX(SSRF): pin the probe to the target Pod IP regardless of httpGet.Host. See
+	// resolveProbeHost - this is the daemon-side backstop for the same invariant the
+	// PodProbeMarker validating webhook claims to enforce.
+	host, err := resolveProbeHost(httpGet.Host, podIP)
+	if err != nil {
+		return nil, err
 	}
 
 	port := httpGet.Port.IntValue()

--- a/pkg/daemon/podprobe/prober_test.go
+++ b/pkg/daemon/podprobe/prober_test.go
@@ -96,6 +96,25 @@ func TestRunProbe(t *testing.T) {
 		},
 
 		{
+			name: "test tcpProbe check, a Host pointing off-pod (SSRF) is rejected",
+			p: &appsv1alpha1.ContainerProbeSpec{
+				Probe: corev1.Probe{
+					ProbeHandler: corev1.ProbeHandler{
+						TCPSocket: &corev1.TCPSocketAction{
+							Host: "169.254.169.254",
+							Port: intstr.IntOrString{Type: intstr.Int, IntVal: int32(tPort)},
+						},
+					},
+				},
+			},
+			probeKey: probeKey{
+				podIP: "10.0.0.5",
+			},
+			expectedStatus: probe.Unknown,
+			expectedError:  fmt.Errorf("probe host %q is not allowed: probes may only target the pod IP", "169.254.169.254"),
+		},
+
+		{
 			name: "test httpProbe check, a connection is made and probing would succeed",
 			p: &appsv1alpha1.ContainerProbeSpec{
 				Probe: corev1.Probe{
@@ -331,11 +350,12 @@ func TestNewRequestForHTTPGetAction(t *testing.T) {
 		expectError       bool
 	}{
 		{
+			// Host equal to the Pod IP is the only non-empty value the daemon accepts.
 			name: "valid request with default scheme",
 			httpGet: &corev1.HTTPGetAction{
 				Port:   intstr.FromInt(8080),
 				Path:   "/health",
-				Host:   "localhost",
+				Host:   "192.168.1.1",
 				Scheme: "",
 				HTTPHeaders: []corev1.HTTPHeader{
 					{Name: "X-Custom-Header", Value: "value"},
@@ -343,7 +363,7 @@ func TestNewRequestForHTTPGetAction(t *testing.T) {
 			},
 			podIP:             "192.168.1.1",
 			userAgentFragment: "test",
-			expectURL:         "http://localhost:8080/health",
+			expectURL:         "http://192.168.1.1:8080/health",
 			expectHeader: http.Header{
 				"X-Custom-Header": {"value"},
 				"User-Agent":      {userAgent("test")},
@@ -356,17 +376,40 @@ func TestNewRequestForHTTPGetAction(t *testing.T) {
 			httpGet: &corev1.HTTPGetAction{
 				Port:   intstr.FromInt(8443),
 				Path:   "/secure",
-				Host:   "secure.example.com",
+				Host:   "192.168.1.1",
 				Scheme: corev1.URISchemeHTTPS,
 			},
 			podIP:             "192.168.1.1",
 			userAgentFragment: "test",
-			expectURL:         "https://secure.example.com:8443/secure",
+			expectURL:         "https://192.168.1.1:8443/secure",
 			expectHeader: http.Header{
 				"User-Agent": {userAgent("test")},
 				"Accept":     {"*/*"},
 			},
 			expectError: false,
+		},
+		{
+			name: "host pointing at cloud metadata is rejected (SSRF)",
+			httpGet: &corev1.HTTPGetAction{
+				Port:   intstr.FromInt(80),
+				Path:   "/latest/meta-data/",
+				Host:   "169.254.169.254",
+				Scheme: corev1.URISchemeHTTP,
+			},
+			podIP:             "10.0.0.5",
+			userAgentFragment: "test",
+			expectError:       true,
+		},
+		{
+			name: "empty pod IP is rejected",
+			httpGet: &corev1.HTTPGetAction{
+				Port:   intstr.FromInt(8080),
+				Path:   "/health",
+				Scheme: corev1.URISchemeHTTP,
+			},
+			podIP:             "",
+			userAgentFragment: "test",
+			expectError:       true,
 		},
 		{
 			name: "default host to podIP when not provided",
@@ -389,7 +432,7 @@ func TestNewRequestForHTTPGetAction(t *testing.T) {
 			httpGet: &corev1.HTTPGetAction{
 				Port:   intstr.FromInt(8080),
 				Path:   "/health",
-				Host:   "localhost",
+				Host:   "192.168.1.1",
 				Scheme: corev1.URISchemeHTTP,
 				HTTPHeaders: []corev1.HTTPHeader{
 					{Name: "Accept", Value: "application/json"},
@@ -398,7 +441,7 @@ func TestNewRequestForHTTPGetAction(t *testing.T) {
 			},
 			podIP:             "192.168.1.1",
 			userAgentFragment: "test",
-			expectURL:         "http://localhost:8080/health",
+			expectURL:         "http://192.168.1.1:8080/health",
 			expectHeader: http.Header{
 				"Accept":     {"application/json"},
 				"User-Agent": {"custom-agent"},
@@ -410,7 +453,6 @@ func TestNewRequestForHTTPGetAction(t *testing.T) {
 			httpGet: &corev1.HTTPGetAction{
 				Port:   intstr.FromInt(-1),
 				Path:   "/health",
-				Host:   "localhost",
 				Scheme: corev1.URISchemeHTTP,
 			},
 			podIP:             "192.168.1.1",
@@ -422,7 +464,6 @@ func TestNewRequestForHTTPGetAction(t *testing.T) {
 			httpGet: &corev1.HTTPGetAction{
 				Port:   intstr.FromInt(65536),
 				Path:   "/health",
-				Host:   "localhost",
 				Scheme: corev1.URISchemeHTTP,
 			},
 			podIP:             "192.168.1.1",
@@ -434,7 +475,6 @@ func TestNewRequestForHTTPGetAction(t *testing.T) {
 			httpGet: &corev1.HTTPGetAction{
 				Port:   intstr.FromInt(8080),
 				Path:   "path%notvalid",
-				Host:   "localhost",
 				Scheme: corev1.URISchemeHTTP,
 			},
 			podIP:             "192.168.1.1",

--- a/pkg/webhook/podprobemarker/validating/probe_create_update_handler.go
+++ b/pkg/webhook/podprobemarker/validating/probe_create_update_handler.go
@@ -270,6 +270,11 @@ func validateHTTPGetAction(http *corev1.HTTPGetAction, fldPath *field.Path) fiel
 		allErrors = append(allErrors, field.NotSupported(fldPath.Child("scheme"), http.Scheme, sets.List(supportedHTTPSchemes)))
 	}
 	for _, header := range http.HTTPHeaders {
+		// The daemon copies a "Host" header into req.Host (see newProbeRequest), so allowing
+		// it would reintroduce the host override that the Host field above forbids.
+		if strings.EqualFold(header.Name, "Host") {
+			allErrors = append(allErrors, field.Invalid(fldPath.Child("httpHeaders"), header.Name, "Host header is not allowed"))
+		}
 		for _, msg := range validationutil.IsHTTPHeaderName(header.Name) {
 			allErrors = append(allErrors, field.Invalid(fldPath.Child("httpHeaders"), header.Name, msg))
 		}

--- a/pkg/webhook/podprobemarker/validating/probe_validating_test.go
+++ b/pkg/webhook/podprobemarker/validating/probe_validating_test.go
@@ -243,6 +243,33 @@ func TestValidatingPodProbeMarker(t *testing.T) {
 			},
 			expectErrList: 1,
 		},
+		{
+			name: "test12, httpGet Host header is rejected (SSRF)",
+			getPpm: func() *appsv1alpha1.PodProbeMarker {
+				ppm := ppmDemo.DeepCopy()
+				ppm.Spec.Probes = append(ppm.Spec.Probes, appsv1alpha1.PodContainerProbe{
+					Name:          "check",
+					ContainerName: "other",
+					Probe: appsv1alpha1.ContainerProbeSpec{
+						Probe: corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								HTTPGet: &corev1.HTTPGetAction{
+									Path:   "/index.html",
+									Scheme: corev1.URISchemeHTTP,
+									Port:   intstr.FromInt(80),
+									HTTPHeaders: []corev1.HTTPHeader{
+										{Name: "host", Value: "169.254.169.254"},
+									},
+								},
+							},
+						},
+					},
+					PodConditionType: "game.kruise.io/check",
+				})
+				return ppm
+			},
+			expectErrList: 1,
+		},
 	}
 
 	decoder := admission.NewDecoder(scheme)


### PR DESCRIPTION
### Describe what this PR does

PodProbeMarker probes are executed by kruise-daemon, which runs with `hostNetwork: true`. The daemon used to honor the `Host` field from the probe spec directly and only fell back to the Pod IP when it was empty:

```go
host := p.TCPSocket.Host
if host == "" {
    host = probeKey.podIP
}
```

The only thing rejecting a non-empty `Host` was the PodProbeMarker validating webhook. But the daemon actually reads `NodePodProbe`, which has no admission webhook of its own, and the controller copies the probe spec into it verbatim. So a `Host` set directly on a `NodePodProbe` was dialed as-is from the node network namespace letting a probe reach node-local services or the cloud metadata endpoint (`169.254.169.254`). On top of that, the webhook forbade `httpGet.Host` but still allowed an HTTP header literally named `Host`, which the daemon copies into `req.Host`.

This PR closes both gaps:

- Adds a `resolveProbeHost` chokepoint in the daemon (`pkg/daemon/podprobe/prober.go`) used by both the TCP and HTTP paths. A probe may only target its Pod IP a non-empty `Host` that differs from the Pod IP is rejected with a clear error instead of being silently dropped, so a direct `NodePodProbe` injection is both blocked and visible in the logs. An empty Pod IP is rejected too, which also closes a latent `net.JoinHostPort("", port)` → `":port"` loopback dial.
- Rejects an HTTP header named `Host` in `validateHTTPGetAction` (`pkg/webhook/podprobemarker/validating`), since the daemon would otherwise apply it as `req.Host`.

The protection now lives in the daemon itself, so it no longer depends solely on admission being in the path.

### Does this pull request fix one issue?

NONE

### Describe how to verify it

Unit tests cover both layers:

```
go test ./pkg/daemon/podprobe/...
go test ./pkg/webhook/podprobemarker/validating/...
```

- `prober_test.go`: a TCP/HTTP probe with `Host: 169.254.169.254` and a different Pod IP is now rejected; an empty Pod IP is rejected; the happy paths (empty `Host`, or `Host` equal to the Pod IP) still pass.
- `probe_validating_test.go`: a PodProbeMarker carrying a `Host` HTTP header is now rejected by the webhook.

To check it end-to-end on a cluster: create a PodProbeMarker whose httpGet probe sets a `Host` header pointing at `169.254.169.254` it is rejected at admission; and a `NodePodProbe` written directly with a `Host` pointing off-pod no longer causes the daemon to dial that address.

### Special notes for reviews

- Existing tests in `TestNewRequestForHTTPGetAction` previously asserted that arbitrary hosts like `localhost` / `secure.example.com` were honored I updated those to use the Pod IP, since that behavior was the vulnerability. The cases that test invalid port/path now leave `Host` empty so they exercise the intended validation rather than short-circuiting on the host check.
- The daemon-side check intentionally errors loudly rather than silently coercing to the Pod IP, so unexpected `Host` values surface in daemon logs for debugging.
