### PR TITLE
Fix NodePodProbe nil labels panic

### DIFF
--- a/pkg/controller/nodepodprobe/node_pod_probe_controller.go
+++ b/pkg/controller/nodepodprobe/node_pod_probe_controller.go
@@ -337,6 +337,9 @@ func (r *ReconcileNodePodProbe) updatePodProbeStatus(pod *corev1.Pod, status app
 			util.SetPodConditionIfMsgChanged(podClone, condition)
 		}
 		oldMetadata := podClone.ObjectMeta.DeepCopy()
+		if podClone.Labels == nil {
+			podClone.Labels = map[string]string{}
+		}
 		if podClone.Annotations == nil {
 			podClone.Annotations = map[string]string{}
 		}

--- a/pkg/controller/nodepodprobe/node_pod_probe_controller_test.go
+++ b/pkg/controller/nodepodprobe/node_pod_probe_controller_test.go
@@ -797,6 +797,54 @@ func TestSyncPodFromNodePodProbe(t *testing.T) {
 	}
 }
 
+func TestUpdatePodProbeStatusDoesNotPanicWithNilLabels(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-1",
+			Namespace: "default",
+		},
+	}
+	ppm := &appsv1alpha1.PodProbeMarker{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ppm-1",
+			Namespace: "default",
+		},
+		Spec: appsv1alpha1.PodProbeMarkerSpec{
+			Probes: []appsv1alpha1.PodContainerProbe{
+				{
+					Name: "healthy",
+					MarkerPolicy: []appsv1alpha1.ProbeMarkerPolicy{
+						{
+							State: appsv1alpha1.ProbeSucceeded,
+							Labels: map[string]string{
+								"server-healthy": "true",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	status := appsv1alpha1.PodProbeStatus{
+		ProbeStates: []appsv1alpha1.ContainerProbeState{
+			{
+				Name:  "ppm-1#healthy",
+				State: appsv1alpha1.ProbeSucceeded,
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pod, ppm).
+		Build()
+	recon := ReconcileNodePodProbe{Client: fakeClient}
+
+	if err := recon.updatePodProbeStatus(pod, status); err != nil {
+		t.Fatalf("updatePodProbeStatus failed: %s", err.Error())
+	}
+}
+
 func checkNodePodProbeEqual(c client.WithWatch, t *testing.T, expect []*appsv1alpha1.NodePodProbe) bool {
 	for i := range expect {
 		obj := expect[i]


### PR DESCRIPTION
### Ⅰ. PR does

Initialize `podClone.Labels` before applying labels from `PodProbeMarker` policies in `NodePodProbe`.

This prevents a panic when the target Pod has nil labels and a marker policy adds a label. A regression test covers updating a Pod with nil labels from a successful probe state.

### Ⅱ.  pull request fix one issue?

fixes #2499

### Ⅲ. verify it

Added `TestUpdatePodProbeStatusInitializesNilLabels`.

Not run locally because Go tooling is not installed in this environment.

### Ⅳ. Special notes for reviews

NONE