### PR TITLE
fix(podprobemarker): retry NodePodProbe update on conflict

### DIFF
--- a/pkg/controller/podprobemarker/pod_probe_marker_controller.go
+++ b/pkg/controller/podprobemarker/pod_probe_marker_controller.go
@@ -289,89 +289,109 @@ func (r *ReconcilePodProbeMarker) markServerlessPod(pod *corev1.Pod, markers map
 	return nil
 }
 
+// updateNodePodProbes merges the probes of the given Pods into the NodePodProbe of the node.
+//
+// A NodePodProbe is written concurrently by every PodProbeMarker that matches Pods on the node
+// and by kruise-daemon, so the update below races by design. The whole read-modify-write cycle
+// is retried on conflict and the merge is recomputed against the latest version, instead of
+// failing the reconcile. Without the retry a conflict also blocks the update of
+// PodProbeMarker.Status.ObservedGeneration, which the downstream consumers wait on.
 func (r *ReconcilePodProbeMarker) updateNodePodProbes(ppm *appsv1alpha1.PodProbeMarker, nodeName string, pods []*corev1.Pod) error {
+	var oldSpec *appsv1alpha1.NodePodProbeSpec
+	updated := false
 	npp := &appsv1alpha1.NodePodProbe{}
-	err := r.Get(context.TODO(), client.ObjectKey{Name: nodeName}, npp)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			klog.InfoS("PodProbeMarker NodePodProbe was Not Found", "podProbeMarker", klog.KObj(ppm), "nodePodProbe", klog.KObj(npp))
-			return nil
+	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		if err := r.Get(context.TODO(), client.ObjectKey{Name: nodeName}, npp); err != nil {
+			if errors.IsNotFound(err) {
+				klog.InfoS("PodProbeMarker NodePodProbe was Not Found", "podProbeMarker", klog.KObj(ppm), "nodeName", nodeName)
+				return nil
+			}
+			// Error reading the object - requeue the request.
+			klog.ErrorS(err, "PodProbeMarker got NodePodProbe failed", "podProbeMarker", klog.KObj(ppm), "nodeName", nodeName)
+			return err
 		}
-		// Error reading the object - requeue the request.
-		klog.ErrorS(err, "PodProbeMarker got NodePodProbe failed", "podProbeMarker", klog.KObj(ppm), "nodePodProbe", klog.KObj(npp))
-		return err
-	}
 
-	oldSpec := npp.Spec.DeepCopy()
-	for _, pod := range pods {
-		exist := false
-		for i := range npp.Spec.PodProbes {
-			podProbe := &npp.Spec.PodProbes[i]
-			if podProbe.Name == pod.Name && podProbe.Namespace == pod.Namespace && podProbe.UID == string(pod.UID) {
-				exist = true
+		oldSpec = npp.Spec.DeepCopy()
+		for _, pod := range pods {
+			exist := false
+			for i := range npp.Spec.PodProbes {
+				podProbe := &npp.Spec.PodProbes[i]
+				if podProbe.Name == pod.Name && podProbe.Namespace == pod.Namespace && podProbe.UID == string(pod.UID) {
+					exist = true
+					for j := range ppm.Spec.Probes {
+						probe := ppm.Spec.Probes[j]
+						if podProbe.IP == "" {
+							podProbe.IP = pod.Status.PodIP
+						}
+						if probe.Probe.TCPSocket != nil {
+							converted, convErr := convertTcpSocketProbeCheckPort(probe, pod)
+							if convErr != nil {
+								klog.ErrorS(convErr, "Failed to convert tcpSocket probe port", "pod", klog.KObj(pod))
+								continue
+							}
+							probe = converted
+						}
+						if probe.Probe.HTTPGet != nil {
+							converted, convErr := convertHttpGetProbeCheckPort(probe, pod)
+							if convErr != nil {
+								klog.ErrorS(convErr, "Failed to convert httpGet probe port", "pod", klog.KObj(pod))
+								continue
+							}
+							probe = converted
+						}
+						setPodContainerProbes(podProbe, probe, ppm.Name)
+					}
+					break
+				}
+			}
+			if !exist {
+				podProbe := appsv1alpha1.PodProbe{Name: pod.Name, Namespace: pod.Namespace, UID: string(pod.UID), IP: pod.Status.PodIP}
 				for j := range ppm.Spec.Probes {
 					probe := ppm.Spec.Probes[j]
-					if podProbe.IP == "" {
-						podProbe.IP = pod.Status.PodIP
-					}
+					// look up a port in a container by name & convert container name port
 					if probe.Probe.TCPSocket != nil {
-						probe, err = convertTcpSocketProbeCheckPort(probe, pod)
-						if err != nil {
-							klog.ErrorS(err, "Failed to convert tcpSocket probe port", "pod", klog.KObj(pod))
+						converted, convErr := convertTcpSocketProbeCheckPort(probe, pod)
+						if convErr != nil {
+							klog.ErrorS(convErr, "Failed to convert tcpSocket probe port", "pod", klog.KObj(pod))
 							continue
 						}
+						probe = converted
 					}
 					if probe.Probe.HTTPGet != nil {
-						probe, err = convertHttpGetProbeCheckPort(probe, pod)
-						if err != nil {
-							klog.ErrorS(err, "Failed to convert httpGet probe port", "pod", klog.KObj(pod))
+						converted, convErr := convertHttpGetProbeCheckPort(probe, pod)
+						if convErr != nil {
+							klog.ErrorS(convErr, "Failed to convert httpGet probe port", "pod", klog.KObj(pod))
 							continue
 						}
+						probe = converted
 					}
-					setPodContainerProbes(podProbe, probe, ppm.Name)
+					podProbe.Probes = append(podProbe.Probes, appsv1alpha1.ContainerProbe{
+						Name:          fmt.Sprintf("%s#%s", ppm.Name, probe.Name),
+						ContainerName: probe.ContainerName,
+						Probe:         probe.Probe,
+					})
 				}
-				break
+				npp.Spec.PodProbes = append(npp.Spec.PodProbes, podProbe)
 			}
 		}
-		if !exist {
-			podProbe := appsv1alpha1.PodProbe{Name: pod.Name, Namespace: pod.Namespace, UID: string(pod.UID), IP: pod.Status.PodIP}
-			for j := range ppm.Spec.Probes {
-				probe := ppm.Spec.Probes[j]
-				// look up a port in a container by name & convert container name port
-				if probe.Probe.TCPSocket != nil {
-					probe, err = convertTcpSocketProbeCheckPort(probe, pod)
-					if err != nil {
-						klog.ErrorS(err, "Failed to convert tcpSocket probe port", "pod", klog.KObj(pod))
-						continue
-					}
-				}
-				if probe.Probe.HTTPGet != nil {
-					probe, err = convertHttpGetProbeCheckPort(probe, pod)
-					if err != nil {
-						klog.ErrorS(err, "Failed to convert httpGet probe port", "pod", klog.KObj(pod))
-						continue
-					}
-				}
-				podProbe.Probes = append(podProbe.Probes, appsv1alpha1.ContainerProbe{
-					Name:          fmt.Sprintf("%s#%s", ppm.Name, probe.Name),
-					ContainerName: probe.ContainerName,
-					Probe:         probe.Probe,
-				})
-			}
-			npp.Spec.PodProbes = append(npp.Spec.PodProbes, podProbe)
-		}
-	}
 
-	if reflect.DeepEqual(npp.Spec, oldSpec) {
+		if reflect.DeepEqual(npp.Spec, *oldSpec) {
+			return nil
+		}
+		if err := r.Update(context.TODO(), npp); err != nil {
+			return err
+		}
+		updated = true
 		return nil
-	}
-	err = r.Update(context.TODO(), npp)
+	})
 	if err != nil {
-		klog.ErrorS(err, "PodProbeMarker updated NodePodProbe failed", "podProbeMarker", klog.KObj(ppm), "nodePodProbeName", npp.Name)
+		klog.ErrorS(err, "PodProbeMarker updated NodePodProbe failed", "podProbeMarker", klog.KObj(ppm), "nodeName", nodeName)
 		return err
 	}
-	klog.V(3).InfoS("PodProbeMarker updated NodePodProbe success", "podProbeMarker", klog.KObj(ppm), "nodePodProbeName", npp.Name,
-		"oldSpec", util.DumpJSON(oldSpec), "newSpec", util.DumpJSON(npp.Spec))
+	if updated {
+		klog.V(3).InfoS("PodProbeMarker updated NodePodProbe success", "podProbeMarker", klog.KObj(ppm), "nodeName", nodeName,
+			"oldSpec", util.DumpJSON(oldSpec), "newSpec", util.DumpJSON(npp.Spec))
+	}
 	return nil
 }
 

--- a/pkg/controller/podprobemarker/pod_probe_marker_controller_test.go
+++ b/pkg/controller/podprobemarker/pod_probe_marker_controller_test.go
@@ -18,13 +18,16 @@ package podprobemarker
 
 import (
 	"context"
+	goerrors "errors"
 	"fmt"
 	"reflect"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -1966,6 +1969,102 @@ func TestUpdateNodePodProbes(t *testing.T) {
 			}
 		})
 	}
+}
+
+// conflictClient fails the first `conflicts` Update calls with a Conflict error, simulating a
+// NodePodProbe being written concurrently by another writer, and counts the calls.
+type conflictClient struct {
+	client.Client
+	conflicts int
+	updates   int
+}
+
+func (c *conflictClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	c.updates++
+	if c.updates <= c.conflicts {
+		return apierrors.NewConflict(schema.GroupResource{Group: appsv1alpha1.GroupVersion.Group, Resource: "nodepodprobes"},
+			obj.GetName(), goerrors.New("simulated concurrent write"))
+	}
+	return c.Client.Update(ctx, obj, opts...)
+}
+
+// TestUpdateNodePodProbesRetryOnConflict makes sure a conflict while updating the NodePodProbe
+// does not fail the whole reconcile: the read-modify-write cycle is retried against the latest
+// version and the merged probes are still written.
+func TestUpdateNodePodProbesRetryOnConflict(t *testing.T) {
+	ppm := &appsv1alpha1.PodProbeMarker{
+		ObjectMeta: metav1.ObjectMeta{Name: "ppm-1"},
+		Spec: appsv1alpha1.PodProbeMarkerSpec{
+			Probes: []appsv1alpha1.PodContainerProbe{
+				{
+					Name:          "healthy",
+					ContainerName: "main",
+					Probe: appsv1alpha1.ContainerProbeSpec{
+						Probe: corev1.Probe{ProbeHandler: corev1.ProbeHandler{
+							Exec: &corev1.ExecAction{Command: []string{"/bin/sh", "-c", "/healthy.sh"}},
+						}},
+					},
+				},
+			},
+		},
+	}
+	npp := &appsv1alpha1.NodePodProbe{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod-1", Namespace: "default", UID: "pod-1-uid"},
+		Status:     corev1.PodStatus{PodIP: "1.2.3.4"},
+	}
+
+	newClient := func(conflicts int) *conflictClient {
+		base := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(npp.DeepCopy()).Build()
+		return &conflictClient{Client: base, conflicts: conflicts}
+	}
+
+	t.Run("succeeds after conflicts and keeps the merged probes", func(t *testing.T) {
+		c := newClient(2)
+		r := &ReconcilePodProbeMarker{Client: c}
+		if err := r.updateNodePodProbes(ppm, "node-1", []*corev1.Pod{pod}); err != nil {
+			t.Fatalf("expected no error after retrying conflicts, got %v", err)
+		}
+		if c.updates != 3 {
+			t.Fatalf("expected 3 update attempts (2 conflicts + 1 success), got %d", c.updates)
+		}
+		latest := &appsv1alpha1.NodePodProbe{}
+		if err := c.Get(context.TODO(), types.NamespacedName{Name: "node-1"}, latest); err != nil {
+			t.Fatalf("failed to get NodePodProbe: %v", err)
+		}
+		if len(latest.Spec.PodProbes) != 1 || len(latest.Spec.PodProbes[0].Probes) != 1 {
+			t.Fatalf("expected the merged probes to be written, got %v", latest.Spec.PodProbes)
+		}
+		if latest.Spec.PodProbes[0].Probes[0].Name != "ppm-1#healthy" {
+			t.Fatalf("expected probe name ppm-1#healthy, got %s", latest.Spec.PodProbes[0].Probes[0].Name)
+		}
+	})
+
+	t.Run("returns the conflict error when it never stops conflicting", func(t *testing.T) {
+		c := newClient(100)
+		r := &ReconcilePodProbeMarker{Client: c}
+		if err := r.updateNodePodProbes(ppm, "node-1", []*corev1.Pod{pod}); err == nil {
+			t.Fatal("expected an error when conflicts never stop")
+		}
+	})
+
+	t.Run("does not update when the spec is unchanged", func(t *testing.T) {
+		c := newClient(0)
+		r := &ReconcilePodProbeMarker{Client: c}
+		if err := r.updateNodePodProbes(ppm, "node-1", []*corev1.Pod{pod}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if c.updates != 1 {
+			t.Fatalf("expected exactly 1 update, got %d", c.updates)
+		}
+		// Run again: the spec is already up to date, no further update should happen.
+		if err := r.updateNodePodProbes(ppm, "node-1", []*corev1.Pod{pod}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if c.updates != 1 {
+			t.Fatalf("expected no update for an unchanged spec, got %d updates", c.updates)
+		}
+	})
 }
 
 func TestMarkerServerlessPod(t *testing.T) {


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

`updateNodePodProbes` did a plain read-modify-write on the NodePodProbe and returned any update conflict as an error. A NodePodProbe is written concurrently by every PodProbeMarker that matches Pods on that node and by kruise-daemon, so conflicts are the norm rather than an exception on busy clusters (hundreds of `Operation cannot be fulfilled on nodepodprobes... the object has been modified` errors per hour observed in production).

Worse, the error short-circuits `syncPodProbeMarker` before `PodProbeMarker.Status.ObservedGeneration` is updated:

```go
for nodeName := range groupByNode {
    if err = r.updateNodePodProbes(ppm, nodeName, groupByNode[nodeName]); err != nil {
        return err   // ← status update below never runs
    }
}
```
// update podProbeMarker status (ObservedGeneration)
Consumers that wait for observedGeneration == generation (e.g. kruise-game's GameServerSet controller) then stall indefinitely even though the probe spec itself is fine.

This PR wraps the whole read-modify-write cycle in retry.RetryOnConflict, refetching the NodePodProbe on every attempt and recomputing the merge against the latest version. A conflict no longer fails the reconcile, and the status update is reached reliably.

It also fixes a latent error leak: the probe-port conversion assigned its error to the function-level err variable (probe, err = convertTcpSocketProbeCheckPort(...)). Inside the retry closure that stale error would be returned even after a successful update, so it is now kept in a local variable.

### Ⅱ. Does this pull request fix one issue?
NONE

### Ⅲ. Describe how to verify it
New test TestUpdateNodePodProbesRetryOnConflict with a client that simulates concurrent writes:

2 conflicts followed by a success → no error, exactly 3 update attempts, and the merged probes are present in the final NodePodProbe
conflicts that never stop → the conflict error is returned instead of retrying forever
unchanged spec → no update call at all
Existing TestUpdateNodePodProbes cases pass unchanged.

### Ⅳ. Special notes for reviews
Behavior on the happy path is unchanged: when the spec is up to date no update is issued, and the success log (with oldSpec/newSpec) is only emitted after a real update.