### PR TITLE
fix(cloneset): do not ignore Pod active state changes in CloneSetEventHandlerOptimization

### DIFF
--- a/pkg/controller/cloneset/core/cloneset_core.go
+++ b/pkg/controller/cloneset/core/cloneset_core.go
@@ -195,6 +195,10 @@ func (c *commonControl) IgnorePodUpdateEvent(oldPod, curPod *v1.Pod) bool {
 		return false
 	}
 
+	if kubecontroller.IsPodActive(oldPod) != kubecontroller.IsPodActive(curPod) {
+		return false
+	}
+
 	containsReadinessGate := func(pod *v1.Pod) bool {
 		for _, r := range pod.Spec.ReadinessGates {
 			if r.ConditionType == appspub.InPlaceUpdateReady {


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

This PR fixes a CloneSet reconcile miss when the `CloneSetEventHandlerOptimization` feature gate is enabled.

#### Root cause

When `CloneSetEventHandlerOptimization` is turned on, some Pod update events are filtered by `IgnorePodUpdateEvent(...)`.  
However, Pod updates where the Pod becomes inactive, such as entering `Failed` phase, may also be filtered unexpectedly.

As a result, the CloneSet controller does not receive the reconcile event for that Pod state transition, so it does not create a replacement Pod even though the old Pod has already become inactive.

#### Fix

This PR adds an active-state check in `IgnorePodUpdateEvent(...)`:

```go
if kubecontroller.IsPodActive(oldPod) != kubecontroller.IsPodActive(curPod) {
    return false
}
```

With this change, updates that change Pod activity state, such as `Running -> Failed`, will no longer be ignored by the event optimization logic, and CloneSet can reconcile correctly.

### Ⅱ. Does this pull request fix one issue?

Fixes #2473

### Ⅲ. Describe how to verify it

1. Enable the `CloneSetEventHandlerOptimization` feature gate.
2. Create a CloneSet workload.
3. Trigger a Pod state transition from active to inactive, for example make the Pod enter `Failed` phase.
4. Verify that the Pod update event is no longer ignored by `IgnorePodUpdateEvent(...)`.
5. Verify that the CloneSet controller reconciles and creates a replacement Pod.

You can also verify it with the original reproduction case:
- after Pod eviction / failure, the Pod phase becomes `Failed`
- CloneSet should now create a new Pod automatically without requiring an extra label update or controller restart

### Ⅳ. Special notes for reviews

This is a minimal and targeted fix:
- it does not disable `CloneSetEventHandlerOptimization`
- it only prevents filtering when Pod active state changes
- it preserves the optimization behavior for other irrelevant Pod updates