### PR TITLE
fix(pub): do not skip sidecar and in-place checks when all images are digest format

### DIFF
--- a/pkg/control/pubcontrol/pub_control.go
+++ b/pkg/control/pubcontrol/pub_control.go
@@ -281,14 +281,15 @@ func (c *commonControl) GetPodsForPub(pub *policyv1beta1.PodUnavailableBudget) (
 }
 
 func (c *commonControl) IsPodStateConsistent(pod *corev1.Pod) bool {
-	// if all container image is digest format
-	// by comparing status.containers[x].ImageID with spec.container[x].Image can determine whether pod is consistent
-	allDigestImage := true
+	// If a container image is digest format, for example
+	// docker.io/busybox@sha256:a9286defaba7b3a519d585ba0e37d0b2cbee74ebfe590960b0b1d6a5e97d1e1d,
+	// it is compared with the imageID in the status directly, which can find the containers
+	// recreated or updated without Kruise.
+	// Note that passing the digest comparison does NOT conclude the Pod is consistent: the
+	// sidecar and in-place update states below are always checked, because the digest comparison
+	// can not tell an in-place update in the grace period or a pending env-from-metadata refresh.
 	for _, container := range pod.Spec.Containers {
-		//whether image is digest format,
-		//for example: docker.io/busybox@sha256:a9286defaba7b3a519d585ba0e37d0b2cbee74ebfe590960b0b1d6a5e97d1e1d
 		if !util.IsImageDigest(container.Image) {
-			allDigestImage = false
 			continue
 		}
 
@@ -297,9 +298,23 @@ func (c *commonControl) IsPodStateConsistent(pod *corev1.Pod) bool {
 			return false
 		}
 	}
-	// If all spec.container[x].image is digest format, only check digest imageId
-	if allDigestImage {
-		return true
+	// Restartable init containers (native sidecar containers) are checked in the same way, for
+	// they can be in-place updated and their imageID in status.initContainerStatuses may lag
+	// behind the spec. Regular init containers are skipped: kubelet never restarts them on
+	// spec change, so their imageID would always lag after a Pod recreation.
+	for i := range pod.Spec.InitContainers {
+		container := &pod.Spec.InitContainers[i]
+		if !util.IsRestartableInitContainer(container) {
+			continue
+		}
+		if !util.IsImageDigest(container.Image) {
+			continue
+		}
+
+		if !util.IsPodContainerDigestEqualIncludingInit(sets.NewString(container.Name), pod) {
+			klog.V(5).InfoS("Pod init container image was inconsistent", "pod", klog.KObj(pod), "containerName", container.Name)
+			return false
+		}
 	}
 
 	// check whether injected sidecar container is consistent

--- a/pkg/control/pubcontrol/pub_control_test.go
+++ b/pkg/control/pubcontrol/pub_control_test.go
@@ -22,6 +22,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/kubelet/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -571,6 +572,112 @@ func TestIsPodReady(t *testing.T) {
 			is := control.IsPodReady(cs.getPod())
 			if cs.expect != is {
 				t.Fatalf("IsPodReady failed")
+			}
+		})
+	}
+}
+
+// TestIsPodStateConsistent covers the digest fast-path of IsPodStateConsistent, including
+// restartable init containers, and makes sure the fast-path can no longer skip the in-place
+// update checks.
+func TestIsPodStateConsistent(t *testing.T) {
+	const (
+		digestImage     = "busybox@sha256:a9286defaba7b3a519d585ba0e37d0b2cbee74ebfe590960b0b1d6a5e97d1e1d"
+		digestImageID   = "docker-pullable://busybox@sha256:a9286defaba7b3a519d585ba0e37d0b2cbee74ebfe590960b0b1d6a5e97d1e1d"
+		staleImageID    = "docker-pullable://busybox@sha256:00006defaba7b3a519d585ba0e37d0b2cbee74ebfe590960b0b1d6a5e97d1e1d"
+		tagImage        = "busybox:1.36"
+		tagImageID      = "docker-pullable://busybox:1.36"
+		graceAnnotation = `{"revision":"r2","containerImages":{"main":"busybox:1.37"}}`
+	)
+
+	restartAlways := corev1.ContainerRestartPolicyAlways
+	newPod := func() *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "pod-0"},
+			Spec: corev1.PodSpec{
+				InitContainers: []corev1.Container{
+					{Name: "setup", Image: digestImage},
+					{Name: "sidecar", Image: digestImage, RestartPolicy: &restartAlways},
+				},
+				Containers: []corev1.Container{
+					{Name: "main", Image: digestImage},
+				},
+			},
+			Status: corev1.PodStatus{
+				InitContainerStatuses: []corev1.ContainerStatus{
+					{Name: "setup", ImageID: digestImageID},
+					{Name: "sidecar", ImageID: digestImageID},
+				},
+				ContainerStatuses: []corev1.ContainerStatus{
+					{Name: "main", ImageID: digestImageID},
+				},
+			},
+		}
+	}
+
+	cases := []struct {
+		name     string
+		mutate   func(pod *corev1.Pod)
+		expected bool
+	}{
+		{
+			name:     "all digest images consistent",
+			mutate:   func(pod *corev1.Pod) {},
+			expected: true,
+		},
+		{
+			name: "all digest images must not skip the in-place update grace period check",
+			mutate: func(pod *corev1.Pod) {
+				pod.Annotations = map[string]string{pub.InPlaceUpdateGraceKey: graceAnnotation}
+			},
+			expected: false,
+		},
+		{
+			name: "restartable init container with stale imageID is inconsistent",
+			mutate: func(pod *corev1.Pod) {
+				pod.Status.InitContainerStatuses[1].ImageID = staleImageID
+			},
+			expected: false,
+		},
+		{
+			name: "regular init container with stale imageID is skipped",
+			mutate: func(pod *corev1.Pod) {
+				pod.Status.InitContainerStatuses[0].ImageID = staleImageID
+			},
+			expected: true,
+		},
+		{
+			name: "tag images keep the previous behavior",
+			mutate: func(pod *corev1.Pod) {
+				pod.Spec.Containers[0].Image = tagImage
+				pod.Spec.InitContainers[1].Image = tagImage
+				pod.Status.ContainerStatuses[0].ImageID = tagImageID
+				pod.Status.ContainerStatuses[0].Image = tagImage
+				pod.Status.InitContainerStatuses[1].ImageID = tagImageID
+				pod.Status.InitContainerStatuses[1].Image = tagImage
+			},
+			expected: true,
+		},
+		{
+			name: "tag images with unchanged imageID in the update state are inconsistent",
+			mutate: func(pod *corev1.Pod) {
+				pod.Spec.Containers[0].Image = "busybox:1.37"
+				pod.Status.ContainerStatuses[0].ImageID = tagImageID
+				pod.Status.ContainerStatuses[0].Image = tagImage
+				pod.Annotations = map[string]string{pub.InPlaceUpdateStateKey: `{"revision":"r2","lastContainerStatuses":{"main":{"imageID":"` + tagImageID + `"}}}`}
+			},
+			expected: false,
+		},
+	}
+
+	for _, cs := range cases {
+		t.Run(cs.name, func(t *testing.T) {
+			control := commonControl{}
+			pod := newPod()
+			cs.mutate(pod)
+			is := control.IsPodStateConsistent(pod)
+			if cs.expected != is {
+				t.Fatalf("IsPodStateConsistent expected %v, but got %v", cs.expected, is)
 			}
 		})
 	}

--- a/pkg/util/pods.go
+++ b/pkg/util/pods.go
@@ -270,6 +270,59 @@ func IsPodContainerDigestEqual(containers sets.String, pod *v1.Pod) bool {
 	return true
 }
 
+// GetPodContainerImageIDsIncludingInit works like GetPodContainerImageIDs, but covers the init
+// containers as well. Restartable init containers (native sidecar containers) report their
+// imageID in status.initContainerStatuses rather than status.containerStatuses.
+func GetPodContainerImageIDsIncludingInit(pod *v1.Pod) map[string]string {
+	cImageIDs := GetPodContainerImageIDs(pod)
+	for i := range pod.Status.InitContainerStatuses {
+		c := &pod.Status.InitContainerStatuses[i]
+		imageID := c.ImageID
+		if strings.Contains(imageID, "://") {
+			imageID = strings.Split(imageID, "://")[1]
+		}
+		cImageIDs[c.Name] = imageID
+	}
+	return cImageIDs
+}
+
+// IsPodContainerDigestEqualIncludingInit works like IsPodContainerDigestEqual, but looks up both
+// spec.containers and spec.initContainers. Unlike IsPodContainerDigestEqual, it is fail-closed:
+// a name that is not found in the Pod spec at all is reported as inconsistent, instead of
+// silently consistent.
+func IsPodContainerDigestEqualIncludingInit(containers sets.String, pod *v1.Pod) bool {
+	cImageIDs := GetPodContainerImageIDsIncludingInit(pod)
+
+	found := sets.NewString()
+	check := func(container *v1.Container) bool {
+		if !containers.Has(container.Name) {
+			return true
+		}
+		found.Insert(container.Name)
+		// image must be digest format
+		if !IsImageDigest(container.Image) {
+			return false
+		}
+		imageID, ok := cImageIDs[container.Name]
+		if !ok {
+			return false
+		}
+		return IsContainerImageEqual(container.Image, imageID)
+	}
+
+	for i := range pod.Spec.InitContainers {
+		if !check(&pod.Spec.InitContainers[i]) {
+			return false
+		}
+	}
+	for i := range pod.Spec.Containers {
+		if !check(&pod.Spec.Containers[i]) {
+			return false
+		}
+	}
+	return found.Equal(containers)
+}
+
 func MergeVolumeMountsInContainer(origin *v1.Container, other v1.Container) {
 	mountExist := make(map[string]bool)
 	for _, volume := range origin.VolumeMounts {

--- a/pkg/util/pods_test.go
+++ b/pkg/util/pods_test.go
@@ -449,6 +449,102 @@ func TestIsPodContainerDigestEqual(t *testing.T) {
 	}
 }
 
+// TestIsPodContainerDigestEqualIncludingInit covers the init container support of
+// IsPodContainerDigestEqualIncludingInit and its fail-closed behavior.
+func TestIsPodContainerDigestEqualIncludingInit(t *testing.T) {
+	restartAlways := v1.ContainerRestartPolicyAlways
+	pod := &v1.Pod{
+		Spec: v1.PodSpec{
+			InitContainers: []v1.Container{
+				{Name: "setup", Image: "busybox@sha256:a9286defaba7b3a519d585ba0e37d0b2cbee74ebfe590960b0b1d6a5e97d1e1d"},
+				{Name: "sidecar", Image: "busybox@sha256:a9286defaba7b3a519d585ba0e37d0b2cbee74ebfe590960b0b1d6a5e97d1e1d", RestartPolicy: &restartAlways},
+			},
+			Containers: []v1.Container{
+				{Name: "main", Image: "busybox@sha256:a9286defaba7b3a519d585ba0e37d0b2cbee74ebfe590960b0b1d6a5e97d1e1d"},
+			},
+		},
+		Status: v1.PodStatus{
+			InitContainerStatuses: []v1.ContainerStatus{
+				{Name: "setup", ImageID: "docker-pullable://busybox@sha256:a9286defaba7b3a519d585ba0e37d0b2cbee74ebfe590960b0b1d6a5e97d1e1d"},
+				{Name: "sidecar", ImageID: "docker-pullable://busybox@sha256:a9286defaba7b3a519d585ba0e37d0b2cbee74ebfe590960b0b1d6a5e97d1e1d"},
+			},
+			ContainerStatuses: []v1.ContainerStatus{
+				{Name: "main", ImageID: "docker-pullable://busybox@sha256:a9286defaba7b3a519d585ba0e37d0b2cbee74ebfe590960b0b1d6a5e97d1e1d"},
+			},
+		},
+	}
+
+	tests := []struct {
+		name       string
+		pod        *v1.Pod
+		containers sets.String
+		result     bool
+	}{
+		{
+			name:       "init container digest equal",
+			containers: sets.NewString("sidecar"),
+			result:     true,
+		},
+		{
+			name:       "init and regular containers digest equal",
+			containers: sets.NewString("sidecar", "main"),
+			result:     true,
+		},
+		{
+			name: "init container digest not equal",
+			pod: func() *v1.Pod {
+				p := pod.DeepCopy()
+				p.Status.InitContainerStatuses[1].ImageID = "docker-pullable://busybox@sha256:00006defaba7b3a519d585ba0e37d0b2cbee74ebfe590960b0b1d6a5e97d1e1d"
+				return p
+			}(),
+			containers: sets.NewString("sidecar"),
+			result:     false,
+		},
+		{
+			name: "init container without status",
+			pod: func() *v1.Pod {
+				p := pod.DeepCopy()
+				p.Status.InitContainerStatuses = p.Status.InitContainerStatuses[:1]
+				return p
+			}(),
+			containers: sets.NewString("sidecar"),
+			result:     false,
+		},
+		{
+			name: "non digest image",
+			pod: func() *v1.Pod {
+				p := pod.DeepCopy()
+				p.Spec.InitContainers[1].Image = "busybox:1.36"
+				return p
+			}(),
+			containers: sets.NewString("sidecar"),
+			result:     false,
+		},
+		{
+			name:       "fail-closed for an unknown container name",
+			containers: sets.NewString("nonexistent"),
+			result:     false,
+		},
+		{
+			name:       "fail-closed for a partially unknown set",
+			containers: sets.NewString("main", "nonexistent"),
+			result:     false,
+		},
+	}
+
+	for i, test := range tests {
+		p := test.pod
+		if p == nil {
+			p = pod
+		}
+		expect := test.result
+		actual := IsPodContainerDigestEqualIncludingInit(test.containers, p)
+		if expect != actual {
+			t.Fatalf("case %d (%s): expect result(%v), but get %v", i, test.name, expect, actual)
+		}
+	}
+}
+
 func TestSetPodConditionIfMsgChanged(t *testing.T) {
 	tests := []struct {
 		pod        *v1.Pod


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

`IsPodStateConsistent` returned `true` early once every `spec.containers` image was digest format, which skipped the SidecarSet completion check and `DefaultCheckInPlaceUpdateCompleted` entirely — e.g. a Pod sitting in the grace period of an in-place update, or waiting for an env-from-metadata refresh, was still counted as available by PodUnavailableBudget.

This PR removes the early return so the sidecar and in-place checks always run. The digest comparison still acts as a fast detector for containers recreated or updated without Kruise.

It also covers restartable init containers (native sidecar containers) in the digest comparison, since they can be in-place updated and report their imageID in `status.initContainerStatuses`. Two new helpers are added in `pkg/util/pods.go`:

- `GetPodContainerImageIDsIncludingInit` — merges `status.initContainerStatuses`
- `IsPodContainerDigestEqualIncludingInit` — fail-closed: a container name not found in the Pod spec is reported as inconsistent instead of silently consistent

The existing `GetPodContainerImageIDs` / `IsPodContainerDigestEqual` are untouched, so all current callers keep their behavior.

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. Describe how to verify it

New unit tests:

- `pkg/util`: `TestIsPodContainerDigestEqualIncludingInit` — digest equality for init and regular containers, missing status, non-digest image, and the fail-closed behavior for unknown container names
- `pkg/control/pubcontrol`: `TestIsPodStateConsistent` — the regression case is an all-digest Pod carrying the in-place-update grace annotation, which used to be reported as consistent and is now inconsistent; also covers a restartable init container with a stale imageID, a regular init container being skipped on purpose, and unchanged behavior for tag-format images

### Ⅳ. Special notes for reviews

Regular init containers are skipped in the digest comparison on purpose: kubelet never restarts them on spec change, so their imageID always lags behind after a Pod recreation and would make every such Pod permanently inconsistent.
