### PR TITLE
fix(sidecarset): fix panic when Pod is deleted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ test/e2e/generated/bindata.go
 .DS_Store
 
 vendor/
+.qoder/

--- a/pkg/controller/sidecarset/sidecarset_processor.go
+++ b/pkg/controller/sidecarset/sidecarset_processor.go
@@ -205,6 +205,7 @@ func (p *Processor) updatePodSidecarAndHash(control sidecarcontrol.SidecarContro
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		if err := p.Client.Get(context.TODO(), types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}, podClone); err != nil {
 			klog.ErrorS(err, "SidecarSet got updated pod from client failed", "sidecarSet", klog.KObj(sidecarSet), "pod", klog.KObj(pod))
+			return err
 		}
 		// update pod sidecar container
 		updatePodSidecarContainer(control, podClone)

--- a/pkg/controller/sidecarset/sidecarset_processor_test.go
+++ b/pkg/controller/sidecarset/sidecarset_processor_test.go
@@ -71,6 +71,18 @@ func TestUpdateColdUpgradeSidecar(t *testing.T) {
 	testUpdateColdUpgradeSidecar(t, podInput, sidecarSetInput, handlers)
 }
 
+func TestUpdatePodSidecarAndHashPodNotFound(t *testing.T) {
+	sidecarSet := sidecarSetDemo.DeepCopy()
+	pod := podDemo.DeepCopy()
+	// pod is intentionally not added to the client, so Get returns NotFound
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(sidecarSet).Build()
+	processor := NewSidecarSetProcessor(fakeClient, record.NewFakeRecorder(10))
+	control := sidecarcontrol.New(sidecarSet)
+	if err := processor.updatePodSidecarAndHash(control, pod); err == nil {
+		t.Fatalf("expect updatePodSidecarAndHash to return error when pod not found, but got nil")
+	}
+}
+
 func testUpdateColdUpgradeSidecar(t *testing.T, podDemo *corev1.Pod, sidecarSetInput *appsv1beta1.SidecarSet, handlers map[string]HandlePod) {
 	podInput1 := podDemo.DeepCopy()
 	podInput2 := podDemo.DeepCopy()


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
```shell
E0601 14:36:01.899458      32 sidecarset_processor.go:209] sidecarset(fuse-28006) error getting updated pod gxxxx from client
E0601 14:36:01.899550      32 runtime.go:79] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 1571 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x1f1

github.com/openkruise/kruise/pkg/control/sidecarcontrol.(*asiControl).UpgradeSidecarContainer(0xc025a2f680?, 0xc01fde9880, 0xc01c641b00)
```

When Pod was deleted, getting container of empty Pod maybe panic when upgrade sidecar container.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

