### PR TITLE
fix(client): strip non-numeric suffix from Minor version before semver parsing

### DIFF
--- a/pkg/client/registry.go
+++ b/pkg/client/registry.go
@@ -2,11 +2,16 @@ package client
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/coreos/go-semver/semver"
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/rest"
 )
+
+// nonDigitSuffix matches any trailing non-numeric characters in a version component,
+// e.g. "28+" or "19+" produced by some private Kubernetes distributions.
+var nonDigitSuffix = regexp.MustCompile(`[^0-9].*$`)
 
 var (
 	cfg *rest.Config
@@ -55,5 +60,12 @@ func GetCurrentServerVersion() *version.Info {
 // ShouldUpdateResourceByResize returns whether should update resource by resize
 // The resize sub-resource was introduced in version 1.32, https://github.com/kubernetes/kubernetes/pull/128266
 func ShouldUpdateResourceByResize() bool {
-	return semver.New(fmt.Sprintf("%s.%s.0", curVersion.Major, curVersion.Minor)).Compare(*semver.New("1.32.0")) >= 0
+	// Some private/custom Kubernetes distributions report Minor versions with a
+	// non-numeric suffix (e.g. "28+" or "19+"). Strip it before semver parsing
+	// to avoid a panic in semver.New.
+	minor := nonDigitSuffix.ReplaceAllString(curVersion.Minor, "")
+	if minor == "" {
+		minor = "0"
+	}
+	return semver.New(fmt.Sprintf("%s.%s.0", curVersion.Major, minor)).Compare(*semver.New("1.32.0")) >= 0
 }

--- a/pkg/client/registry_test.go
+++ b/pkg/client/registry_test.go
@@ -1,0 +1,74 @@
+package client
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/version"
+)
+
+func TestShouldUpdateResourceByResize(t *testing.T) {
+	tests := []struct {
+		name     string
+		major    string
+		minor    string
+		expected bool
+	}{
+		{
+			name:     "standard minor below 1.32",
+			major:    "1",
+			minor:    "28",
+			expected: false,
+		},
+		{
+			name:     "standard minor at 1.32",
+			major:    "1",
+			minor:    "32",
+			expected: true,
+		},
+		{
+			name:     "standard minor above 1.32",
+			major:    "1",
+			minor:    "33",
+			expected: true,
+		},
+		{
+			name:     "private build minor with plus suffix below 1.32",
+			major:    "1",
+			minor:    "19+",
+			expected: false,
+		},
+		{
+			name:     "private build minor with plus suffix below 1.32 (28+)",
+			major:    "1",
+			minor:    "28+",
+			expected: false,
+		},
+		{
+			name:     "private build minor with plus suffix at 1.32",
+			major:    "1",
+			minor:    "32+",
+			expected: true,
+		},
+		{
+			name:     "private build minor with plus suffix above 1.32",
+			major:    "1",
+			minor:    "35+",
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Temporarily override curVersion for the test.
+			orig := curVersion
+			curVersion = &version.Info{Major: tt.major, Minor: tt.minor}
+			defer func() { curVersion = orig }()
+
+			got := ShouldUpdateResourceByResize()
+			if got != tt.expected {
+				t.Errorf("ShouldUpdateResourceByResize() with Major=%q Minor=%q = %v, want %v",
+					tt.major, tt.minor, got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Some private/custom Kubernetes distributions report `Minor` versions with a trailing non-numeric suffix such as `"19+"` or `"28+"`. The `ShouldUpdateResourceByResize` function in `pkg/client/registry.go` passes this raw value directly to `semver.New`, which panics:

```
panic: "1.19+ is not in dotted-tri format"
```

This crash propagates through the in-place update reconcile loop and causes every StatefulSet reconcile to fail when running on these clusters.

This PR strips any trailing non-numeric characters from `curVersion.Minor` before constructing the semver string, preventing the panic. A unit test covering both plain and suffixed minor versions is included.

### Ⅱ. Does this pull request fix one issue?

Fixes #2404

### Ⅲ. Describe how to verify it

1. Set `curVersion.Minor = "19+"` (or `"28+"`) and call `ShouldUpdateResourceByResize()` — it should return `false` without panicking.
2. Run the new unit test: `go test ./pkg/client/... -run TestShouldUpdateResourceByResize -v`

### Ⅳ. Special notes for reviews

The regex `[^0-9].*$` is anchored to the first non-digit character and strips everything from that point onward, covering `"+"` suffixes as well as any other build-metadata conventions used by private distributions.