### PR TITLE
 fix CRR queue progression after deletion

### DIFF
--- a/pkg/daemon/containerrecreate/crr_daemon_controller.go
+++ b/pkg/daemon/containerrecreate/crr_daemon_controller.go
@@ -101,10 +101,7 @@ func NewController(opts daemonoptions.Options) (*Controller, error) {
 			}
 		},
 		DeleteFunc: func(obj interface{}) {
-			crr, ok := obj.(*appsv1beta1.ContainerRecreateRequest)
-			if ok {
-				resourceVersionExpectation.Delete(crr)
-			}
+			enqueueAfterDelete(queue, obj)
 		},
 	})
 
@@ -156,6 +153,29 @@ func enqueue(queue workqueue.Interface, obj *appsv1beta1.ContainerRecreateReques
 		return
 	}
 	queue.Add(objectKey(obj))
+}
+
+// enqueueAfterDelete requeues the Pod so another CRR targeting it can be processed.
+// The filtered informer sends a delete event both when a CRR is deleted and when
+// its active label is removed after completion. It can also send a tombstone when
+// the original delete notification was missed.
+func enqueueAfterDelete(queue workqueue.Interface, obj interface{}) {
+	crr, ok := obj.(*appsv1beta1.ContainerRecreateRequest)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %+v", obj))
+			return
+		}
+		crr, ok = tombstone.Obj.(*appsv1beta1.ContainerRecreateRequest)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a ContainerRecreateRequest %+v", obj))
+			return
+		}
+	}
+
+	resourceVersionExpectation.Delete(crr)
+	queue.Add(objectKey(crr))
 }
 
 func objectKey(obj *appsv1beta1.ContainerRecreateRequest) string {

--- a/pkg/daemon/containerrecreate/crr_daemon_controller_test.go
+++ b/pkg/daemon/containerrecreate/crr_daemon_controller_test.go
@@ -36,18 +36,32 @@ func TestEnqueueAfterDelete(t *testing.T) {
 	}
 
 	tests := []struct {
-		name string
-		obj  interface{}
+		name    string
+		obj     interface{}
+		wantKey string
 	}{
 		{
-			name: "delete event",
-			obj:  crr,
+			name:    "delete event",
+			obj:     crr,
+			wantKey: "default/pod-1",
 		},
 		{
 			name: "delete tombstone",
 			obj: cache.DeletedFinalStateUnknown{
 				Key: "default/crr-1",
 				Obj: crr,
+			},
+			wantKey: "default/pod-1",
+		},
+		{
+			name: "unexpected delete object",
+			obj:  struct{}{},
+		},
+		{
+			name: "tombstone containing unexpected object",
+			obj: cache.DeletedFinalStateUnknown{
+				Key: "default/not-a-crr",
+				Obj: struct{}{},
 			},
 		},
 	}
@@ -59,6 +73,12 @@ func TestEnqueueAfterDelete(t *testing.T) {
 
 			enqueueAfterDelete(queue, tt.obj)
 
+			if tt.wantKey == "" {
+				if queue.Len() != 0 {
+					t.Fatalf("expected no queued key, got %d", queue.Len())
+				}
+				return
+			}
 			if queue.Len() != 1 {
 				t.Fatalf("expected one queued key, got %d", queue.Len())
 			}
@@ -67,8 +87,8 @@ func TestEnqueueAfterDelete(t *testing.T) {
 				t.Fatal("queue unexpectedly shut down")
 			}
 			defer queue.Done(key)
-			if key != "default/pod-1" {
-				t.Fatalf("expected key default/pod-1, got %v", key)
+			if key != tt.wantKey {
+				t.Fatalf("expected key %s, got %v", tt.wantKey, key)
 			}
 		})
 	}

--- a/pkg/daemon/containerrecreate/crr_daemon_controller_test.go
+++ b/pkg/daemon/containerrecreate/crr_daemon_controller_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2026 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package containerrecreate
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+
+	appsv1beta1 "github.com/openkruise/kruise/apis/apps/v1beta1"
+)
+
+func TestEnqueueAfterDelete(t *testing.T) {
+	crr := &appsv1beta1.ContainerRecreateRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "crr-1",
+		},
+		Spec: appsv1beta1.ContainerRecreateRequestSpec{PodName: "pod-1"},
+	}
+
+	tests := []struct {
+		name string
+		obj  interface{}
+	}{
+		{
+			name: "delete event",
+			obj:  crr,
+		},
+		{
+			name: "delete tombstone",
+			obj: cache.DeletedFinalStateUnknown{
+				Key: "default/crr-1",
+				Obj: crr,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			queue := workqueue.New()
+			defer queue.ShutDown()
+
+			enqueueAfterDelete(queue, tt.obj)
+
+			if queue.Len() != 1 {
+				t.Fatalf("expected one queued key, got %d", queue.Len())
+			}
+			key, shutdown := queue.Get()
+			if shutdown {
+				t.Fatal("queue unexpectedly shut down")
+			}
+			defer queue.Done(key)
+			if key != "default/pod-1" {
+				t.Fatalf("expected key default/pod-1, got %v", key)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

This PR prevents a `ContainerRecreateRequest` (CRR) from remaining `Pending` when it is created immediately after a completed CRR for the same Pod is deleted.

The kruise-daemon intentionally serializes CRRs by using `<namespace>/<podName>` as its workqueue key. A race was possible when a second CRR was created while the daemon informer still contained the first CRR:

1. The second CRR's add event queued the Pod.
2. The daemon's stale informer view still selected the first CRR, leaving the second CRR `Pending`.
3. When the first CRR was deleted or lost its `active` label after completion, the filtered informer's delete handler only cleared its resource-version expectation.
4. Because the informer has no periodic resync, no event queued the Pod again and the second CRR remained `Pending` indefinitely.

The delete handler now:

- clears the deleted CRR's resource-version expectation;
- requeues its Pod so the next pending CRR can progress; and
- handles `DeletedFinalStateUnknown` tombstones when the original delete notification was missed.

Unit coverage verifies that both normal delete events and tombstone delete events enqueue the expected Pod key. The existing one-at-a-time execution semantics for CRRs targeting the same Pod are preserved.

### Ⅱ. Does this pull request fix one issue?

Fixes #2474

### Ⅲ. Describe how to verify it

The following checks pass locally with Go 1.23.8:

```shell
go test -count=1 ./pkg/daemon/containerrecreate
go test -run TestEnqueueAfterDelete -count=100 ./pkg/daemon/containerrecreate
go vet ./pkg/daemon/containerrecreate
git diff --check
```

To verify the original scenario in a cluster:

1. Create a Pod containing two containers.
2. Create a CRR for the first container and wait for it to complete.
3. Delete that CRR and immediately create another CRR for the second container without sleeping.
4. Confirm that the second CRR advances from `Pending` to `Recreating` and then `Completed`.

### Ⅳ. Special notes for reviews

This change deliberately keeps the Pod-scoped queue key instead of allowing CRRs for one Pod to execute concurrently. It only restores the missing wake-up when the previous active CRR leaves the filtered informer.

`go test ./pkg/daemon/...` was also attempted. The modified `containerrecreate` package and the other daemon packages passed, except the unrelated existing `pkg/daemon/criruntime/imageruntime` test, which requires a credential-provider plugin binary that is not present in the local environment. A live cluster e2e run was not available locally.
