### PR TITLE
feat: support in-place update for restartable init containers

### DIFF
--- a/pkg/controller/cloneset/cloneset_predownload_image.go
+++ b/pkg/controller/cloneset/cloneset_predownload_image.go
@@ -196,5 +196,10 @@ func diffImagesBetweenRevisions(oldRevision, newRevision *apps.ControllerRevisio
 			containerImages[name] = newImage
 		}
 	}
+	// Also pre-download the images of restartable init containers (native sidecar containers)
+	// when they can be in-place updated.
+	for name, image := range inplaceupdate.DiffRestartableInitContainerImages(oldTemp, newTemp) {
+		containerImages[name] = image
+	}
 	return containerImages
 }

--- a/pkg/controller/cloneset/core/cloneset_core.go
+++ b/pkg/controller/cloneset/core/cloneset_core.go
@@ -19,7 +19,6 @@ package core
 import (
 	"encoding/json"
 	"fmt"
-	"regexp"
 
 	"github.com/appscode/jsonpatch"
 	v1 "k8s.io/api/core/v1"
@@ -35,10 +34,6 @@ import (
 	"github.com/openkruise/kruise/pkg/features"
 	utilfeature "github.com/openkruise/kruise/pkg/util/feature"
 	"github.com/openkruise/kruise/pkg/util/inplaceupdate"
-)
-
-var (
-	inPlaceUpdateTemplateSpecPatchRexp = regexp.MustCompile("^/containers/([0-9]+)/image$")
 )
 
 type commonControl struct {
@@ -165,11 +160,9 @@ func (c *commonControl) ValidateCloneSetUpdate(oldCS, newCS *appsv1beta1.CloneSe
 		return fmt.Errorf("failed calculate patches between old/new template spec")
 	}
 
-	for _, p := range patches {
-		if p.Operation != "replace" || !inPlaceUpdateTemplateSpecPatchRexp.MatchString(p.Path) {
-			return fmt.Errorf("only allowed to update images in spec for %s, but found %s %s",
-				appsv1beta1.InPlaceOnlyCloneSetPodUpdateStrategyType, p.Operation, p.Path)
-		}
+	if err := inplaceupdate.ValidateInPlaceOnlyTemplateSpecPatches(patches, &oldCS.Spec.Template, &newCS.Spec.Template); err != nil {
+		return fmt.Errorf("only allowed to update images in spec for %s, but found %v",
+			appsv1beta1.InPlaceOnlyCloneSetPodUpdateStrategyType, err)
 	}
 	return nil
 }

--- a/pkg/controller/containerrecreaterequest/crr_controller.go
+++ b/pkg/controller/containerrecreaterequest/crr_controller.go
@@ -244,7 +244,11 @@ func (r *ReconcileContainerRecreateRequest) syncContainerStatuses(crr *appsv1bet
 	syncContainerStatuses := make([]appsv1beta1.ContainerRecreateRequestSyncContainerStatus, 0, len(crr.Spec.Containers))
 	for i := range crr.Spec.Containers {
 		c := &crr.Spec.Containers[i]
-		containerStatus := util.GetContainerStatus(c.Name, pod)
+		// Look up status.initContainerStatuses as well, for a restartable init container
+		// (native sidecar container) reports its status there rather than in
+		// status.containerStatuses. Without it the synced status would be missing and
+		// kruise-daemon could never mark the recreation of such a container as succeeded.
+		containerStatus := util.GetContainerStatusIncludingInit(c.Name, pod)
 		if containerStatus == nil {
 			klog.InfoS("Could not find container in Pod Status for CRR", "containerName", c.Name, "containerRecreateRequest", klog.KObj(crr))
 			continue

--- a/pkg/controller/daemonset/daemonset_predownload_image.go
+++ b/pkg/controller/daemonset/daemonset_predownload_image.go
@@ -165,5 +165,19 @@ func diffImagesBetweenRevisions(oldRevisions []*apps.ControllerRevision, newRevi
 			containerImages[name] = newImage
 		}
 	}
+	// Also pre-download the images of restartable init containers (native sidecar containers)
+	// when they can be in-place updated. An image is pre-downloaded as long as it differs from
+	// any of the old revisions, which keeps the same semantics as the loop above.
+	initOldTemps := oldTemps
+	if len(initOldTemps) == 0 {
+		// Diff against an empty template, so that every restartable init container image is
+		// pre-downloaded. It matches the `!found` branch of the loop above.
+		initOldTemps = []*v1.PodTemplateSpec{{}}
+	}
+	for _, oldTemp := range initOldTemps {
+		for name, image := range inplaceupdate.DiffRestartableInitContainerImages(oldTemp, newTemp) {
+			containerImages[name] = image
+		}
+	}
 	return containerImages
 }

--- a/pkg/controller/daemonset/daemonset_predownload_image_test.go
+++ b/pkg/controller/daemonset/daemonset_predownload_image_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2026 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package daemonset
+
+import (
+	"fmt"
+	"testing"
+
+	apps "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/openkruise/kruise/pkg/features"
+	utilfeature "github.com/openkruise/kruise/pkg/util/feature"
+)
+
+func revisionOf(name, raw string) *apps.ControllerRevision {
+	return &apps.ControllerRevision{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Data:       runtime.RawExtension{Raw: []byte(raw)},
+	}
+}
+
+func setRestartableInitContainerGate(t *testing.T, enabled bool) {
+	t.Helper()
+
+	if err := utilfeature.DefaultMutableFeatureGate.Set(
+		fmt.Sprintf("%s=%v", features.InPlaceUpdateRestartableInitContainer, enabled)); err != nil {
+		t.Fatalf("failed to set feature-gate: %v", err)
+	}
+}
+
+// TestDiffImagesBetweenRevisionsForRestartableInitContainer makes sure the images of the
+// restartable init containers (native sidecar containers) are pre-downloaded as well.
+// Advanced DaemonSet uses the default CalculateSpec of the inplaceupdate package, so it does
+// in-place update such containers and therefore has to pre-download their images too.
+func TestDiffImagesBetweenRevisionsForRestartableInitContainer(t *testing.T) {
+	const (
+		// "sidecar" is restartable, "setup" is a regular init container
+		oldRaw = `{"spec":{"template":{"spec":{"containers":[{"name":"main","image":"main1"}],"initContainers":[{"name":"setup","image":"setup1"},{"name":"sidecar","image":"foo1","restartPolicy":"Always"}]}}}}`
+		newRaw = `{"spec":{"template":{"spec":{"containers":[{"name":"main","image":"main1"}],"initContainers":[{"name":"setup","image":"setup2"},{"name":"sidecar","image":"foo2","restartPolicy":"Always"}]}}}}`
+		// an older revision where the sidecar image is yet another one
+		olderRaw = `{"spec":{"template":{"spec":{"containers":[{"name":"main","image":"main1"}],"initContainers":[{"name":"setup","image":"setup1"},{"name":"sidecar","image":"foo0","restartPolicy":"Always"}]}}}}`
+	)
+
+	cases := []struct {
+		name         string
+		gateEnabled  bool
+		oldRevisions []*apps.ControllerRevision
+		expect       map[string]string
+	}{
+		{
+			name:         "gate disabled keeps the previous behavior",
+			gateEnabled:  false,
+			oldRevisions: []*apps.ControllerRevision{revisionOf("old", oldRaw)},
+			expect:       map[string]string{},
+		},
+		{
+			name:         "only the restartable init container image is pre-downloaded",
+			gateEnabled:  true,
+			oldRevisions: []*apps.ControllerRevision{revisionOf("old", oldRaw)},
+			expect:       map[string]string{"sidecar": "foo2"},
+		},
+		{
+			name:        "differs from any of the old revisions",
+			gateEnabled: true,
+			oldRevisions: []*apps.ControllerRevision{
+				revisionOf("old", oldRaw),
+				revisionOf("older", olderRaw),
+			},
+			expect: map[string]string{"sidecar": "foo2"},
+		},
+		{
+			name:         "no old revision pre-downloads everything",
+			gateEnabled:  true,
+			oldRevisions: nil,
+			expect:       map[string]string{"main": "main1", "sidecar": "foo2"},
+		},
+	}
+
+	defer setRestartableInitContainerGate(t, false)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			setRestartableInitContainerGate(t, tc.gateEnabled)
+
+			got := diffImagesBetweenRevisions(tc.oldRevisions, revisionOf("new", newRaw))
+			if len(got) != len(tc.expect) {
+				t.Fatalf("expected %v, got %v", tc.expect, got)
+			}
+			for k, v := range tc.expect {
+				if got[k] != v {
+					t.Fatalf("expected %v, got %v", tc.expect, got)
+				}
+			}
+		})
+	}
+}

--- a/pkg/controller/statefulset/statefulset_predownload_image.go
+++ b/pkg/controller/statefulset/statefulset_predownload_image.go
@@ -184,5 +184,10 @@ func diffImagesBetweenRevisions(oldRevision, newRevision *apps.ControllerRevisio
 			containerImages[name] = newImage
 		}
 	}
+	// Also pre-download the images of restartable init containers (native sidecar containers)
+	// when they can be in-place updated.
+	for name, image := range inplaceupdate.DiffRestartableInitContainerImages(oldTemp, newTemp) {
+		containerImages[name] = image
+	}
 	return containerImages
 }

--- a/pkg/daemon/containermeta/container_meta_controller.go
+++ b/pkg/daemon/containermeta/container_meta_controller.go
@@ -156,26 +156,67 @@ func eventFilter(oldPod, newPod *v1.Pod) bool {
 		return true
 	}
 	containerMetaSet, _ := appspub.GetRuntimeContainerMetaSet(newPod)
-	for i := range newPod.Status.ContainerStatuses {
-		if newPod.Status.ContainerStatuses[i].ContainerID == "" {
-			continue
+
+	// Look up the reported meta by container name rather than by index, because the meta set
+	// contains the restartable init containers (native sidecar containers) as well and therefore
+	// no longer aligns with status.containerStatuses positionally.
+	var metaByName map[string]*appspub.RuntimeContainerMeta
+	if containerMetaSet != nil {
+		metaByName = make(map[string]*appspub.RuntimeContainerMeta, len(containerMetaSet.Containers))
+		for i := range containerMetaSet.Containers {
+			metaByName[containerMetaSet.Containers[i].Name] = &containerMetaSet.Containers[i]
 		}
-		if containerMetaSet == nil || len(containerMetaSet.Containers) != len(newPod.Status.ContainerStatuses) {
-			return true
-		}
-		if containerMetaSet.Containers[i].ContainerID != newPod.Status.ContainerStatuses[i].ContainerID {
-			return true
-		}
-		if utilfeature.DefaultFeatureGate.Enabled(features.InPlaceUpdateEnvFromMetadata) {
-			hasher := utilcontainermeta.NewEnvFromMetadataHasher()
-			newHash := hasher.GetExpectHash(&newPod.Spec.Containers[i], newPod)
-			if newHash != containerMetaSet.Containers[i].Hashes.ExtractedEnvFromMetadataHash {
+	}
+
+	// expectedCount counts the containers that should be reported, so that a stale meta set which
+	// still contains a removed container can be detected.
+	var expectedCount int
+	changed := func(statuses []v1.ContainerStatus, onlyRestartableInit bool) bool {
+		for i := range statuses {
+			cs := &statuses[i]
+			containerSpec := util.GetContainer(cs.Name, newPod)
+			if containerSpec == nil {
+				continue
+			}
+			if onlyRestartableInit && !util.IsRestartableInitContainer(containerSpec) {
+				continue
+			}
+			expectedCount++
+			if cs.ContainerID == "" {
+				continue
+			}
+			if containerMetaSet == nil {
 				return true
 			}
-			if oldPod != nil && newHash != hasher.GetExpectHash(&oldPod.Spec.Containers[i], oldPod) {
+			meta, ok := metaByName[cs.Name]
+			if !ok || meta.ContainerID != cs.ContainerID {
 				return true
 			}
+			if utilfeature.DefaultFeatureGate.Enabled(features.InPlaceUpdateEnvFromMetadata) {
+				hasher := utilcontainermeta.NewEnvFromMetadataHasher()
+				newHash := hasher.GetExpectHash(containerSpec, newPod)
+				if newHash != meta.Hashes.ExtractedEnvFromMetadataHash {
+					return true
+				}
+				if oldPod != nil {
+					if oldSpec := util.GetContainer(cs.Name, oldPod); oldSpec != nil &&
+						newHash != hasher.GetExpectHash(oldSpec, oldPod) {
+						return true
+					}
+				}
+			}
 		}
+		return false
+	}
+
+	if changed(newPod.Status.InitContainerStatuses, true) {
+		return true
+	}
+	if changed(newPod.Status.ContainerStatuses, false) {
+		return true
+	}
+	if containerMetaSet != nil && expectedCount > 0 && len(containerMetaSet.Containers) != expectedCount {
+		return true
 	}
 	return false
 }
@@ -319,66 +360,98 @@ func (c *Controller) reportContainerMetaSet(pod *v1.Pod, oldMetaSet, newMetaSet 
 }
 
 func (c *Controller) manageContainerMetaSet(pod *v1.Pod, kubePodStatus *kubeletcontainer.PodStatus, oldMetaSet *appspub.RuntimeContainerMetaSet, criRuntime criapi.RuntimeService) *appspub.RuntimeContainerMetaSet {
-	var err error
-	metaSet := appspub.RuntimeContainerMetaSet{Containers: make([]appspub.RuntimeContainerMeta, 0, len(pod.Status.ContainerStatuses))}
-	for _, cs := range pod.Status.ContainerStatuses {
-		status := kubePodStatus.FindContainerStatusByName(cs.Name)
-		if status == nil {
+	metaSet := appspub.RuntimeContainerMetaSet{
+		Containers: make([]appspub.RuntimeContainerMeta, 0, len(pod.Status.InitContainerStatuses)+len(pod.Status.ContainerStatuses)),
+	}
+
+	// Report the restartable init containers (native sidecar containers) as well, so that the
+	// workload controllers can verify their in-place update with the container hash, instead of
+	// falling back to the weaker imageID comparison.
+	//
+	// Regular init containers are skipped on purpose: they exit after completion and kubelet
+	// never restarts them when their spec changes, so their runtime meta would never become
+	// consistent and their containerID may already have been garbage collected.
+	//
+	// Note that the order here must be stable, for the meta set is compared with the previous one
+	// to decide whether the Pod annotation has to be patched.
+	for i := range pod.Status.InitContainerStatuses {
+		containerSpec := util.GetContainer(pod.Status.InitContainerStatuses[i].Name, pod)
+		if containerSpec == nil || !util.IsRestartableInitContainer(containerSpec) {
 			continue
 		}
-		containerSpec := util.GetContainer(cs.Name, pod)
+		if meta := c.buildContainerMeta(pod, containerSpec, kubePodStatus, oldMetaSet, criRuntime); meta != nil {
+			metaSet.Containers = append(metaSet.Containers, *meta)
+		}
+	}
+
+	for i := range pod.Status.ContainerStatuses {
+		containerSpec := util.GetContainer(pod.Status.ContainerStatuses[i].Name, pod)
 		if containerSpec == nil {
 			continue
 		}
-
-		var containerMeta *appspub.RuntimeContainerMeta
-		if oldMetaSet != nil {
-			for i := range oldMetaSet.Containers {
-				if oldMetaSet.Containers[i].ContainerID == status.ID.String() {
-					containerMeta = oldMetaSet.Containers[i].DeepCopy()
-				}
-			}
+		if meta := c.buildContainerMeta(pod, containerSpec, kubePodStatus, oldMetaSet, criRuntime); meta != nil {
+			metaSet.Containers = append(metaSet.Containers, *meta)
 		}
-		if containerMeta == nil {
-			containerMeta = &appspub.RuntimeContainerMeta{
-				Name:         status.Name,
-				ContainerID:  status.ID.String(),
-				RestartCount: int32(status.RestartCount),
-				Hashes: appspub.RuntimeContainerHashes{
-					PlainHash: status.Hash,
-				},
-			}
-		}
-		if utilfeature.DefaultFeatureGate.Enabled(features.InPlaceUpdateEnvFromMetadata) {
-			envHasher := utilcontainermeta.NewEnvFromMetadataHasher()
-
-			if containerMeta.Hashes.ExtractedEnvFromMetadataHash == 0 && status.State == kubeletcontainer.ContainerStateRunning {
-				envGetter := wrapEnvGetter(criRuntime, status.ID.ID, fmt.Sprintf("container %s (%s) in Pod %s/%s", containerSpec.Name, status.ID.String(), pod.Namespace, pod.Name))
-				containerMeta.Hashes.ExtractedEnvFromMetadataHash, err = envHasher.GetCurrentHash(containerSpec, envGetter)
-				if err != nil {
-					klog.ErrorS(err, "Failed to hash container with env for Pod", "containerName", containerSpec.Name, "containerID", status.ID.String(), "namespace", pod.Namespace, "podName", pod.Name)
-					enqueueAfter(c.queue, pod, time.Second*3)
-				} else {
-					klog.V(4).InfoS("Extracted env from metadata for container",
-						"containerName", containerSpec.Name, "containerID", status.ID.String(), "namespace", pod.Namespace, "podName", pod.Name, "hash", containerMeta.Hashes.ExtractedEnvFromMetadataHash)
-				}
-			}
-
-			// Trigger restarting only if it is in-place updating
-			_, condition := podutil.GetPodCondition(&pod.Status, appspub.InPlaceUpdateReady)
-			if condition != nil && condition.Status == v1.ConditionFalse {
-				// Trigger restarting when expected env hash is not equal to current hash
-				if containerMeta.Hashes.ExtractedEnvFromMetadataHash > 0 && containerMeta.Hashes.ExtractedEnvFromMetadataHash != envHasher.GetExpectHash(containerSpec, pod) {
-					// Maybe checking PlainHash inconsistent here can skip to trigger restart. But it is not a good idea for some special scenarios.
-					klog.V(2).InfoS("Triggering container in Pod to restart, for it has inconsistent hash of env from metadata", "containerName", containerSpec.Name, "containerID", status.ID.String(), "namespace", pod.Namespace, "podName", pod.Name)
-					c.restarter.queue.AddRateLimited(status.ID)
-				}
-			}
-		}
-
-		metaSet.Containers = append(metaSet.Containers, *containerMeta)
 	}
+
 	return &metaSet
+}
+
+// buildContainerMeta builds the runtime meta for a single container. It returns nil if the
+// container has not been created by the runtime yet.
+func (c *Controller) buildContainerMeta(pod *v1.Pod, containerSpec *v1.Container, kubePodStatus *kubeletcontainer.PodStatus, oldMetaSet *appspub.RuntimeContainerMetaSet, criRuntime criapi.RuntimeService) *appspub.RuntimeContainerMeta {
+	var err error
+	status := kubePodStatus.FindContainerStatusByName(containerSpec.Name)
+	if status == nil {
+		return nil
+	}
+
+	var containerMeta *appspub.RuntimeContainerMeta
+	if oldMetaSet != nil {
+		for i := range oldMetaSet.Containers {
+			if oldMetaSet.Containers[i].ContainerID == status.ID.String() {
+				containerMeta = oldMetaSet.Containers[i].DeepCopy()
+			}
+		}
+	}
+	if containerMeta == nil {
+		containerMeta = &appspub.RuntimeContainerMeta{
+			Name:         status.Name,
+			ContainerID:  status.ID.String(),
+			RestartCount: int32(status.RestartCount),
+			Hashes: appspub.RuntimeContainerHashes{
+				PlainHash: status.Hash,
+			},
+		}
+	}
+	if utilfeature.DefaultFeatureGate.Enabled(features.InPlaceUpdateEnvFromMetadata) {
+		envHasher := utilcontainermeta.NewEnvFromMetadataHasher()
+
+		if containerMeta.Hashes.ExtractedEnvFromMetadataHash == 0 && status.State == kubeletcontainer.ContainerStateRunning {
+			envGetter := wrapEnvGetter(criRuntime, status.ID.ID, fmt.Sprintf("container %s (%s) in Pod %s/%s", containerSpec.Name, status.ID.String(), pod.Namespace, pod.Name))
+			containerMeta.Hashes.ExtractedEnvFromMetadataHash, err = envHasher.GetCurrentHash(containerSpec, envGetter)
+			if err != nil {
+				klog.ErrorS(err, "Failed to hash container with env for Pod", "containerName", containerSpec.Name, "containerID", status.ID.String(), "namespace", pod.Namespace, "podName", pod.Name)
+				enqueueAfter(c.queue, pod, time.Second*3)
+			} else {
+				klog.V(4).InfoS("Extracted env from metadata for container",
+					"containerName", containerSpec.Name, "containerID", status.ID.String(), "namespace", pod.Namespace, "podName", pod.Name, "hash", containerMeta.Hashes.ExtractedEnvFromMetadataHash)
+			}
+		}
+
+		// Trigger restarting only if it is in-place updating
+		_, condition := podutil.GetPodCondition(&pod.Status, appspub.InPlaceUpdateReady)
+		if condition != nil && condition.Status == v1.ConditionFalse {
+			// Trigger restarting when expected env hash is not equal to current hash
+			if containerMeta.Hashes.ExtractedEnvFromMetadataHash > 0 && containerMeta.Hashes.ExtractedEnvFromMetadataHash != envHasher.GetExpectHash(containerSpec, pod) {
+				// Maybe checking PlainHash inconsistent here can skip to trigger restart. But it is not a good idea for some special scenarios.
+				klog.V(2).InfoS("Triggering container in Pod to restart, for it has inconsistent hash of env from metadata", "containerName", containerSpec.Name, "containerID", status.ID.String(), "namespace", pod.Namespace, "podName", pod.Name)
+				c.restarter.queue.AddRateLimited(status.ID)
+			}
+		}
+	}
+
+	return containerMeta
 }
 
 func wrapEnvGetter(criRuntime criapi.RuntimeService, containerID, logID string) func(string) (string, error) {

--- a/pkg/features/kruise_features.go
+++ b/pkg/features/kruise_features.go
@@ -161,6 +161,19 @@ const (
 	// node affinity, then the pods on the nodes that have undergone
 	// this reduction will not be counted in the maxUnavailable.
 	DaemonSetPruneIneligibleNodes featuregate.Feature = "DaemonSetPruneIneligibleNodes"
+
+	// InPlaceUpdateRestartableInitContainer enables CloneSet/Advanced StatefulSet controllers to
+	// in-place update the images of restartable init containers, a.k.a. the native sidecar containers
+	// that have `restartPolicy: Always` in spec.initContainers.
+	//
+	// It requires the SidecarContainers feature of Kubernetes, which is GA since v1.33 and enabled
+	// by default since v1.29. Note that only restartable init containers are supported: kubelet
+	// restarts an init container on image change only when its restartPolicy is Always, so a regular
+	// init container would never report a new imageID and the in-place update would never complete.
+	//
+	// When this feature is disabled, changing any field under spec.initContainers falls back to
+	// recreating the Pod, which is the behavior before this feature was introduced.
+	InPlaceUpdateRestartableInitContainer featuregate.Feature = "InPlaceUpdateRestartableInitContainer"
 )
 
 var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
@@ -204,6 +217,8 @@ var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	DefaultHostNetworkHostPortsInPodTemplates: {Default: false, PreRelease: featuregate.Alpha},
 
 	DaemonSetPruneIneligibleNodes: {Default: false, PreRelease: featuregate.Alpha},
+
+	InPlaceUpdateRestartableInitContainer: {Default: false, PreRelease: featuregate.Alpha},
 }
 
 func init() {

--- a/pkg/features/kruise_features.go
+++ b/pkg/features/kruise_features.go
@@ -162,14 +162,19 @@ const (
 	// this reduction will not be counted in the maxUnavailable.
 	DaemonSetPruneIneligibleNodes featuregate.Feature = "DaemonSetPruneIneligibleNodes"
 
-	// InPlaceUpdateRestartableInitContainer enables CloneSet/Advanced StatefulSet controllers to
-	// in-place update the images of restartable init containers, a.k.a. the native sidecar containers
-	// that have `restartPolicy: Always` in spec.initContainers.
+	// InPlaceUpdateRestartableInitContainer enables CloneSet/Advanced StatefulSet/Advanced DaemonSet
+	// controllers to in-place update the images of restartable init containers, a.k.a. the native
+	// sidecar containers that have `restartPolicy: Always` in spec.initContainers.
 	//
 	// It requires the SidecarContainers feature of Kubernetes, which is GA since v1.33 and enabled
 	// by default since v1.29. Note that only restartable init containers are supported: kubelet
 	// restarts an init container on image change only when its restartPolicy is Always, so a regular
 	// init container would never report a new imageID and the in-place update would never complete.
+	//
+	// Only the image is in-place updatable. Any other change under spec.initContainers, including
+	// the resources of a restartable init container, still falls back to recreating the Pod.
+	// Restartable init containers do not participate in the container launch priority batching
+	// either, they are always updated in the current batch.
 	//
 	// When this feature is disabled, changing any field under spec.initContainers falls back to
 	// recreating the Pod, which is the behavior before this feature was introduced.

--- a/pkg/util/inplaceupdate/inplace_update.go
+++ b/pkg/util/inplaceupdate/inplace_update.go
@@ -44,6 +44,10 @@ import (
 var (
 	containerImagePatchRexp     = regexp.MustCompile("^/spec/containers/([0-9]+)/image$")
 	containerResourcesPatchRexp = regexp.MustCompile("^/spec/containers/([0-9]+)/resources/.*$")
+	// initContainerImagePatchRexp matches the image of an init container. Only restartable init
+	// containers (native sidecar containers) can be in-place updated, and it is guarded by the
+	// InPlaceUpdateRestartableInitContainer feature-gate. See defaultCalculateInPlaceUpdateSpec.
+	initContainerImagePatchRexp = regexp.MustCompile("^/spec/initContainers/([0-9]+)/image$")
 	rfc6901Decoder              = strings.NewReplacer("~1", "/", "~0", "~")
 
 	Clock clock.Clock = clock.RealClock{}
@@ -86,7 +90,11 @@ type Interface interface {
 type UpdateSpec struct {
 	Revision string `json:"revision"`
 
-	ContainerImages       map[string]string                  `json:"containerImages,omitempty"`
+	ContainerImages map[string]string `json:"containerImages,omitempty"`
+	// InitContainerImages is the images of the restartable init containers (native sidecar
+	// containers) that need to in-place update. It is only calculated when the
+	// InPlaceUpdateRestartableInitContainer feature-gate is enabled.
+	InitContainerImages   map[string]string                  `json:"initContainerImages,omitempty"`
 	ContainerRefMetadata  map[string]metav1.ObjectMeta       `json:"containerRefMetadata,omitempty"`
 	ContainerResources    map[string]v1.ResourceRequirements `json:"containerResources,omitempty"`
 	MetaDataPatch         []byte                             `json:"metaDataPatch,omitempty"`
@@ -98,7 +106,8 @@ type UpdateSpec struct {
 }
 
 func (u *UpdateSpec) VerticalUpdateOnly() bool {
-	return len(u.ContainerResources) > 0 && len(u.ContainerImages) == 0 && !u.UpdateEnvFromMetadata
+	return len(u.ContainerResources) > 0 && len(u.ContainerImages) == 0 &&
+		len(u.InitContainerImages) == 0 && !u.UpdateEnvFromMetadata
 }
 
 type realControl struct {
@@ -380,7 +389,7 @@ func (c *realControl) updatePodInPlace(pod *v1.Pod, spec *UpdateSpec, opts *Upda
 			Revision:              spec.Revision,
 			UpdateTimestamp:       metav1.NewTime(Clock.Now()),
 			UpdateEnvFromMetadata: spec.UpdateEnvFromMetadata,
-			UpdateImages:          len(spec.ContainerImages) > 0,
+			UpdateImages:          len(spec.ContainerImages) > 0 || len(spec.InitContainerImages) > 0,
 			UpdateResources:       len(spec.ContainerResources) > 0,
 		}
 		inPlaceUpdateStateJSON, _ := json.Marshal(inPlaceUpdateState)
@@ -472,7 +481,9 @@ func doPreCheckBeforeNext(pod *v1.Pod, preCheck *appspub.InPlaceUpdatePreCheckBe
 		return nil
 	}
 	for _, cName := range preCheck.ContainersRequiredReady {
-		cStatus := util.GetContainerStatus(cName, pod)
+		// Look up init container statuses as well, for restartable init containers may also be
+		// recorded in ContainersRequiredReady when they are in-place updated.
+		cStatus := util.GetContainerStatusIncludingInit(cName, pod)
 		if cStatus == nil {
 			return fmt.Errorf("not found container %s in pod status", cName)
 		}

--- a/pkg/util/inplaceupdate/inplace_update.go
+++ b/pkg/util/inplaceupdate/inplace_update.go
@@ -42,13 +42,22 @@ import (
 )
 
 var (
-	containerImagePatchRexp     = regexp.MustCompile("^/spec/containers/([0-9]+)/image$")
+	containerImagePatchRexp = regexp.MustCompile("^/spec/containers/([0-9]+)/image$")
+	// containerResourcesPatchRexp intentionally matches the regular containers only. The resources
+	// of a restartable init container are not in-place updatable, so such a patch falls through to
+	// the fallback of defaultCalculateInPlaceUpdateSpec and the Pod gets recreated.
 	containerResourcesPatchRexp = regexp.MustCompile("^/spec/containers/([0-9]+)/resources/.*$")
 	// initContainerImagePatchRexp matches the image of an init container. Only restartable init
 	// containers (native sidecar containers) can be in-place updated, and it is guarded by the
 	// InPlaceUpdateRestartableInitContainer feature-gate. See defaultCalculateInPlaceUpdateSpec.
 	initContainerImagePatchRexp = regexp.MustCompile("^/spec/initContainers/([0-9]+)/image$")
 	rfc6901Decoder              = strings.NewReplacer("~1", "/", "~0", "~")
+
+	// The two regexps below match the patches calculated between two PodTemplateSpec.Spec, so
+	// they have no leading "/spec". They are used by the InPlaceOnly validation of the workload
+	// webhooks. See ValidateInPlaceOnlyTemplateSpecPatches.
+	inPlaceOnlyContainerImagePatchRexp     = regexp.MustCompile("^/containers/([0-9]+)/image$")
+	inPlaceOnlyInitContainerImagePatchRexp = regexp.MustCompile("^/initContainers/([0-9]+)/image$")
 
 	Clock clock.Clock = clock.RealClock{}
 )

--- a/pkg/util/inplaceupdate/inplace_update_defaults.go
+++ b/pkg/util/inplaceupdate/inplace_update_defaults.go
@@ -521,6 +521,56 @@ func DiffRestartableInitContainerImages(oldTemp, newTemp *v1.PodTemplateSpec) ma
 	return images
 }
 
+// ValidateInPlaceOnlyTemplateSpecPatches checks the JSON patches calculated between the pod
+// template spec of the old and the new workload, and returns an error describing the first patch
+// that an in-place update can not carry out.
+//
+// A workload with the InPlaceOnly strategy never recreates its Pods, so its validating webhook has
+// to reject every template change that the in-place update is unable to apply. Besides the images
+// of the regular containers, the images of restartable init containers (native sidecar containers)
+// are accepted as well once the InPlaceUpdateRestartableInitContainer feature-gate is enabled,
+// which keeps this validation consistent with defaultCalculateInPlaceUpdateSpec.
+//
+// The patches are expected to be calculated between PodTemplateSpec.Spec, so their paths have no
+// leading "/spec", e.g. "/containers/0/image".
+func ValidateInPlaceOnlyTemplateSpecPatches(patches []jsonpatch.Operation, oldTemp, newTemp *v1.PodTemplateSpec) error {
+	for _, p := range patches {
+		if p.Operation != "replace" {
+			return fmt.Errorf("%s %s", p.Operation, p.Path)
+		}
+		if inPlaceOnlyContainerImagePatchRexp.MatchString(p.Path) {
+			continue
+		}
+
+		words := inPlaceOnlyInitContainerImagePatchRexp.FindStringSubmatch(p.Path)
+		if words == nil {
+			return fmt.Errorf("%s %s", p.Operation, p.Path)
+		}
+		if !utilfeature.DefaultFeatureGate.Enabled(features.InPlaceUpdateRestartableInitContainer) {
+			return fmt.Errorf("%s %s, for the %s feature-gate is disabled",
+				p.Operation, p.Path, features.InPlaceUpdateRestartableInitContainer)
+		}
+		idx, err := strconv.Atoi(words[1])
+		if err != nil {
+			return fmt.Errorf("%s %s", p.Operation, p.Path)
+		}
+		if oldTemp == nil || newTemp == nil ||
+			len(oldTemp.Spec.InitContainers) <= idx || len(newTemp.Spec.InitContainers) <= idx {
+			return fmt.Errorf("%s %s", p.Operation, p.Path)
+		}
+		// Require the init container to be restartable in both the old and the new template, so
+		// that toggling restartPolicy itself is still rejected. kubelet restarts an init container
+		// whose spec changed only when its restartPolicy is Always, otherwise the in-place update
+		// would never be considered completed and the Pod would hang forever.
+		if !util.IsRestartableInitContainer(&oldTemp.Spec.InitContainers[idx]) ||
+			!util.IsRestartableInitContainer(&newTemp.Spec.InitContainers[idx]) {
+			return fmt.Errorf("%s %s, for the init container %s is not restartable",
+				p.Operation, p.Path, oldTemp.Spec.InitContainers[idx].Name)
+		}
+	}
+	return nil
+}
+
 // DefaultCheckInPlaceUpdateCompleted checks whether imageID in pod status has been changed since in-place update.
 // If the imageID in containerStatuses has not been changed, we assume that kubelet has not updated
 // containers in Pod.

--- a/pkg/util/inplaceupdate/inplace_update_defaults.go
+++ b/pkg/util/inplaceupdate/inplace_update_defaults.go
@@ -123,6 +123,19 @@ func defaultPatchUpdateSpecToPod(pod *v1.Pod, spec *UpdateSpec, state *appspub.I
 	for _, cName := range containersWithHighestPriority {
 		containersToUpdate.Insert(cName)
 	}
+	// Restartable init containers (native sidecar containers) do not participate in the container
+	// launch priority batching, because the priority env is only injected into spec.containers.
+	// They are always updated in the current batch. They are still recorded in containersToUpdate
+	// so that the lower-priority containers wait for them to become ready before being updated.
+	initContainersToUpdate := sets.NewString()
+	for i := range pod.Spec.InitContainers {
+		c := &pod.Spec.InitContainers[i]
+		if _, exists := spec.InitContainerImages[c.Name]; !exists {
+			continue
+		}
+		initContainersToUpdate.Insert(c.Name)
+		containersToUpdate.Insert(c.Name)
+	}
 	addMetadataSharedContainersToUpdate(pod, containersToUpdate, spec.ContainerRefMetadata)
 
 	// DO NOT modify the fields in spec for it may have to retry on conflict in updatePodInPlace
@@ -152,6 +165,32 @@ func defaultPatchUpdateSpecToPod(pod *v1.Pod, spec *UpdateSpec, state *appspub.I
 			} else {
 				// now just update imageID
 				cs.ImageID = c.ImageID
+			}
+		}
+	}
+
+	// update images of the restartable init containers and record their current imageIDs.
+	// Note that their statuses live in pod.Status.InitContainerStatuses.
+	if len(spec.InitContainerImages) > 0 {
+		initContainersImageChanged := sets.NewString()
+		for i := range pod.Spec.InitContainers {
+			c := &pod.Spec.InitContainers[i]
+			newImage, exists := spec.InitContainerImages[c.Name]
+			if !exists || !initContainersToUpdate.Has(c.Name) {
+				continue
+			}
+			pod.Spec.InitContainers[i].Image = newImage
+			initContainersImageChanged.Insert(c.Name)
+		}
+		for _, c := range pod.Status.InitContainerStatuses {
+			if !initContainersImageChanged.Has(c.Name) {
+				continue
+			}
+			if state.LastContainerStatuses == nil {
+				state.LastContainerStatuses = map[string]appspub.InPlaceUpdateContainerStatus{}
+			}
+			if _, ok := state.LastContainerStatuses[c.Name]; !ok {
+				state.LastContainerStatuses[c.Name] = appspub.InPlaceUpdateContainerStatus{ImageID: c.ImageID}
 			}
 		}
 	}
@@ -333,6 +372,38 @@ func defaultCalculateInPlaceUpdateSpec(oldRevision, newRevision *apps.Controller
 			continue
 		}
 
+		if initContainerImagePatchRexp.MatchString(op.Path) {
+			// for example: /spec/initContainers/0/image
+			if !utilfeature.DefaultFeatureGate.Enabled(features.InPlaceUpdateRestartableInitContainer) {
+				return nil
+			}
+			words := strings.Split(op.Path, "/")
+			idx, _ := strconv.Atoi(words[3])
+			if len(oldTemp.Spec.InitContainers) <= idx || len(newTemp.Spec.InitContainers) <= idx {
+				return nil
+			}
+			// Only restartable init containers (native sidecar containers) can be in-place updated.
+			// kubelet restarts an init container whose spec changed only when its restartPolicy is
+			// Always. For a regular init container the imageID in status would never change, so the
+			// in-place update would never be considered completed and the Pod would hang forever.
+			// Require it to be restartable in both the old and the new revision, so that toggling
+			// restartPolicy itself still falls back to recreating the Pod.
+			if !util.IsRestartableInitContainer(&oldTemp.Spec.InitContainers[idx]) ||
+				!util.IsRestartableInitContainer(&newTemp.Spec.InitContainers[idx]) {
+				klog.V(4).InfoS("Can not in-place update the image of a non-restartable init container",
+					"initContainerName", oldTemp.Spec.InitContainers[idx].Name)
+				return nil
+			}
+			// Lazily initialize the map, so that InitContainerImages stays nil when no restartable
+			// init container image changes. This keeps the calculated spec byte-for-byte identical
+			// to the behavior before this feature was introduced.
+			if updateSpec.InitContainerImages == nil {
+				updateSpec.InitContainerImages = make(map[string]string)
+			}
+			updateSpec.InitContainerImages[oldTemp.Spec.InitContainers[idx].Name] = op.Value.(string)
+			continue
+		}
+
 		if utilfeature.DefaultFeatureGate.Enabled(features.InPlaceWorkloadVerticalScaling) &&
 			containerResourcesPatchRexp.MatchString(op.Path) {
 			err = verticalUpdateImpl.UpdateInplaceUpdateMetadata(&op, oldTemp, updateSpec)
@@ -411,6 +482,45 @@ func defaultCalculateInPlaceUpdateSpec(oldRevision, newRevision *apps.Controller
 	return updateSpec
 }
 
+// DiffRestartableInitContainerImages returns the images of the restartable init containers
+// (native sidecar containers) whose image differs between the old and the new pod template.
+// It returns nil when the InPlaceUpdateRestartableInitContainer feature-gate is disabled, so
+// that callers keep their previous behavior by default.
+//
+// It is used by the workload controllers to pre-download images for in-place update.
+func DiffRestartableInitContainerImages(oldTemp, newTemp *v1.PodTemplateSpec) map[string]string {
+	if !utilfeature.DefaultFeatureGate.Enabled(features.InPlaceUpdateRestartableInitContainer) {
+		return nil
+	}
+	if oldTemp == nil || newTemp == nil {
+		return nil
+	}
+
+	oldImages := make(map[string]string, len(oldTemp.Spec.InitContainers))
+	for i := range oldTemp.Spec.InitContainers {
+		c := &oldTemp.Spec.InitContainers[i]
+		if !util.IsRestartableInitContainer(c) {
+			continue
+		}
+		oldImages[c.Name] = c.Image
+	}
+
+	images := make(map[string]string)
+	for i := range newTemp.Spec.InitContainers {
+		c := &newTemp.Spec.InitContainers[i]
+		if !util.IsRestartableInitContainer(c) {
+			continue
+		}
+		if oldImage, ok := oldImages[c.Name]; !ok || oldImage != c.Image {
+			images[c.Name] = c.Image
+		}
+	}
+	if len(images) == 0 {
+		return nil
+	}
+	return images
+}
+
 // DefaultCheckInPlaceUpdateCompleted checks whether imageID in pod status has been changed since in-place update.
 // If the imageID in containerStatuses has not been changed, we assume that kubelet has not updated
 // containers in Pod.
@@ -463,7 +573,7 @@ func defaultCheckContainersInPlaceUpdateCompleted(pod *v1.Pod, inPlaceUpdateStat
 		// in case kruise-daemon has broken for some reason and runtime-container-meta is still in an old version.
 	}
 
-	containerImages := make(map[string]string, len(pod.Spec.Containers))
+	containerImages := make(map[string]string, len(pod.Spec.Containers)+len(pod.Spec.InitContainers))
 	for i := range pod.Spec.Containers {
 		c := &pod.Spec.Containers[i]
 		containerImages[c.Name] = c.Image
@@ -471,17 +581,35 @@ func defaultCheckContainersInPlaceUpdateCompleted(pod *v1.Pod, inPlaceUpdateStat
 			containerImages[c.Name] = fmt.Sprintf("%s:latest", c.Image)
 		}
 	}
-
-	for _, cs := range pod.Status.ContainerStatuses {
-		if oldStatus, ok := inPlaceUpdateState.LastContainerStatuses[cs.Name]; ok {
-			// TODO: we assume that users should not update workload template with new image which actually has the same imageID as the old image
-			if oldStatus.ImageID == cs.ImageID {
-				if containerImages[cs.Name] != cs.Image {
-					return fmt.Errorf("container %s imageID not changed", cs.Name)
-				}
-			}
-			delete(inPlaceUpdateState.LastContainerStatuses, cs.Name)
+	for i := range pod.Spec.InitContainers {
+		c := &pod.Spec.InitContainers[i]
+		containerImages[c.Name] = c.Image
+		if len(strings.Split(c.Image, ":")) <= 1 {
+			containerImages[c.Name] = fmt.Sprintf("%s:latest", c.Image)
 		}
+	}
+
+	checkStatuses := func(statuses []v1.ContainerStatus) error {
+		for _, cs := range statuses {
+			if oldStatus, ok := inPlaceUpdateState.LastContainerStatuses[cs.Name]; ok {
+				// TODO: we assume that users should not update workload template with new image which actually has the same imageID as the old image
+				if oldStatus.ImageID == cs.ImageID {
+					if containerImages[cs.Name] != cs.Image {
+						return fmt.Errorf("container %s imageID not changed", cs.Name)
+					}
+				}
+				delete(inPlaceUpdateState.LastContainerStatuses, cs.Name)
+			}
+		}
+		return nil
+	}
+
+	if err := checkStatuses(pod.Status.ContainerStatuses); err != nil {
+		return err
+	}
+	// Restartable init containers (native sidecar containers) report their status here.
+	if err := checkStatuses(pod.Status.InitContainerStatuses); err != nil {
+		return err
 	}
 
 	if len(inPlaceUpdateState.LastContainerStatuses) > 0 {
@@ -502,17 +630,25 @@ const (
 // 1. all containers in spec.containers should also be in status.containerStatuses and runtime-container-meta
 // 2. all containers in status.containerStatuses and runtime-container-meta should have the same containerID
 // 3. all containers in spec.containers and runtime-container-meta should have the same hashes
+//
+// The restartable init containers (native sidecar containers) are checked in the same way, for
+// kruise-daemon reports them into runtime-container-meta as well. Regular init containers are
+// skipped, because kubelet never restarts them on spec change.
 func checkAllContainersHashConsistent(pod *v1.Pod, runtimeContainerMetaSet *appspub.RuntimeContainerMetaSet, hashType hashType) bool {
-	for i := range pod.Spec.Containers {
-		containerSpec := &pod.Spec.Containers[i]
-
-		var containerStatus *v1.ContainerStatus
-		for j := range pod.Status.ContainerStatuses {
-			if pod.Status.ContainerStatuses[j].Name == containerSpec.Name {
-				containerStatus = &pod.Status.ContainerStatuses[j]
-				break
-			}
+	containerSpecs := make([]*v1.Container, 0, len(pod.Spec.InitContainers)+len(pod.Spec.Containers))
+	for i := range pod.Spec.InitContainers {
+		c := &pod.Spec.InitContainers[i]
+		if !util.IsRestartableInitContainer(c) {
+			continue
 		}
+		containerSpecs = append(containerSpecs, c)
+	}
+	for i := range pod.Spec.Containers {
+		containerSpecs = append(containerSpecs, &pod.Spec.Containers[i])
+	}
+
+	for _, containerSpec := range containerSpecs {
+		containerStatus := util.GetContainerStatusIncludingInit(containerSpec.Name, pod)
 		if containerStatus == nil {
 			klog.InfoS("Find no container in status for Pod", "containerName", containerSpec.Name, "namespace", pod.Namespace, "podName", pod.Name)
 			return false

--- a/pkg/util/inplaceupdate/inplace_update_initcontainer_test.go
+++ b/pkg/util/inplaceupdate/inplace_update_initcontainer_test.go
@@ -1,0 +1,345 @@
+/*
+Copyright 2025 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inplaceupdate
+
+import (
+	"fmt"
+	"testing"
+
+	apps "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kubeletcontainer "k8s.io/kubernetes/pkg/kubelet/container"
+
+	appspub "github.com/openkruise/kruise/apis/apps/pub"
+	"github.com/openkruise/kruise/pkg/features"
+	utilfeature "github.com/openkruise/kruise/pkg/util/feature"
+)
+
+func restartAlways() *v1.ContainerRestartPolicy {
+	p := v1.ContainerRestartPolicyAlways
+	return &p
+}
+
+func setInitContainerGate(t *testing.T, enabled bool) {
+	t.Helper()
+	if err := utilfeature.DefaultMutableFeatureGate.Set(
+		fmt.Sprintf("%s=%v", features.InPlaceUpdateRestartableInitContainer, enabled)); err != nil {
+		t.Fatalf("failed to set feature-gate: %v", err)
+	}
+}
+
+func revisionOf(name, raw string) *apps.ControllerRevision {
+	return &apps.ControllerRevision{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Data:       runtime.RawExtension{Raw: []byte(raw)},
+	}
+}
+
+// TestCalculateSpecForRestartableInitContainer covers the gating rules of in-place updating
+// the image of an init container.
+func TestCalculateSpecForRestartableInitContainer(t *testing.T) {
+	const (
+		// a restartable init container (native sidecar), image changes foo1 -> foo2
+		oldSidecar = `{"spec":{"template":{"$patch":"replace","spec":{"containers":[{"name":"c1","image":"main1"}],"initContainers":[{"name":"sidecar","image":"foo1","restartPolicy":"Always"}]}}}}`
+		newSidecar = `{"spec":{"template":{"$patch":"replace","spec":{"containers":[{"name":"c1","image":"main1"}],"initContainers":[{"name":"sidecar","image":"foo2","restartPolicy":"Always"}]}}}}`
+		// a regular init container (no restartPolicy), image changes foo1 -> foo2
+		oldRegular = `{"spec":{"template":{"$patch":"replace","spec":{"containers":[{"name":"c1","image":"main1"}],"initContainers":[{"name":"setup","image":"foo1"}]}}}}`
+		newRegular = `{"spec":{"template":{"$patch":"replace","spec":{"containers":[{"name":"c1","image":"main1"}],"initContainers":[{"name":"setup","image":"foo2"}]}}}}`
+		// restartPolicy itself is being removed together with the image change
+		newSidecarDemoted = `{"spec":{"template":{"$patch":"replace","spec":{"containers":[{"name":"c1","image":"main1"}],"initContainers":[{"name":"sidecar","image":"foo2"}]}}}}`
+	)
+
+	cases := []struct {
+		name        string
+		gateEnabled bool
+		old, new    string
+		expectNil   bool
+		expectInit  map[string]string
+	}{
+		{
+			name:        "gate disabled falls back to recreate",
+			gateEnabled: false,
+			old:         oldSidecar,
+			new:         newSidecar,
+			expectNil:   true,
+		},
+		{
+			name:        "restartable init container can be in-place updated",
+			gateEnabled: true,
+			old:         oldSidecar,
+			new:         newSidecar,
+			expectInit:  map[string]string{"sidecar": "foo2"},
+		},
+		{
+			name:        "regular init container falls back to recreate",
+			gateEnabled: true,
+			old:         oldRegular,
+			new:         newRegular,
+			expectNil:   true,
+		},
+		{
+			name:        "demoting a sidecar falls back to recreate",
+			gateEnabled: true,
+			old:         oldSidecar,
+			new:         newSidecarDemoted,
+			expectNil:   true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			setInitContainerGate(t, tc.gateEnabled)
+			defer setInitContainerGate(t, false)
+
+			got := defaultCalculateInPlaceUpdateSpec(
+				revisionOf("old-revision", tc.old), revisionOf("new-revision", tc.new), nil)
+
+			if tc.expectNil {
+				if got != nil {
+					t.Fatalf("expected nil spec (recreate), got %+v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("expected a non-nil spec, got nil")
+			}
+			if len(got.InitContainerImages) != len(tc.expectInit) {
+				t.Fatalf("expected initContainerImages %v, got %v", tc.expectInit, got.InitContainerImages)
+			}
+			for k, v := range tc.expectInit {
+				if got.InitContainerImages[k] != v {
+					t.Fatalf("expected initContainerImages %v, got %v", tc.expectInit, got.InitContainerImages)
+				}
+			}
+		})
+	}
+}
+
+// TestCalculateSpecKeepsInitContainerImagesNilByDefault makes sure the calculated spec is
+// unchanged for the ordinary containers-only case, so that existing consumers and the
+// serialized annotation are not affected when the feature is not used.
+func TestCalculateSpecKeepsInitContainerImagesNilByDefault(t *testing.T) {
+	setInitContainerGate(t, true)
+	defer setInitContainerGate(t, false)
+
+	old := `{"spec":{"template":{"$patch":"replace","spec":{"containers":[{"name":"c1","image":"foo1"}]}}}}`
+	new := `{"spec":{"template":{"$patch":"replace","spec":{"containers":[{"name":"c1","image":"foo2"}]}}}}`
+
+	got := defaultCalculateInPlaceUpdateSpec(revisionOf("old", old), revisionOf("new", new), nil)
+	if got == nil {
+		t.Fatalf("expected a non-nil spec")
+	}
+	if got.InitContainerImages != nil {
+		t.Fatalf("expected InitContainerImages to stay nil, got %v", got.InitContainerImages)
+	}
+}
+
+// TestPatchRestartableInitContainerToPod verifies that the new image is written into
+// spec.initContainers and the old imageID is recorded from status.initContainerStatuses.
+func TestPatchRestartableInitContainerToPod(t *testing.T) {
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "p1", Annotations: map[string]string{}},
+		Spec: v1.PodSpec{
+			InitContainers: []v1.Container{
+				{Name: "sidecar", Image: "foo1", RestartPolicy: restartAlways()},
+			},
+			Containers: []v1.Container{{Name: "c1", Image: "main1"}},
+		},
+		Status: v1.PodStatus{
+			InitContainerStatuses: []v1.ContainerStatus{
+				{Name: "sidecar", Image: "foo1", ImageID: "img-old"},
+			},
+			ContainerStatuses: []v1.ContainerStatus{
+				{Name: "c1", Image: "main1", ImageID: "main-old"},
+			},
+		},
+	}
+
+	spec := &UpdateSpec{
+		Revision:            "new-revision",
+		InitContainerImages: map[string]string{"sidecar": "foo2"},
+	}
+	state := &appspub.InPlaceUpdateState{Revision: "new-revision"}
+
+	got, _, err := defaultPatchUpdateSpecToPod(pod.DeepCopy(), spec, state)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got.Spec.InitContainers[0].Image != "foo2" {
+		t.Fatalf("expected init container image to be patched to foo2, got %s", got.Spec.InitContainers[0].Image)
+	}
+	if got.Spec.Containers[0].Image != "main1" {
+		t.Fatalf("main container image should not change, got %s", got.Spec.Containers[0].Image)
+	}
+	if cs, ok := state.LastContainerStatuses["sidecar"]; !ok || cs.ImageID != "img-old" {
+		t.Fatalf("expected the old imageID of the sidecar to be recorded, got %v", state.LastContainerStatuses)
+	}
+}
+
+// TestCheckCompletedForRestartableInitContainer covers the imageID based fallback, which is used
+// when kruise-daemon is not deployed and therefore runtime-container-meta is absent.
+func TestCheckCompletedForRestartableInitContainer(t *testing.T) {
+	newPod := func(specImage, statusImage, statusImageID string) *v1.Pod {
+		return &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "p1"},
+			Spec: v1.PodSpec{
+				InitContainers: []v1.Container{
+					{Name: "sidecar", Image: specImage, RestartPolicy: restartAlways()},
+				},
+				Containers: []v1.Container{{Name: "c1", Image: "main1"}},
+			},
+			Status: v1.PodStatus{
+				InitContainerStatuses: []v1.ContainerStatus{
+					{Name: "sidecar", Image: statusImage, ImageID: statusImageID},
+				},
+				ContainerStatuses: []v1.ContainerStatus{
+					{Name: "c1", Image: "main1", ImageID: "main-old"},
+				},
+			},
+		}
+	}
+
+	state := func() *appspub.InPlaceUpdateState {
+		return &appspub.InPlaceUpdateState{
+			Revision:     "new-revision",
+			UpdateImages: true,
+			LastContainerStatuses: map[string]appspub.InPlaceUpdateContainerStatus{
+				"sidecar": {ImageID: "img-old"},
+			},
+		}
+	}
+
+	// kubelet has not restarted the sidecar yet: imageID is still the old one.
+	if err := defaultCheckContainersInPlaceUpdateCompleted(
+		newPod("foo2:v2", "foo1:v1", "img-old"), state()); err == nil {
+		t.Fatalf("expected not-completed while the sidecar imageID has not changed")
+	}
+
+	// kubelet has restarted the sidecar with the new image.
+	if err := defaultCheckContainersInPlaceUpdateCompleted(
+		newPod("foo2:v2", "foo2:v2", "img-new"), state()); err != nil {
+		t.Fatalf("expected completed, got %v", err)
+	}
+}
+
+// TestHashConsistentCoversRestartableInitContainer verifies that the runtime-container-meta fast
+// path now covers the restartable init containers, so a sidecar whose image has not actually been
+// restarted yet can no longer be mistaken for completed.
+func TestHashConsistentCoversRestartableInitContainer(t *testing.T) {
+	sidecarOld := v1.Container{Name: "sidecar", Image: "foo1", RestartPolicy: restartAlways()}
+	sidecarNew := v1.Container{Name: "sidecar", Image: "foo2", RestartPolicy: restartAlways()}
+	main := v1.Container{Name: "c1", Image: "main1"}
+
+	// The meta reported by kruise-daemon still describes the OLD sidecar.
+	metaSet := &appspub.RuntimeContainerMetaSet{
+		Containers: []appspub.RuntimeContainerMeta{
+			{
+				Name:        "sidecar",
+				ContainerID: "docker://sidecar-1",
+				Hashes:      appspub.RuntimeContainerHashes{PlainHash: kubeletcontainer.HashContainer(&sidecarOld)},
+			},
+			{
+				Name:        "c1",
+				ContainerID: "docker://c1-1",
+				Hashes:      appspub.RuntimeContainerHashes{PlainHash: kubeletcontainer.HashContainer(&main)},
+			},
+		},
+	}
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "p1"},
+		Spec:       v1.PodSpec{InitContainers: []v1.Container{sidecarNew}, Containers: []v1.Container{main}},
+		Status: v1.PodStatus{
+			InitContainerStatuses: []v1.ContainerStatus{{Name: "sidecar", ContainerID: "docker://sidecar-1"}},
+			ContainerStatuses:     []v1.ContainerStatus{{Name: "c1", ContainerID: "docker://c1-1"}},
+		},
+	}
+
+	// spec says foo2 but the meta still hashes foo1 -> not consistent yet.
+	if checkAllContainersHashConsistent(pod, metaSet, plainHash) {
+		t.Fatalf("expected inconsistent while the sidecar has not been restarted")
+	}
+
+	// after kubelet restarted the sidecar, kruise-daemon reports the new hash and containerID.
+	metaSet.Containers[0].ContainerID = "docker://sidecar-2"
+	metaSet.Containers[0].Hashes.PlainHash = kubeletcontainer.HashContainer(&sidecarNew)
+	pod.Status.InitContainerStatuses[0].ContainerID = "docker://sidecar-2"
+	if !checkAllContainersHashConsistent(pod, metaSet, plainHash) {
+		t.Fatalf("expected consistent after the sidecar has been restarted")
+	}
+}
+
+// TestHashConsistentIgnoresRegularInitContainer makes sure a regular (non-restartable) init
+// container is not required to appear in runtime-container-meta, for kruise-daemon does not
+// report it and kubelet never restarts it on spec change.
+func TestHashConsistentIgnoresRegularInitContainer(t *testing.T) {
+	main := v1.Container{Name: "c1", Image: "main1"}
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "p1"},
+		Spec: v1.PodSpec{
+			InitContainers: []v1.Container{{Name: "setup", Image: "bar1"}},
+			Containers:     []v1.Container{main},
+		},
+		Status: v1.PodStatus{
+			InitContainerStatuses: []v1.ContainerStatus{{Name: "setup", ContainerID: "docker://setup-1"}},
+			ContainerStatuses:     []v1.ContainerStatus{{Name: "c1", ContainerID: "docker://c1-1"}},
+		},
+	}
+	metaSet := &appspub.RuntimeContainerMetaSet{
+		Containers: []appspub.RuntimeContainerMeta{
+			{
+				Name:        "c1",
+				ContainerID: "docker://c1-1",
+				Hashes:      appspub.RuntimeContainerHashes{PlainHash: kubeletcontainer.HashContainer(&main)},
+			},
+		},
+	}
+
+	if !checkAllContainersHashConsistent(pod, metaSet, plainHash) {
+		t.Fatalf("expected consistent, the regular init container should be ignored")
+	}
+}
+
+func TestDiffRestartableInitContainerImages(t *testing.T) {
+	oldTemp := &v1.PodTemplateSpec{Spec: v1.PodSpec{
+		InitContainers: []v1.Container{
+			{Name: "sidecar", Image: "foo1", RestartPolicy: restartAlways()},
+			{Name: "setup", Image: "bar1"},
+		},
+	}}
+	newTemp := &v1.PodTemplateSpec{Spec: v1.PodSpec{
+		InitContainers: []v1.Container{
+			{Name: "sidecar", Image: "foo2", RestartPolicy: restartAlways()},
+			{Name: "setup", Image: "bar2"},
+		},
+	}}
+
+	setInitContainerGate(t, false)
+	if got := DiffRestartableInitContainerImages(oldTemp, newTemp); got != nil {
+		t.Fatalf("expected nil when the feature-gate is disabled, got %v", got)
+	}
+
+	setInitContainerGate(t, true)
+	defer setInitContainerGate(t, false)
+	got := DiffRestartableInitContainerImages(oldTemp, newTemp)
+	if len(got) != 1 || got["sidecar"] != "foo2" {
+		t.Fatalf("expected only the restartable init container to be diffed, got %v", got)
+	}
+}

--- a/pkg/util/inplaceupdate/inplace_update_initcontainer_test.go
+++ b/pkg/util/inplaceupdate/inplace_update_initcontainer_test.go
@@ -17,9 +17,11 @@ limitations under the License.
 package inplaceupdate
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 
+	"github.com/appscode/jsonpatch"
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -341,5 +343,129 @@ func TestDiffRestartableInitContainerImages(t *testing.T) {
 	got := DiffRestartableInitContainerImages(oldTemp, newTemp)
 	if len(got) != 1 || got["sidecar"] != "foo2" {
 		t.Fatalf("expected only the restartable init container to be diffed, got %v", got)
+	}
+}
+
+// TestValidateInPlaceOnlyTemplateSpecPatches covers the InPlaceOnly whitelist used by the
+// CloneSet / Advanced StatefulSet validating webhooks. Without accepting the images of the
+// restartable init containers here, the workload controllers would never get the chance to
+// in-place update them, for the update request is rejected by the admission webhook first.
+func TestValidateInPlaceOnlyTemplateSpecPatches(t *testing.T) {
+	templateOf := func(mainImage, initImage string, restartable bool, extra func(*v1.PodTemplateSpec)) *v1.PodTemplateSpec {
+		temp := &v1.PodTemplateSpec{Spec: v1.PodSpec{
+			InitContainers: []v1.Container{
+				{Name: "setup", Image: "setup1"},
+				{Name: "sidecar", Image: initImage},
+			},
+			Containers: []v1.Container{{Name: "c1", Image: mainImage}},
+		}}
+		if restartable {
+			temp.Spec.InitContainers[1].RestartPolicy = restartAlways()
+		}
+		if extra != nil {
+			extra(temp)
+		}
+		return temp
+	}
+
+	cases := []struct {
+		name        string
+		gateEnabled bool
+		oldTemp     *v1.PodTemplateSpec
+		newTemp     *v1.PodTemplateSpec
+		expectErr   bool
+	}{
+		{
+			name:        "regular container image is always allowed",
+			gateEnabled: false,
+			oldTemp:     templateOf("main1", "foo1", true, nil),
+			newTemp:     templateOf("main2", "foo1", true, nil),
+			expectErr:   false,
+		},
+		{
+			name:        "restartable init container image is allowed when the gate is enabled",
+			gateEnabled: true,
+			oldTemp:     templateOf("main1", "foo1", true, nil),
+			newTemp:     templateOf("main1", "foo2", true, nil),
+			expectErr:   false,
+		},
+		{
+			name:        "restartable init container image is rejected when the gate is disabled",
+			gateEnabled: false,
+			oldTemp:     templateOf("main1", "foo1", true, nil),
+			newTemp:     templateOf("main1", "foo2", true, nil),
+			expectErr:   true,
+		},
+		{
+			name:        "regular init container image is rejected",
+			gateEnabled: true,
+			oldTemp:     templateOf("main1", "foo1", false, nil),
+			newTemp:     templateOf("main1", "foo2", false, nil),
+			expectErr:   true,
+		},
+		{
+			name:        "demoting a restartable init container is rejected",
+			gateEnabled: true,
+			oldTemp:     templateOf("main1", "foo1", true, nil),
+			newTemp:     templateOf("main1", "foo2", false, nil),
+			expectErr:   true,
+		},
+		{
+			name:        "both a regular and a restartable init container image is rejected",
+			gateEnabled: true,
+			oldTemp:     templateOf("main1", "foo1", true, nil),
+			newTemp: templateOf("main1", "foo2", true, func(temp *v1.PodTemplateSpec) {
+				temp.Spec.InitContainers[0].Image = "setup2"
+			}),
+			expectErr: true,
+		},
+		{
+			name:        "non-image field of an init container is rejected",
+			gateEnabled: true,
+			oldTemp:     templateOf("main1", "foo1", true, nil),
+			newTemp: templateOf("main1", "foo1", true, func(temp *v1.PodTemplateSpec) {
+				temp.Spec.InitContainers[1].Env = []v1.EnvVar{{Name: "k", Value: "v"}}
+			}),
+			expectErr: true,
+		},
+		{
+			name:        "adding an init container is rejected",
+			gateEnabled: true,
+			oldTemp:     templateOf("main1", "foo1", true, nil),
+			newTemp: templateOf("main1", "foo1", true, func(temp *v1.PodTemplateSpec) {
+				temp.Spec.InitContainers = append(temp.Spec.InitContainers,
+					v1.Container{Name: "extra", Image: "extra1", RestartPolicy: restartAlways()})
+			}),
+			expectErr: true,
+		},
+		{
+			name:        "no change is allowed",
+			gateEnabled: true,
+			oldTemp:     templateOf("main1", "foo1", true, nil),
+			newTemp:     templateOf("main1", "foo1", true, nil),
+			expectErr:   false,
+		},
+	}
+
+	defer setInitContainerGate(t, false)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			setInitContainerGate(t, tc.gateEnabled)
+
+			oldJSON, _ := json.Marshal(tc.oldTemp.Spec)
+			newJSON, _ := json.Marshal(tc.newTemp.Spec)
+			patches, err := jsonpatch.CreatePatch(oldJSON, newJSON)
+			if err != nil {
+				t.Fatalf("failed to create patches: %v", err)
+			}
+
+			err = ValidateInPlaceOnlyTemplateSpecPatches(patches, tc.oldTemp, tc.newTemp)
+			if tc.expectErr && err == nil {
+				t.Fatalf("expected an error, got nil (patches: %v)", patches)
+			}
+			if !tc.expectErr && err != nil {
+				t.Fatalf("expected no error, got %v (patches: %v)", err, patches)
+			}
+		})
 	}
 }

--- a/pkg/util/pods.go
+++ b/pkg/util/pods.go
@@ -221,6 +221,26 @@ func GetContainerStatus(name string, pod *v1.Pod) *v1.ContainerStatus {
 	return nil
 }
 
+// GetContainerStatusIncludingInit returns the status of the container with the given name,
+// looking up both status.containerStatuses and status.initContainerStatuses.
+// It is needed because restartable init containers (native sidecar containers) report their
+// status in status.initContainerStatuses rather than status.containerStatuses.
+func GetContainerStatusIncludingInit(name string, pod *v1.Pod) *v1.ContainerStatus {
+	if pod == nil {
+		return nil
+	}
+	if cs := GetContainerStatus(name, pod); cs != nil {
+		return cs
+	}
+	for i := range pod.Status.InitContainerStatuses {
+		v := &pod.Status.InitContainerStatuses[i]
+		if v.Name == name {
+			return v
+		}
+	}
+	return nil
+}
+
 func GetPodVolume(pod *v1.Pod, volumeName string) *v1.Volume {
 	for idx, v := range pod.Spec.Volumes {
 		if v.Name == volumeName {

--- a/pkg/webhook/containerrecreaterequest/mutating/crr_mutating_handler.go
+++ b/pkg/webhook/containerrecreaterequest/mutating/crr_mutating_handler.go
@@ -288,7 +288,10 @@ func injectPodIntoContainerRecreateRequestV1alpha1(obj *appsv1alpha1.ContainerRe
 		if podContainer == nil {
 			return fmt.Errorf("container %s not found in Pod", c.Name)
 		}
-		podContainerStatus := util.GetContainerStatus(c.Name, pod)
+		// Look up status.initContainerStatuses as well, for a restartable init container
+		// (native sidecar container) reports its status there rather than in
+		// status.containerStatuses.
+		podContainerStatus := util.GetContainerStatusIncludingInit(c.Name, pod)
 		if podContainerStatus == nil {
 			return fmt.Errorf("not found %s containerStatus in Pod Status", c.Name)
 		} else if podContainerStatus.ContainerID == "" {
@@ -344,7 +347,10 @@ func injectPodIntoContainerRecreateRequestV1beta1(obj *appsv1beta1.ContainerRecr
 		if podContainer == nil {
 			return fmt.Errorf("container %s not found in Pod", c.Name)
 		}
-		podContainerStatus := util.GetContainerStatus(c.Name, pod)
+		// Look up status.initContainerStatuses as well, for a restartable init container
+		// (native sidecar container) reports its status there rather than in
+		// status.containerStatuses.
+		podContainerStatus := util.GetContainerStatusIncludingInit(c.Name, pod)
 		if podContainerStatus == nil {
 			return fmt.Errorf("not found %s containerStatus in Pod Status", c.Name)
 		} else if podContainerStatus.ContainerID == "" {

--- a/pkg/webhook/containerrecreaterequest/mutating/crr_mutating_handler_test.go
+++ b/pkg/webhook/containerrecreaterequest/mutating/crr_mutating_handler_test.go
@@ -623,3 +623,152 @@ func TestInjectPodIntoContainerRecreateRequestV1beta1_VirtualKubeletLabel(t *tes
 		})
 	}
 }
+
+// TestInjectPodIntoContainerRecreateRequest_RestartableInitContainer makes sure a CRR can target
+// a restartable init container (native sidecar container). Such a container reports its status in
+// status.initContainerStatuses, so looking up status.containerStatuses only would reject the
+// request and leave no way to recreate a native sidecar.
+//
+// The same cases are run against both API versions on purpose: the injection logic is duplicated
+// in injectPodIntoContainerRecreateRequestV1alpha1 and ...V1beta1, so a fix applied to only one
+// of them would silently leave the other one rejecting native sidecars.
+func TestInjectPodIntoContainerRecreateRequest_RestartableInitContainer(t *testing.T) {
+	restartAlways := v1.ContainerRestartPolicyAlways
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			UID:       types.UID("pod-uid-123"),
+		},
+		Spec: v1.PodSpec{
+			NodeName: "test-node",
+			InitContainers: []v1.Container{
+				{Name: "setup"},
+				{Name: "sidecar", RestartPolicy: &restartAlways},
+			},
+			Containers: []v1.Container{{Name: "main"}},
+		},
+		Status: v1.PodStatus{
+			InitContainerStatuses: []v1.ContainerStatus{
+				{Name: "setup", ContainerID: "containerd://setup1", RestartCount: 0},
+				{Name: "sidecar", ContainerID: "containerd://sidecar1", RestartCount: 2},
+			},
+			ContainerStatuses: []v1.ContainerStatus{
+				{Name: "main", ContainerID: "containerd://main1", RestartCount: 0},
+			},
+		},
+	}
+
+	// injectedContext is the version-agnostic view of the injected StatusContext.
+	type injectedContext struct {
+		containerID  string
+		restartCount int32
+	}
+
+	injectors := []struct {
+		version string
+		inject  func(containerName string) (*injectedContext, error)
+	}{
+		{
+			version: "v1alpha1",
+			inject: func(containerName string) (*injectedContext, error) {
+				crr := &appsv1alpha1.ContainerRecreateRequest{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-crr", Namespace: "default", Labels: map[string]string{}},
+					Spec: appsv1alpha1.ContainerRecreateRequestSpec{
+						PodName:    "test-pod",
+						Containers: []appsv1alpha1.ContainerRecreateRequestContainer{{Name: containerName}},
+						Strategy:   &appsv1alpha1.ContainerRecreateRequestStrategy{},
+					},
+				}
+				if err := injectPodIntoContainerRecreateRequestV1alpha1(crr, pod, nil); err != nil {
+					return nil, err
+				}
+				statusContext := crr.Spec.Containers[0].StatusContext
+				if statusContext == nil {
+					return nil, nil
+				}
+				return &injectedContext{statusContext.ContainerID, statusContext.RestartCount}, nil
+			},
+		},
+		{
+			version: "v1beta1",
+			inject: func(containerName string) (*injectedContext, error) {
+				crr := &appsv1beta1.ContainerRecreateRequest{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-crr", Namespace: "default", Labels: map[string]string{}},
+					Spec: appsv1beta1.ContainerRecreateRequestSpec{
+						PodName:    "test-pod",
+						Containers: []appsv1beta1.ContainerRecreateRequestContainer{{Name: containerName}},
+						Strategy:   &appsv1beta1.ContainerRecreateRequestStrategy{},
+					},
+				}
+				if err := injectPodIntoContainerRecreateRequestV1beta1(crr, pod, nil); err != nil {
+					return nil, err
+				}
+				statusContext := crr.Spec.Containers[0].StatusContext
+				if statusContext == nil {
+					return nil, nil
+				}
+				return &injectedContext{statusContext.ContainerID, statusContext.RestartCount}, nil
+			},
+		},
+	}
+
+	cases := []struct {
+		name               string
+		containerName      string
+		expectErr          bool
+		expectContainerID  string
+		expectRestartCount int32
+	}{
+		{
+			name:               "restartable init container is accepted",
+			containerName:      "sidecar",
+			expectContainerID:  "containerd://sidecar1",
+			expectRestartCount: 2,
+		},
+		{
+			name:               "regular init container is accepted as well",
+			containerName:      "setup",
+			expectContainerID:  "containerd://setup1",
+			expectRestartCount: 0,
+		},
+		{
+			name:               "regular container keeps working",
+			containerName:      "main",
+			expectContainerID:  "containerd://main1",
+			expectRestartCount: 0,
+		},
+		{
+			name:          "unknown container is still rejected",
+			containerName: "nonexistent",
+			expectErr:     true,
+		},
+	}
+
+	for _, injector := range injectors {
+		for _, tc := range cases {
+			t.Run(injector.version+"/"+tc.name, func(t *testing.T) {
+				got, err := injector.inject(tc.containerName)
+
+				if tc.expectErr {
+					if err == nil {
+						t.Fatalf("expected an error for container %s, got nil", tc.containerName)
+					}
+					return
+				}
+				if err != nil {
+					t.Fatalf("unexpected error for container %s: %v", tc.containerName, err)
+				}
+				if got == nil {
+					t.Fatalf("expected statusContext to be injected for container %s", tc.containerName)
+				}
+				if got.containerID != tc.expectContainerID {
+					t.Errorf("expected containerID %s, got %s", tc.expectContainerID, got.containerID)
+				}
+				if got.restartCount != tc.expectRestartCount {
+					t.Errorf("expected restartCount %d, got %d", tc.expectRestartCount, got.restartCount)
+				}
+			})
+		}
+	}
+}

--- a/pkg/webhook/statefulset/validating/statefulset_validation.go
+++ b/pkg/webhook/statefulset/validating/statefulset_validation.go
@@ -22,12 +22,12 @@ import (
 	appspub "github.com/openkruise/kruise/apis/apps/pub"
 	appsv1beta1 "github.com/openkruise/kruise/apis/apps/v1beta1"
 	apiutil "github.com/openkruise/kruise/pkg/util/api"
+	"github.com/openkruise/kruise/pkg/util/inplaceupdate"
 	"github.com/openkruise/kruise/pkg/util/pvc"
 	webhookutil "github.com/openkruise/kruise/pkg/webhook/util"
 	"github.com/openkruise/kruise/pkg/webhook/util/convertor"
 )
 
-var inPlaceUpdateTemplateSpecPatchRexp = regexp.MustCompile("/containers/([0-9]+)/image")
 var reserveOrdinalRangeRexp = regexp.MustCompile(`^\d+-\d+$`)
 
 func validatePodManagementPolicy(spec *appsv1beta1.StatefulSetSpec, fldPath *field.Path) field.ErrorList {
@@ -362,13 +362,7 @@ func validateTemplateInPlaceOnly(oldTemp, newTemp *v1.PodTemplateSpec) error {
 		return fmt.Errorf("failed calculate patches between old/new template spec")
 	}
 
-	for _, p := range patches {
-		if p.Operation != "replace" || !inPlaceUpdateTemplateSpecPatchRexp.MatchString(p.Path) {
-			return fmt.Errorf("%s %s", p.Operation, p.Path)
-		}
-	}
-
-	return nil
+	return inplaceupdate.ValidateInPlaceOnlyTemplateSpecPatches(patches, oldTemp, newTemp)
 }
 
 // ValidateVolumeClaimTemplateUpdate tests if only size expand when sc allow expansion.


### PR DESCRIPTION
## What type of PR is this?

/kind feature

## What this PR does / why we need it

### Motivation

Kruise currently controls the container launch order through the `KRUISE_CONTAINER_PRIORITY` environment variable: each container carries a `ConfigMapKeyRef` pointing at a **per-Pod** barrier ConfigMap named `<pod-name>-barrier`, and the kruise-manager unblocks each priority by patching keys into it.

This per-Pod ConfigMap design does not scale. In a cluster that hosts tens of thousands of game servers (a typical OpenKruise Game deployment), every Pod carries one barrier ConfigMap, so the number of ConfigMaps equals the number of Pods. Each of them is individually listed, watched, created and patched by kruise-manager, which adds significant pressure on the control plane (apiserver watch traffic, etcd object count, and the client caches of every controller that watches ConfigMaps).

Since Kubernetes 1.29, kubelet natively supports **restartable init containers** (a.k.a. native sidecar containers, `restartPolicy: Always` under `spec.initContainers`, GA in 1.33). Init containers start strictly in order, and a restartable init container blocks the startup of the regular containers until it is ready. This provides launch-order control **in the Pod spec itself**, with no barrier ConfigMaps at all.

Kruise already supports *creating* such Pods, but the in-place update — the core Kruise capability that keeps these workloads upgradeable without disrupting availability — rejects any change under `spec.initContainers` and falls back to recreating the Pod. A game server that hosts long-lived connections cannot afford a recreate for a sidecar image bump. To make native sidecars a viable replacement for the barrier mechanism, they must be in-place updatable.

### What this PR does

Adds a new alpha feature-gate **`InPlaceUpdateRestartableInitContainer`** (default off). When enabled, CloneSet, Advanced StatefulSet and Advanced DaemonSet can in-place update the **image** of a restartable init container.

Only restartable init containers are supported, and only their image:

- kubelet restarts an init container on image change only when its `restartPolicy` is `Always`; a regular init container would never report a new imageID and the in-place update would never complete;
- any other change under `spec.initContainers`, including the resources of a restartable init container, still falls back to recreating the Pod;
- restartable init containers do not participate in the container launch priority batching of in-place update (the priority env is only injected into `spec.containers`); they are always updated in the current batch.
- changes to `envFrom` or any field other than `image` fall back to recreating the Pod, which is the same as for the regular containers; the metadata-driven env refresh (`InPlaceUpdateEnvFromMetadata`) does cover restartable init containers, for the daemon reports their meta and the consistency check includes them.


### Implementation overview

- `inplaceupdate`: recognize `/spec/initContainers/N/image` patches for restartable init containers; carry them through `UpdateSpec.InitContainerImages`; verify completion against `status.initContainerStatuses` in addition to `status.containerStatuses`.
- `kruise-daemon` containermeta controller: report the runtime meta of restartable init containers as well, and look the reported meta up by container name rather than by index (the meta set no longer aligns with `status.containerStatuses` positionally).
- Workload controllers: pre-download the changed restartable init container images (CloneSet / Advanced StatefulSet / Advanced DaemonSet).
- Admission: the InPlaceOnly whitelist of the CloneSet / Advanced StatefulSet validating webhooks accepts the image of a restartable init container; `ContainerRecreateRequest` can target a restartable init container (both v1alpha1 and v1beta1).

### Backward compatibility

The feature is off by default and everything is gated. With the gate disabled the behavior is byte-for-byte identical to before: any change under `spec.initContainers` still recreates the Pod, the meta annotation keeps its previous shape (the new init-container loop in `manageContainerMetaSet` adds nothing), and the webhooks reject the same inputs as before.

## Which issue(s) this PR fixes

## Special notes for your reviewer

Requires the Kubernetes `SidecarContainers` feature (enabled by default since v1.29, GA in v1.33). The gate check is paired with `util.IsRestartableInitContainer`, so on clusters where `restartPolicy` is absent from init containers the behavior degrades to the pre-feature fallback.

Verified end-to-end on a v1.35.2 cluster with an Advanced StatefulSet backed by OpenKruise Game: changing the image of a native sidecar under the InPlaceOnly strategy updates the container in place — `restartCount` incremented, `imageID` switched to the new digest, Pod UID and IP unchanged — while a change to a regular init container still recreates the Pod.

New tests:

- `pkg/util/inplaceupdate/inplace_update_initcontainer_test.go` — spec calculation, patching, completion checking, image diffing, and the InPlaceOnly whitelist (including the downgrade of `restartPolicy`, which must still be rejected)
- `pkg/controller/daemonset/daemonset_predownload_image_test.go` — image pre-download for multiple and empty old revisions
- `pkg/webhook/containerrecreaterequest/mutating/crr_mutating_handler_test.go` — table-driven cases running against both API versions
