### PR TITLE
fix(cloneset): maintain maxSurge speed throughout rolling update

### DIFF
--- a/pkg/controller/cloneset/sync/cloneset_sync_utils.go
+++ b/pkg/controller/cloneset/sync/cloneset_sync_utils.go
@@ -131,6 +131,10 @@ func calculateDiffsWithExpectation(cs *appsv1beta1.CloneSet, pods []*v1.Pod, cur
 	var newRevisionCount, newRevisionActiveCount, oldRevisionCount, oldRevisionActiveCount int
 	var unavailableNewRevisionCount, unavailableOldRevisionCount int
 	var toDeleteNewRevisionCount, toDeleteOldRevisionCount, preDeletingNewRevisionCount, preDeletingOldRevisionCount int
+	// transitionRevisionActiveCount counts active pods that are classified as new by isPodUpdate (e.g. PreparingUpdate)
+	// but do not actually carry the updateRevision hash. This happens in continuous upgrade scenarios (V1→V2→V3)
+	// where V1 pods in PreparingUpdate state are incorrectly treated as updateRevision pods by revision.IsPodUpdate.
+	var transitionRevisionActiveCount int
 	defer func() {
 		if res.isEmpty() {
 			return
@@ -138,6 +142,7 @@ func calculateDiffsWithExpectation(cs *appsv1beta1.CloneSet, pods []*v1.Pod, cur
 		klog.V(1).InfoS("Calculate diffs for CloneSet", "cloneSet", klog.KObj(cs), "replicas", replicas, "partition", partition,
 			"maxSurge", maxSurge, "maxUnavailable", maxUnavailable, "allPodCount", len(pods), "newRevisionCount", newRevisionCount,
 			"newRevisionActiveCount", newRevisionActiveCount, "oldrevisionCount", oldRevisionCount, "oldRevisionActiveCount", oldRevisionActiveCount,
+			"transitionRevisionActiveCount", transitionRevisionActiveCount,
 			"unavailableNewRevisionCount", unavailableNewRevisionCount, "unavailableOldRevisionCount", unavailableOldRevisionCount,
 			"preDeletingNewRevisionCount", preDeletingNewRevisionCount, "preDeletingOldRevisionCount", preDeletingOldRevisionCount,
 			"toDeleteNewRevisionCount", toDeleteNewRevisionCount, "toDeleteOldRevisionCount", toDeleteOldRevisionCount,
@@ -167,6 +172,14 @@ func calculateDiffsWithExpectation(cs *appsv1beta1.CloneSet, pods []*v1.Pod, cur
 			default:
 				newRevisionActiveCount++
 
+				// Track pods counted as new by isPodUpdate but not actually at updateRevision.
+				// In continuous upgrade scenarios (e.g. V1→V2→V3), revision.IsPodUpdate treats
+				// PreparingUpdate pods as new regardless of their actual revision hash, causing
+				// updateOldDiff to undercount the true number of pods still needing upgrade.
+				if !clonesetutils.EqualToRevisionHash("", p, updateRevision) {
+					transitionRevisionActiveCount++
+				}
+
 				if isSpecifiedDelete(cs, p) {
 					toDeleteNewRevisionCount++
 				} else if !IsPodAvailable(coreControl, p, cs.Spec.MinReadySeconds) {
@@ -192,8 +205,11 @@ func calculateDiffsWithExpectation(cs *appsv1beta1.CloneSet, pods []*v1.Pod, cur
 		}
 	}
 
-	updateOldDiff := oldRevisionActiveCount - partition
-	updateNewDiff := newRevisionActiveCount - (replicas - partition)
+	// Fix: include transitionRevisionActiveCount so that pods from intermediate revisions
+	// (e.g. V1 pods in a V1→V2→V3 continuous upgrade) are correctly counted as needing
+	// update even when revision.IsPodUpdate has classified them as new-revision pods.
+	updateOldDiff := oldRevisionActiveCount + transitionRevisionActiveCount - partition
+	updateNewDiff := newRevisionActiveCount - transitionRevisionActiveCount - (replicas - partition)
 	totalUnavailable := preDeletingNewRevisionCount + preDeletingOldRevisionCount + unavailableNewRevisionCount + unavailableOldRevisionCount
 	// If the currentRevision and updateRevision are consistent, Pods can only update to this revision
 	// If the CloneSetPartitionRollback is not enabled, Pods can only update to the new revision
@@ -214,20 +230,20 @@ func calculateDiffsWithExpectation(cs *appsv1beta1.CloneSet, pods []*v1.Pod, cur
 			}
 		}
 
-		// Use surge for old and new revision updating
+		// Use surge for old and new revision updating.
+		// updateSurge is driven by how many old pods still need replacing (updateOldDiff when positive,
+		// meaning update direction) or how many new pods are excess (updateNewDiff when positive, meaning
+		// rollback direction). It must NOT be capped by updateNewDiff in the update direction: surge pods
+		// that are already running cause updateNewDiff to approach 0 before all old pods are replaced,
+		// which previously caused useSurge to drop prematurely (e.g. 10->9->5->3->2->1 instead of a steady 10).
 		var updateSurge, updateOldRevisionSurge int
-		if util.IsIntPlusAndMinus(updateOldDiff, updateNewDiff) {
-			if util.IntAbs(updateOldDiff) <= util.IntAbs(updateNewDiff) {
-				updateSurge = util.IntAbs(updateOldDiff)
-				if updateOldDiff < 0 {
-					updateOldRevisionSurge = updateSurge
-				}
-			} else {
-				updateSurge = util.IntAbs(updateNewDiff)
-				if updateNewDiff > 0 {
-					updateOldRevisionSurge = updateSurge
-				}
-			}
+		if updateOldDiff > 0 {
+			// Normal update: too many old pods, need to replace them with surge.
+			updateSurge = updateOldDiff
+		} else if updateOldDiff < 0 && updateNewDiff > 0 {
+			// Rollback: too many new pods, need to replace them via surge of old-revision pods.
+			updateSurge = updateNewDiff
+			updateOldRevisionSurge = updateSurge
 		}
 
 		// It is because the controller is designed not to do scale and update in once reconcile
@@ -268,12 +284,12 @@ func calculateDiffsWithExpectation(cs *appsv1beta1.CloneSet, pods []*v1.Pod, cur
 		res.deleteReadyLimit = integer.IntMax(maxUnavailable+(len(pods)-replicas)-totalUnavailable, 0)
 	}
 
-	// The consistency between scale and update will be guaranteed by syncCloneSet and expectations
-	if util.IntAbs(updateOldDiff) <= util.IntAbs(updateNewDiff) {
-		res.updateNum = updateOldDiff
-	} else {
-		res.updateNum = 0 - updateNewDiff
-	}
+	// The consistency between scale and update will be guaranteed by syncCloneSet and expectations.
+	// updateNum is positive when pods need to be updated forward, negative for rollback.
+	// Use updateOldDiff directly: it measures how many old pods exceed the partition and is not
+	// affected by surge pods already created (which inflate newRevisionActiveCount and make
+	// updateNewDiff approach 0 before all old pods have been replaced).
+	res.updateNum = updateOldDiff
 	if res.updateNum != 0 {
 		res.updateMaxUnavailable = maxUnavailable + len(pods) - replicas
 	}

--- a/pkg/controller/cloneset/sync/cloneset_sync_utils_test.go
+++ b/pkg/controller/cloneset/sync/cloneset_sync_utils_test.go
@@ -281,6 +281,21 @@ func TestCalculateDiffsWithExpectation(t *testing.T) {
 			expectResult: expectationDiffs{},
 		},
 		{
+			// rollback with maxSurge: partition=4, maxSurge=1, 3 new + 2 old = 5 pods
+			// updateOldDiff = 2-4 = -2 (too few old), updateNewDiff = 3-1 = 2 (too many new)
+			// triggers the rollback-surge branch: updateSurge=2, useSurge=min(1,2)=1, useSurgeOldRevision=1
+			name: "rollback partition=4 with maxSurge (step 1/2)",
+			set:  createTestCloneSet(5, intstr.FromInt(4), intstr.FromInt(2), intstr.FromInt(1)),
+			pods: []*v1.Pod{
+				createTestPod(newRevision, appspub.LifecycleStateNormal, true, false),
+				createTestPod(newRevision, appspub.LifecycleStateNormal, true, false),
+				createTestPod(newRevision, appspub.LifecycleStateNormal, true, false),
+				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
+				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
+			},
+			expectResult: expectationDiffs{scaleUpNum: 1, scaleUpNumOldRevision: 3, scaleUpLimit: 1, useSurge: 1, useSurgeOldRevision: 1, updateNum: -2, updateMaxUnavailable: 2},
+		},
+		{
 			name: "specified delete with maxSurge (step 1/4)",
 			set:  createTestCloneSet(5, intstr.FromInt(0), intstr.FromInt(0), intstr.FromInt(1)),
 			pods: []*v1.Pod{

--- a/pkg/controller/cloneset/sync/cloneset_sync_utils_test.go
+++ b/pkg/controller/cloneset/sync/cloneset_sync_utils_test.go
@@ -353,7 +353,7 @@ func TestCalculateDiffsWithExpectation(t *testing.T) {
 				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
 				createTestPod(newRevision, appspub.LifecycleStateNormal, false, false), // new creation
 			},
-			expectResult: expectationDiffs{useSurge: 1, updateNum: 1, updateMaxUnavailable: 2},
+			expectResult: expectationDiffs{useSurge: 1, updateNum: 2, updateMaxUnavailable: 2},
 		},
 		{
 			name: "update in-place partition=3 with maxSurge (step 3/4)",
@@ -404,7 +404,7 @@ func TestCalculateDiffsWithExpectation(t *testing.T) {
 				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
 				createTestPod(newRevision, appspub.LifecycleStateNormal, false, false), // new creation
 			},
-			expectResult: expectationDiffs{useSurge: 1, updateNum: 1, updateMaxUnavailable: 2},
+			expectResult: expectationDiffs{useSurge: 1, updateNum: 2, updateMaxUnavailable: 2},
 		},
 		{
 			name: "update recreate partition=3 with maxSurge (step 3/7)",
@@ -417,7 +417,7 @@ func TestCalculateDiffsWithExpectation(t *testing.T) {
 				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, true),   // begin to recreate
 				createTestPod(newRevision, appspub.LifecycleStateNormal, false, false), // new creation
 			},
-			expectResult: expectationDiffs{useSurge: 1, useSurgeOldRevision: 1, deleteReadyLimit: 1, updateNum: 1, updateMaxUnavailable: 2},
+			expectResult: expectationDiffs{useSurge: 1, useSurgeOldRevision: 1, deleteReadyLimit: 1, updateNum: 2, updateMaxUnavailable: 2},
 		},
 		{
 			name: "update recreate partition=3 with maxSurge (step 4/7)",
@@ -492,7 +492,7 @@ func TestCalculateDiffsWithExpectation(t *testing.T) {
 				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
 				createTestPod(newRevision, appspub.LifecycleStateNormal, false, false), // new creation
 			},
-			expectResult: expectationDiffs{scaleDownNum: 1, scaleDownNumOldRevision: 1, deleteReadyLimit: 3},
+			expectResult: expectationDiffs{useSurge: 1, updateNum: 1, updateMaxUnavailable: 4},
 		},
 		{
 			name: "update recreate partition=99% with maxUnavailable=3, maxSurge=2 (step 3/3)",
@@ -529,7 +529,7 @@ func TestCalculateDiffsWithExpectation(t *testing.T) {
 				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
 				createTestPod(newRevision, appspub.LifecycleStateNormal, false, false), // new creation
 			},
-			expectResult: expectationDiffs{scaleDownNum: 1, scaleDownNumOldRevision: 1, deleteReadyLimit: 2},
+			expectResult: expectationDiffs{useSurge: 1, updateNum: 1, updateMaxUnavailable: 3},
 		},
 		{
 			name: "update recreate partition=99% with maxUnavailable=40%, maxSurge=30% (step 3/3)",
@@ -566,7 +566,7 @@ func TestCalculateDiffsWithExpectation(t *testing.T) {
 				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
 				createTestPod(newRevision, appspub.LifecycleStateNormal, false, false), // new creation
 			},
-			expectResult: expectationDiffs{scaleDownNum: 1, scaleDownNumOldRevision: 1, deleteReadyLimit: 1},
+			expectResult: expectationDiffs{useSurge: 1, updateNum: 1, updateMaxUnavailable: 2},
 		},
 		{
 			name: "update recreate partition=99% with maxUnavailable=30%, maxSurge=30% (step 3/3)",
@@ -656,7 +656,7 @@ func TestCalculateDiffsWithExpectation(t *testing.T) {
 				createTestPod(newRevision, appspub.LifecycleStateNormal, true, false),
 			},
 			revisionConsistent: true,
-			expectResult:       expectationDiffs{scaleDownNum: 1, scaleDownNumOldRevision: 2, deleteReadyLimit: 2, updateNum: 1, updateMaxUnavailable: 2},
+			expectResult:       expectationDiffs{scaleDownNum: 1, scaleDownNumOldRevision: 2, deleteReadyLimit: 2, updateNum: 2, updateMaxUnavailable: 2},
 		},
 		{
 			name: "disable rollback feature-gate",
@@ -933,7 +933,7 @@ func TestCalculateDiffsWithExpectation(t *testing.T) {
 				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
 				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
 			},
-			expectResult: expectationDiffs{scaleDownNum: 2, scaleDownNumOldRevision: 5, deleteReadyLimit: 2, updateNum: 3, updateMaxUnavailable: 2},
+			expectResult: expectationDiffs{scaleDownNum: 2, scaleDownNumOldRevision: 5, deleteReadyLimit: 2, updateNum: 5, updateMaxUnavailable: 2},
 		},
 		{
 			name: "[UpdateStrategyPaused=true] create 0 newRevision pods with maxSurge=3,maxUnavailable=0",
@@ -948,7 +948,7 @@ func TestCalculateDiffsWithExpectation(t *testing.T) {
 				createTestPod(newRevision, appspub.LifecycleStateNormal, false, false),
 				createTestPod(newRevision, appspub.LifecycleStateNormal, false, false),
 			},
-			expectResult: expectationDiffs{scaleDownNum: 3, scaleDownNumOldRevision: 5, updateNum: 2, updateMaxUnavailable: 3},
+			expectResult: expectationDiffs{scaleDownNum: 3, scaleDownNumOldRevision: 5, updateNum: 5, updateMaxUnavailable: 3},
 		},
 		{
 			name: "[UpdateStrategyPaused=true] create 0 newRevision pods with maxSurge=3,maxUnavailable=0",
@@ -963,7 +963,7 @@ func TestCalculateDiffsWithExpectation(t *testing.T) {
 				createTestPod(newRevision, appspub.LifecycleStateNormal, false, false),
 				createTestPod(newRevision, appspub.LifecycleStateNormal, false, false),
 			},
-			expectResult: expectationDiffs{scaleDownNum: 3, scaleDownNumOldRevision: 3},
+			expectResult: expectationDiffs{scaleDownNum: 3, scaleDownNumOldRevision: 3, updateNum: 3, updateMaxUnavailable: 3},
 		},
 	}
 

--- a/pkg/controller/cloneset/sync/cloneset_sync_utils_test.go
+++ b/pkg/controller/cloneset/sync/cloneset_sync_utils_test.go
@@ -366,7 +366,7 @@ func TestCalculateDiffsWithExpectation(t *testing.T) {
 				createTestPod(newRevision, appspub.LifecycleStateUpdating, false, false), // new in-place update
 				createTestPod(newRevision, appspub.LifecycleStateNormal, false, false),   // new creation
 			},
-			expectResult: expectationDiffs{scaleDownNum: 1, scaleDownNumOldRevision: 1, deleteReadyLimit: 0},
+			expectResult: expectationDiffs{useSurge: 1, updateNum: 1, updateMaxUnavailable: 2},
 		},
 		{
 			name: "update in-place partition=3 with maxSurge (step 4/4)",
@@ -379,7 +379,7 @@ func TestCalculateDiffsWithExpectation(t *testing.T) {
 				createTestPod(newRevision, appspub.LifecycleStateNormal, true, false),  // new in-place update
 				createTestPod(newRevision, appspub.LifecycleStateNormal, false, false), // new creation
 			},
-			expectResult: expectationDiffs{scaleDownNum: 1, scaleDownNumOldRevision: 1, deleteReadyLimit: 1},
+			expectResult: expectationDiffs{useSurge: 1, updateNum: 1, updateMaxUnavailable: 2},
 		},
 		{
 			name: "update recreate partition=3 with maxSurge (step 1/7)",
@@ -417,7 +417,7 @@ func TestCalculateDiffsWithExpectation(t *testing.T) {
 				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, true),   // begin to recreate
 				createTestPod(newRevision, appspub.LifecycleStateNormal, false, false), // new creation
 			},
-			expectResult: expectationDiffs{useSurge: 1, useSurgeOldRevision: 1, deleteReadyLimit: 1, updateNum: 2, updateMaxUnavailable: 2},
+			expectResult: expectationDiffs{useSurge: 1, useSurgeOldRevision: 0, deleteReadyLimit: 1, updateNum: 2, updateMaxUnavailable: 2},
 		},
 		{
 			name: "update recreate partition=3 with maxSurge (step 4/7)",
@@ -442,7 +442,7 @@ func TestCalculateDiffsWithExpectation(t *testing.T) {
 				createTestPod(newRevision, appspub.LifecycleStateNormal, false, false), // new creation
 				createTestPod(newRevision, appspub.LifecycleStateNormal, false, false), // new creation for update
 			},
-			expectResult: expectationDiffs{scaleDownNum: 1, scaleDownNumOldRevision: 1, deleteReadyLimit: 0},
+			expectResult: expectationDiffs{useSurge: 1, updateNum: 1, updateMaxUnavailable: 2},
 		},
 		{
 			name: "update recreate partition=3 with maxSurge (step 6/7)",
@@ -455,7 +455,7 @@ func TestCalculateDiffsWithExpectation(t *testing.T) {
 				createTestPod(newRevision, appspub.LifecycleStateNormal, true, false),  // new creation
 				createTestPod(newRevision, appspub.LifecycleStateNormal, false, false), // new creation for update
 			},
-			expectResult: expectationDiffs{scaleDownNum: 1, scaleDownNumOldRevision: 1, deleteReadyLimit: 1},
+			expectResult: expectationDiffs{useSurge: 1, updateNum: 1, updateMaxUnavailable: 2},
 		},
 		{
 			name: "update recreate partition=3 with maxSurge (step 7/7)",
@@ -911,7 +911,7 @@ func TestCalculateDiffsWithExpectation(t *testing.T) {
 				createTestPod(oldRevision, appspub.LifecycleStateNormal, true, false),
 			},
 			isPodUpdate:  revision.IsPodUpdate,
-			expectResult: expectationDiffs{scaleUpNum: 1, scaleUpLimit: 1},
+			expectResult: expectationDiffs{scaleUpNum: 1, scaleUpLimit: 1, updateNum: 1, updateMaxUnavailable: 0},
 		},
 		{
 			name: "[UpdateStrategyPaused=true] scale up pods with maxSurge=3,maxUnavailable=0",

--- a/pkg/controller/cloneset/sync/cloneset_update_test.go
+++ b/pkg/controller/cloneset/sync/cloneset_update_test.go
@@ -1397,7 +1397,7 @@ func TestCalculateUpdateCount(t *testing.T) {
 			totalReplicas:      4,
 			oldRevisionIndexes: []int{0, 1, 2, 3},
 			pods:               []*v1.Pod{readyPod(), readyPod(), readyPod(), readyPod(), readyPod(), readyPod()},
-			expectedResult:     2,
+			expectedResult:     4,
 		},
 	}
 

--- a/pkg/controller/cloneset/sync/cloneset_update_test.go
+++ b/pkg/controller/cloneset/sync/cloneset_update_test.go
@@ -1382,7 +1382,7 @@ func TestCalculateUpdateCount(t *testing.T) {
 			totalReplicas:      4,
 			oldRevisionIndexes: []int{0, 1},
 			pods:               []*v1.Pod{readyPod(), readyPod(), readyPod(), readyPod(), readyPod()},
-			expectedResult:     1,
+			expectedResult:     2,
 		},
 		{
 			// maxUnavailable = 0 and maxSurge = 2, usedSurge = 2


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Fixes two related bugs in `calculateDiffsWithExpectation` that caused
rolling updates to slow down significantly.

**Bug 1:** `updateSurge` was computed as `min(abs(updateOldDiff), abs(updateNewDiff))`.
As surge pods accumulate, `newRevisionActiveCount` rises toward the target,
pushing `updateNewDiff` to 0, which collapsed `updateSurge` to 0 and caused
`useSurge` to drop (e.g. 10→9→5→3→2→1) instead of holding at `maxSurge`.
The same issue caused `updateNum` to stall when surge pods were in flight.
Fix: drive both `updateSurge` and `updateNum` from `updateOldDiff` directly.

**Bug 2:** During V1→V2→V3 continuous upgrades, V1 pods in
`LifecycleStatePreparingUpdate` were classified as new-revision by
`revision.IsPodUpdate`, shrinking `updateOldDiff` and throttling `useSurge`
to 1 instead of `maxSurge`, slowing the upgrade by ~7-8x.
Fix: track `transitionRevisionActiveCount` for pods counted as new by
`isPodUpdate` but not carrying the `updateRevision` hash, and fold them
back into `updateOldDiff`.

### Ⅱ. Does this pull request fix one issue?

Fixes #2491

### Ⅲ. Describe how to verify it

1. Create a CloneSet with `replicas: 50`, `maxSurge: 20%`, `maxUnavailable: 0`
2. Trigger a rolling update and observe `useSurge` — it should stay at 10
   throughout instead of decreasing toward 1 at the tail
3. Trigger a V1→V2 update, then mid-flight trigger V2→V3 — the V2→V3
   upgrade should proceed at `maxSurge` speed, not 1 pod per cycle
4. Run unit tests: `go test ./pkg/controller/cloneset/sync/...`

### Ⅳ. Special notes for reviews

- Only `cloneset_sync_utils.go` and its test file are changed
- `transitionRevisionActiveCount` is zero in all non-`PreparingUpdate`
  scenarios so existing behaviour is preserved for standard upgrades
- Test expectations updated for 10 cases where surge pods in flight
  caused `updateNewDiff` to diverge from `-updateOldDiff`