### PR TITLE
fix(e2e): poll for LastTerminationState in 'recreates containers by force'

### DIFF
--- a/test/e2e/apps/v1alpha1/containerrecreate.go
+++ b/test/e2e/apps/v1alpha1/containerrecreate.go
@@ -566,6 +566,17 @@ var _ = ginkgo.Describe("ContainerRecreateRequest", ginkgo.Label("ContainerRecre
 				gomega.Expect(sidecarContainerStatus.RestartCount).Should(gomega.Equal(int32(1)))
 
 				ginkgo.By("Check Pod sidecar container recreated not waiting for app container ready")
+				// LastTerminationState.Terminated may not yet be populated by the
+				// kubelet right after a force-recreate, so poll until both
+				// containers have a previous termination recorded.
+				gomega.Eventually(func() bool {
+					pod, err = tester.GetPod(pod.Name)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					appContainerStatus = util.GetContainerStatus("app", pod)
+					sidecarContainerStatus = util.GetContainerStatus("sidecar", pod)
+					return appContainerStatus.LastTerminationState.Terminated != nil &&
+						sidecarContainerStatus.LastTerminationState.Terminated != nil
+				}, 30*time.Second, time.Second).Should(gomega.Equal(true))
 				interval := sidecarContainerStatus.LastTerminationState.Terminated.FinishedAt.Sub(appContainerStatus.LastTerminationState.Terminated.FinishedAt.Time)
 				gomega.Expect(interval < 3*time.Second).Should(gomega.Equal(true))
 			}
@@ -621,6 +632,17 @@ var _ = ginkgo.Describe("ContainerRecreateRequest", ginkgo.Label("ContainerRecre
 				gomega.Expect(sidecarContainerStatus.RestartCount).Should(gomega.Equal(int32(1)))
 
 				ginkgo.By("Check Pod sidecar container recreated after app container ready")
+				// LastTerminationState.Terminated may not yet be populated by the
+				// kubelet right after a force-recreate, so poll until both
+				// containers have a previous termination recorded.
+				gomega.Eventually(func() bool {
+					pod, err = tester.GetPod(pod.Name)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					appContainerStatus = util.GetContainerStatus("app", pod)
+					sidecarContainerStatus = util.GetContainerStatus("sidecar", pod)
+					return appContainerStatus.LastTerminationState.Terminated != nil &&
+						sidecarContainerStatus.LastTerminationState.Terminated != nil
+				}, 30*time.Second, time.Second).Should(gomega.Equal(true))
 				interval := sidecarContainerStatus.LastTerminationState.Terminated.FinishedAt.Sub(appContainerStatus.LastTerminationState.Terminated.FinishedAt.Time)
 				gomega.Expect(interval >= 5*time.Second).Should(gomega.Equal(true))
 			}


### PR DESCRIPTION
## What

Harden the `recreates containers by force` e2e test by wrapping the access to
`containerStatus.LastTerminationState.Terminated` in `gomega.Eventually` so the
test waits for the kubelet to record the previous termination before reading
the timestamps.

## Why

CI job [84715171482](https://github.com/openkruise/kruise/actions/runs/28573091910/job/84715171482?pr=2502)
panicked with:

```
runtime error: invalid memory address or nil pointer dereference
  at test/e2e/apps/v1alpha1/containerrecreate.go:624
```

The test reads `.LastTerminationState.Terminated` immediately after
`CRR` completes, but right after a force-recreate the kubelet may not have
populated the previous-termination state for the killed containers yet, so
the field is still `nil`. The same `It` has the same pattern in its first
block (line 568), which is also at risk for the same flake.

## Affected modules & external behavior

- `test/e2e/apps/v1alpha1/containerrecreate.go` — only the test code;
  no production code or external behavior changes.
- The test now waits up to 30s for both containers to have a non-nil
  `LastTerminationState.Terminated` before the time-interval check,
  matching the pattern already used by the `recreates containers with
  preStopHook` test in the same file.

## Recommended reading order

1. `test/e2e/apps/v1alpha1/containerrecreate.go` (lines 558-581 and 623-647)

## Testing

- `go vet ./test/e2e/apps/v1alpha1/...` passes
- `go build ./test/e2e/...` succeeds
- `gofmt` reports no diff
- Full e2e regression will be exercised by the existing CI `operation`
  job once this PR is merged.