### PR TITLE
fix(client): avoid panic in ShouldUpdateResourceByResize on GKE/EKS version strings

### DIFF
--- a/pkg/client/registry.go
+++ b/pkg/client/registry.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/coreos/go-semver/semver"
 	"k8s.io/apimachinery/pkg/version"
@@ -54,6 +55,42 @@ func GetCurrentServerVersion() *version.Info {
 
 // ShouldUpdateResourceByResize returns whether should update resource by resize
 // The resize sub-resource was introduced in version 1.32, https://github.com/kubernetes/kubernetes/pull/128266
-func ShouldUpdateResourceByResize() bool {
-	return semver.New(fmt.Sprintf("%s.%s.0", curVersion.Major, curVersion.Minor)).Compare(*semver.New("1.32.0")) >= 0
+func ShouldUpdateResourceByResize() (result bool) {
+	defer func() {
+		if r := recover(); r != nil {
+			// semver.New panics on strings that are not in dotted-tri format
+			// (e.g. unexpected non-numeric content from custom build metadata).
+			// Treat that as "not >= 1.32" so the caller falls back to the
+			// pre-1.32 update path.
+			_ = r
+			result = false
+		}
+	}()
+	// coreos/go-semver does not strip the leading 'v' that k8s prefixes on
+	// GitVersion (e.g. "v1.32.0"). Remove it before parsing.
+	v := strings.TrimPrefix(curVersion.GitVersion, "v")
+	// digitsOnly cleans each dotted component so cloud-provider build metadata
+	// (e.g. "1.32+gke.1" → "1.32.1") does not cause a parse panic. SplitN
+	// keeps at most three parts (major/minor/patch); any extra segments are
+	// folded into the last part and then trimmed by digitsOnly. Any
+	// remaining format exception is caught by the deferred recover above.
+	parts := strings.SplitN(v, ".", 3)
+	for i, p := range parts {
+		parts[i] = digitsOnly(p)
+	}
+	cur := semver.New(strings.Join(parts, "."))
+	return cur.Compare(*semver.New("1.32.0")) >= 0
+}
+
+// digitsOnly returns the leading numeric prefix of a version component.
+// This handles GKE/EKS-style build metadata embedded in a component
+// (e.g. "32+gke" → "32"). If the input has no leading digit, an empty
+// string is returned.
+func digitsOnly(s string) string {
+	for i, r := range s {
+		if r < '0' || r > '9' {
+			return s[:i]
+		}
+	}
+	return s
 }

--- a/pkg/client/registry_test.go
+++ b/pkg/client/registry_test.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2026 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/version"
+)
+
+func TestDigitsOnly(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "empty string", in: "", want: ""},
+		{name: "plain digits", in: "28", want: "28"},
+		{name: "gke build metadata suffix", in: "32+gke", want: "32"},
+		{name: "eks build metadata suffix", in: "30+eks", want: "30"},
+		{name: "trailing plus", in: "28+", want: "28"},
+		{name: "major with plus", in: "1+", want: "1"},
+		{name: "all non-numeric", in: "+++", want: ""},
+		{name: "letters only", in: "abc", want: ""},
+		{name: "leading digits then letters", in: "1a2b3c", want: "1"},
+		{name: "zero", in: "0", want: "0"},
+		{name: "large number", in: "132", want: "132"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := digitsOnly(tc.in); got != tc.want {
+				t.Errorf("digitsOnly(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestShouldUpdateResourceByResize(t *testing.T) {
+	original := curVersion
+	t.Cleanup(func() {
+		curVersion = original
+	})
+
+	cases := []struct {
+		name    string
+		version *version.Info
+		want    bool
+	}{
+		{
+			name:    "exactly 1.32.0 returns true",
+			version: &version.Info{Major: "1", Minor: "32", GitVersion: "v1.32.0"},
+			want:    true,
+		},
+		{
+			name:    "above 1.32 returns true",
+			version: &version.Info{Major: "1", Minor: "33", GitVersion: "v1.33.0"},
+			want:    true,
+		},
+		{
+			name:    "below 1.32 returns false",
+			version: &version.Info{Major: "1", Minor: "31", GitVersion: "v1.31.0"},
+			want:    false,
+		},
+		{
+			name:    "gke-style 1.28+gke.1 is cleaned to 1.28.1 and returns false",
+			version: &version.Info{Major: "1", Minor: "28+", GitVersion: "v1.28+gke.1"},
+			want:    false,
+		},
+		{
+			name:    "gke-style 1.32+gke.1 is cleaned to 1.32.1 and returns true",
+			version: &version.Info{Major: "1", Minor: "32+", GitVersion: "v1.32+gke.1"},
+			want:    true,
+		},
+		{
+			name:    "eks-style 1.30+eks.1 is cleaned to 1.30.1 and returns false",
+			version: &version.Info{Major: "1", Minor: "30+", GitVersion: "v1.30+eks.1"},
+			want:    false,
+		},
+		{
+			name:    "1.28+.1 is cleaned to 1.28.1 and returns false",
+			version: &version.Info{Major: "1", Minor: "28+", GitVersion: "v1.28+.1"},
+			want:    false,
+		},
+		{
+			name:    "extra segment after patch is folded into patch and cleaned to 1.32.0",
+			version: &version.Info{Major: "1", Minor: "32", GitVersion: "v1.32.0.extra"},
+			want:    true,
+		},
+		{
+			name:    "empty GitVersion recovers from panic and returns false",
+			version: &version.Info{Major: "1", Minor: ""},
+			want:    false,
+		},
+		{
+			name:    "non-semver garbage recovers from panic and returns false",
+			version: &version.Info{Major: "1", Minor: "32", GitVersion: "garbage"},
+			want:    false,
+		},
+		{
+			name:    "missing patch segment recovers from panic and returns false",
+			version: &version.Info{Major: "1", Minor: "32", GitVersion: "1.32"},
+			want:    false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			curVersion = tc.version
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("ShouldUpdateResourceByResize leaked a panic for GitVersion=%q: %v",
+						tc.version.GitVersion, r)
+				}
+			}()
+			if got := ShouldUpdateResourceByResize(); got != tc.want {
+				t.Errorf("ShouldUpdateResourceByResize() for GitVersion=%q = %v, want %v",
+					tc.version.GitVersion, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What changed

`ShouldUpdateResourceByResize` in `pkg/client/registry.go` no longer panics when the K8s server reports a version with non-numeric build metadata (e.g. `v1.28+gke.1` from GKE, `v1.30+eks.1` from EKS, or any other non-dotted-tri input).

## Why

`github.com/coreos/go-semver` `semver.New` calls `Must`, which panics on any string that is not in dotted-tri format. The previous implementation built the version string via `fmt.Sprintf("%s.%s.0", curVersion.Major, curVersion.Minor)`. When `curVersion` was populated from a cloud-provider K8s API server whose `Minor` carries a trailing `+` or whose `GitVersion` includes build metadata, the resulting `1.28+.0` triggered the panic and crashed the controller on startup.

## Affected modules & external behavior

- `pkg/client/registry.go`
  - Strips the leading `v` from `curVersion.GitVersion` (k8s standard, not stripped by coreos/go-semver).
  - New `digitsOnly` helper keeps the leading numeric prefix of each dotted component, so cloud-provider build metadata is dropped before parsing (`1.32+gke.1` -> `1.32.1`).
  - Deferred `recover()` in `ShouldUpdateResourceByResize` (named return `result`) catches any remaining parse panic and returns `false`, preserving the pre-1.32 update path as a safe default.
  - `curVersion` is now driven by `GitVersion` (the natural full-version field on `version.Info`); `Major`/`Minor` are no longer used by this function.
- `pkg/client/registry_test.go` (new)
  - `TestDigitsOnly` (11 cases).
  - `TestShouldUpdateResourceByResize` (10 cases) covering standard `v1.32.0`/`v1.33.0`/`v1.31.0`, cleaned GKE/EKS variants, plus panic-recovery cases (empty, garbage, missing patch).

No API, CRD, or RBAC changes. Backward compatible — the function returns the same boolean it always did for normal upstream k8s versions.

## Recommended reading order

1. `pkg/client/registry.go` — function + `digitsOnly` helper.
2. `pkg/client/registry_test.go` — verifies the no-panic contract and the GKE/EKS cleanup.

## Test evidence

```
$ go test -race ./pkg/client/
ok      github.com/openkruise/kruise/pkg/client 1.681s
```