### PR TITLE
Respect metadata env refs in PUB resize checks

### DIFF
--- a/pkg/control/pubcontrol/pub_control.go
+++ b/pkg/control/pubcontrol/pub_control.go
@@ -40,6 +40,7 @@ import (
 	"github.com/openkruise/kruise/pkg/control/sidecarcontrol"
 	"github.com/openkruise/kruise/pkg/util"
 	utilclient "github.com/openkruise/kruise/pkg/util/client"
+	utilcontainermeta "github.com/openkruise/kruise/pkg/util/containermeta"
 	"github.com/openkruise/kruise/pkg/util/controllerfinder"
 	"github.com/openkruise/kruise/pkg/util/inplaceupdate"
 )
@@ -121,8 +122,49 @@ func (c *commonControl) CanResizeInplace(oldPod, newPod *corev1.Pod) bool {
 		return false
 	}
 
-	// TODO: Check annotations、labels bind with env using downwardAPI and considering `InPlaceUpdateEnvFromMetadata` featureGate in kruise-daemon
+	if isChangedMetadataReferencedByEnv(oldPod, newPod) {
+		klog.V(3).InfoS("Pod metadata referenced by env changed, and maybe cause unavailability", "pod", klog.KObj(newPod))
+		return false
+	}
 	return true
+}
+
+func isChangedMetadataReferencedByEnv(oldPod, newPod *corev1.Pod) bool {
+	for key, value := range newPod.Labels {
+		if isMapValueChanged(oldPod.Labels, key, value) && isAnyContainerReferenceToMeta(newPod.Spec.Containers, "metadata.labels", key) {
+			return true
+		}
+	}
+	for key, value := range oldPod.Labels {
+		if isMapValueChanged(newPod.Labels, key, value) && isAnyContainerReferenceToMeta(newPod.Spec.Containers, "metadata.labels", key) {
+			return true
+		}
+	}
+	for key, value := range newPod.Annotations {
+		if isMapValueChanged(oldPod.Annotations, key, value) && isAnyContainerReferenceToMeta(newPod.Spec.Containers, "metadata.annotations", key) {
+			return true
+		}
+	}
+	for key, value := range oldPod.Annotations {
+		if isMapValueChanged(newPod.Annotations, key, value) && isAnyContainerReferenceToMeta(newPod.Spec.Containers, "metadata.annotations", key) {
+			return true
+		}
+	}
+	return false
+}
+
+func isMapValueChanged(values map[string]string, key, oldValue string) bool {
+	value, exist := values[key]
+	return !exist || value != oldValue
+}
+
+func isAnyContainerReferenceToMeta(containers []corev1.Container, fieldPath, key string) bool {
+	for i := range containers {
+		if utilcontainermeta.IsContainerReferenceToMeta(&containers[i], fieldPath, key) {
+			return true
+		}
+	}
+	return false
 }
 
 // only allowedResizeResourceKey with NotRequired or "" restartPolicy can do inplace update

--- a/pkg/control/pubcontrol/pub_control_test.go
+++ b/pkg/control/pubcontrol/pub_control_test.go
@@ -322,6 +322,168 @@ func TestCanResizeInplace(t *testing.T) {
 			},
 			expect: false,
 		},
+		{
+			name: "resources changed with referenced label changed",
+			getOldPod: func() *corev1.Pod {
+				demo := podDemo.DeepCopy()
+				demo.Labels["version"] = "v1"
+				demo.Spec.Containers[0].Env = []corev1.EnvVar{
+					{
+						Name: "VERSION",
+						ValueFrom: &corev1.EnvVarSource{
+							FieldRef: &corev1.ObjectFieldSelector{
+								FieldPath: "metadata.labels['version']",
+							},
+						},
+					},
+				}
+				demo.Spec.Containers[0].Resources = corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("2Gi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("2"),
+						corev1.ResourceMemory: resource.MustParse("4Gi"),
+					},
+				}
+				return demo
+			},
+			getNewPod: func() *corev1.Pod {
+				demo := podDemo.DeepCopy()
+				demo.Labels["version"] = "v2"
+				demo.Spec.Containers[0].Env = []corev1.EnvVar{
+					{
+						Name: "VERSION",
+						ValueFrom: &corev1.EnvVarSource{
+							FieldRef: &corev1.ObjectFieldSelector{
+								FieldPath: "metadata.labels['version']",
+							},
+						},
+					},
+				}
+				demo.Spec.Containers[0].Resources = corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("3"),
+						corev1.ResourceMemory: resource.MustParse("3Gi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("2"),
+						corev1.ResourceMemory: resource.MustParse("4Gi"),
+					},
+				}
+				return demo
+			},
+			expect: false,
+		},
+		{
+			name: "resources changed with unrelated label changed",
+			getOldPod: func() *corev1.Pod {
+				demo := podDemo.DeepCopy()
+				demo.Labels["version"] = "v1"
+				demo.Spec.Containers[0].Env = []corev1.EnvVar{
+					{
+						Name: "APP",
+						ValueFrom: &corev1.EnvVarSource{
+							FieldRef: &corev1.ObjectFieldSelector{
+								FieldPath: "metadata.labels['app']",
+							},
+						},
+					},
+				}
+				demo.Spec.Containers[0].Resources = corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("2Gi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("2"),
+						corev1.ResourceMemory: resource.MustParse("4Gi"),
+					},
+				}
+				return demo
+			},
+			getNewPod: func() *corev1.Pod {
+				demo := podDemo.DeepCopy()
+				demo.Labels["version"] = "v2"
+				demo.Spec.Containers[0].Env = []corev1.EnvVar{
+					{
+						Name: "APP",
+						ValueFrom: &corev1.EnvVarSource{
+							FieldRef: &corev1.ObjectFieldSelector{
+								FieldPath: "metadata.labels['app']",
+							},
+						},
+					},
+				}
+				demo.Spec.Containers[0].Resources = corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("3"),
+						corev1.ResourceMemory: resource.MustParse("3Gi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("2"),
+						corev1.ResourceMemory: resource.MustParse("4Gi"),
+					},
+				}
+				return demo
+			},
+			expect: true,
+		},
+		{
+			name: "resources changed with referenced annotation changed",
+			getOldPod: func() *corev1.Pod {
+				demo := podDemo.DeepCopy()
+				demo.Annotations["config"] = "v1"
+				demo.Spec.Containers[0].Env = []corev1.EnvVar{
+					{
+						Name: "CONFIG",
+						ValueFrom: &corev1.EnvVarSource{
+							FieldRef: &corev1.ObjectFieldSelector{
+								FieldPath: "metadata.annotations['config']",
+							},
+						},
+					},
+				}
+				demo.Spec.Containers[0].Resources = corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("2Gi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("2"),
+						corev1.ResourceMemory: resource.MustParse("4Gi"),
+					},
+				}
+				return demo
+			},
+			getNewPod: func() *corev1.Pod {
+				demo := podDemo.DeepCopy()
+				demo.Annotations["config"] = "v2"
+				demo.Spec.Containers[0].Env = []corev1.EnvVar{
+					{
+						Name: "CONFIG",
+						ValueFrom: &corev1.EnvVarSource{
+							FieldRef: &corev1.ObjectFieldSelector{
+								FieldPath: "metadata.annotations['config']",
+							},
+						},
+					},
+				}
+				demo.Spec.Containers[0].Resources = corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("3"),
+						corev1.ResourceMemory: resource.MustParse("3Gi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("2"),
+						corev1.ResourceMemory: resource.MustParse("4Gi"),
+					},
+				}
+				return demo
+			},
+			expect: false,
+		},
 	}
 
 	for _, cs := range cases {


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Teach `PodUnavailableBudget` in-place resize checks to reject a resize as harmless when Pod labels or annotations changed and a container reads the changed key through downward API env.

This fills the existing TODO in `CanResizeInplace` and keeps PUB from treating this kind of update as safe when the metadata value can affect the running container environment.

### Ⅱ. Does this pull request fix one issue?

Related to #1192

### Ⅲ. Describe how to verify it

Added `TestCanResizeInplace` cases for:

- referenced label changed
- unrelated label changed
- referenced annotation changed

Not run locally because Go tooling is not installed in this environment.

### Ⅳ. Special notes for reviews

NONE