### PR TITLE
test: add coverage for scale expectations Delete and Get functions

### DIFF
--- a/pkg/util/expectations/scale_expectations_test.go
+++ b/pkg/util/expectations/scale_expectations_test.go
@@ -4,6 +4,60 @@ import (
 	"testing"
 )
 
+func TestDeleteExpectations(t *testing.T) {
+	e := NewScaleExpectations()
+	key := "default/cs-delete"
+	pod := "pod01"
+
+	// No-op delete on missing key should not panic
+	e.DeleteExpectations(key)
+
+	// Add expectation then delete
+	e.ExpectScale(key, Create, pod)
+	if ok, _, _ := e.SatisfiedExpectations(key); ok {
+		t.Fatal("expected unsatisfied before delete")
+	}
+	e.DeleteExpectations(key)
+	if ok, _, _ := e.SatisfiedExpectations(key); !ok {
+		t.Fatal("expected satisfied after DeleteExpectations")
+	}
+}
+
+func TestGetExpectations(t *testing.T) {
+	e := NewScaleExpectations()
+	key := "default/cs-get"
+	pod1 := "pod01"
+	pod2 := "pod02"
+
+	// No entry yet
+	if got := e.GetExpectations(key); got != nil {
+		t.Fatalf("expected nil for unknown key, got %v", got)
+	}
+
+	// Add create expectations
+	e.ExpectScale(key, Create, pod1)
+	e.ExpectScale(key, Create, pod2)
+	e.ExpectScale(key, Delete, pod1)
+
+	got := e.GetExpectations(key)
+	if got == nil {
+		t.Fatal("expected non-nil expectations map")
+	}
+	if !got[Create].Has(pod1) || !got[Create].Has(pod2) {
+		t.Fatalf("expected create set to contain %s and %s, got %v", pod1, pod2, got[Create])
+	}
+	if !got[Delete].Has(pod1) {
+		t.Fatalf("expected delete set to contain %s, got %v", pod1, got[Delete])
+	}
+
+	// GetExpectations should return a copy; mutating it should not affect the original
+	got[Create].Delete(pod1)
+	original := e.GetExpectations(key)
+	if !original[Create].Has(pod1) {
+		t.Fatal("GetExpectations should return a copy; mutating the result affected the source")
+	}
+}
+
 func TestScale(t *testing.T) {
 	e := NewScaleExpectations()
 	controllerKey01 := "default/cs01"


### PR DESCRIPTION
## Summary
Adds unit tests for `DeleteExpectations` and `GetExpectations`, improving coverage in `pkg/util/expectations`.

## Changes
- Added `TestDeleteExpectations` with 2 test cases: no-op delete on unknown key, and delete after expecting scale
- Added `TestGetExpectations` with 3 test cases: unknown key returns nil, populated expectations are returned correctly, and the returned map is a copy (mutations do not affect the source)

Signed-off-by: Goutham Annem <annem.usedu@gmail.com>